### PR TITLE
generateconfs.py: apply values from environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Binaries
+*.pyc
+
+# macOS
+*.DS_Store

--- a/README
+++ b/README
@@ -552,6 +552,10 @@ settings:
 --io_account_expire=IO_ACCOUNT_EXPIRE
 --gdp_email_notify=GDP_EMAIL_NOTIFY
 
+All those values can also be set via environment variable, by using the options name in upper case.
+Eg. --enable_hsts=true would become $ENABLE_HSTS=true
+If the same option is set both as environment variable and CLI parameter, then the CLI parameter take precedence.
+
 For one of our servers running MiG as the 'mig' user with the code
 checked out directly in the home directory and Debian apache 2.4 without OpenID:
 ./generateconfs.py --source=. --destination=generated-confs \

--- a/mig/install/generateconfs.py
+++ b/mig/install/generateconfs.py
@@ -271,6 +271,13 @@ if '__main__' == __name__:
         usage(names)
         sys.exit(1)
 
+    # apply values from environment
+    for name in names:
+        value = os.getenv(name.upper())
+        if value:
+            settings[name] = value
+
+    # apply values from CLI parameters
     for (opt, val) in opts:
         opt_name = opt.lstrip('-')
         if opt in ('-h', '--help'):


### PR DESCRIPTION
This PR add the possiblity to feed option values to the generateconfs.py script via env variables.
If the same option is set both as env variable and CLI parameter, then the CLI parameter take precedence.

This feature might come in handy with future (container) deployments as one does not have to maintain lists of arguments given to the config generator and environment variable are already heavily in use in the docker-migrid code.