### PR TITLE
Arrange mig test cases to throw if any leaked resources are detected.

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -1,5 +1,8 @@
+from collections import defaultdict
 import errno
+import logging
 import os
+import re
 import shutil
 import stat
 import sys
@@ -8,6 +11,7 @@ from unittest import TestCase, main as testmain
 TEST_BASE = os.path.dirname(__file__)
 TEST_OUTPUT_DIR = os.path.join(TEST_BASE, "output")
 MIG_BASE = os.path.realpath(os.path.join(TEST_BASE, ".."))
+PY2 = sys.version_info[0] == 2
 
 # All MiG related code will at some point include bits
 # from the mig module namespace. Rather than have this
@@ -22,16 +26,39 @@ try:
 except EnvironmentError as e:
     if e.errno == errno.EEXIST: pass # FileExistsError
 
+# basic global logging configuration for testing
+#
+# arrange a stream that ignores all logging messages
+class BlackHole:
+    def write(self, message):
+        pass
+BLACKHOLE_STREAM = BlackHole()
+# provide a working logging setup (black hole by default)
+logging.basicConfig(stream=BLACKHOLE_STREAM)
+# request capturing warnings from within the Python runtime
+logging.captureWarnings(True)
+
 class FakeLogger:
-    CHANNELS = [
-        'error',
-    ]
+    RE_UNCLOSEDFILE = re.compile('unclosed file <.*? name=\'(?P<location>.*?)\'( .*?)?>')
 
     def __init__(self):
-        self.channels_dict = FakeLogger.create_channels_dict()
+        self.channels_dict = defaultdict(list)
+        self.unclosed_by_file = defaultdict(list)
 
     def _append_as(self, channel, line):
         self.channels_dict[channel].append(line)
+
+    def check_empty_and_reset(self):
+        unclosed_by_file = self.unclosed_by_file
+
+        # reset the record of any logged messages
+        self.channels_dict = defaultdict(list)
+        self.unclosed_by_file = defaultdict(list)
+
+        # complain loudly (and in detail) in the case of unclosed files
+        if len(unclosed_by_file) > 0:
+            messages = '\n'.join({' --> %s: line=%s, file=%s' % (fname, lineno, outname) for fname, (lineno, outname) in unclosed_by_file.items()})
+            raise RuntimeError('unclosed files encountered:\n%s' % (messages,))
 
     def debug(self, line):
         self._append_as('debug', line)
@@ -45,18 +72,46 @@ class FakeLogger:
     def warning(self, line):
         self._append_as('warning', line)
 
-    @classmethod
-    def create_channels_dict(cls):
-        return dict(((channel, []) for channel in cls.CHANNELS))
+    def write(self, message):
+        channel, namespace, specifics = message.split(':', maxsplit=2)
+
+        # ignore everything except warnings sent by th python runtime
+        if not (channel == 'WARNING' and namespace == 'py.warnings'):
+            return
+
+        filename_and_datatuple = FakeLogger.identify_unclosed_file(specifics)
+        if filename_and_datatuple is not None:
+            self.unclosed_by_file.update((filename_and_datatuple,))
+
+    @staticmethod
+    def identify_unclosed_file(specifics):
+        filename, lineno, exc_name, message = specifics.split(':', maxsplit=3)
+        exc_name = exc_name.lstrip()
+        if exc_name != 'ResourceWarning':
+            return
+        matched = FakeLogger.RE_UNCLOSEDFILE.match(message.lstrip())
+        if matched is None:
+            return
+        relative_testfile = os.path.relpath(filename, start=MIG_BASE)
+        relative_outputfile = os.path.relpath(matched.groups('location')[0], start=TEST_BASE)
+        return (relative_testfile, (lineno, relative_outputfile))
 
 class MigTestCase(TestCase):
     def __init__(self, *args):
         super(MigTestCase, self).__init__(*args)
         self._cleanup_paths = set()
         self._logger = None
+        self._skip_logging = False
+
+    def setUp(self):
+        if not self._skip_logging:
+            self._reset_logging(stream=self.logger)
 
     def tearDown(self):
-        self._logger = None
+        if not self._skip_logging:
+            self._logger.check_empty_and_reset()
+        if self._logger is not None:
+            self._reset_logging(stream=BLACKHOLE_STREAM)
 
         for path in self._cleanup_paths:
             if os.path.isdir(path):
@@ -65,6 +120,11 @@ class MigTestCase(TestCase):
                 os.remove(path)
             else:
                 continue
+
+    def _reset_logging(self, stream):
+        root_logger = logging.getLogger()
+        root_handler = root_logger.handlers[0]
+        root_handler.stream = stream
 
     @property
     def logger(self):

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+import os
+import sys
+import unittest
+
+from support import MigTestCase, PY2, testmain, temppath
+
+class SupportTestCase(MigTestCase):
+    @unittest.skipIf(PY2, "Python 3 only")
+    def test_unclosed_files_are_recorded(self):
+        tmp_path = temppath("support-unclosed", self)
+
+        def open_without_close():
+            with open(tmp_path, 'w'): pass
+            open(tmp_path)
+            return
+
+        open_without_close()
+
+        with self.assertRaises(RuntimeError):
+            self._logger.check_empty_and_reset()
+
+    def test_unclosed_files_are_reset(self):
+        # test name is purposefully after ..._recorded in sort order
+        # such that we can check the fake logger was cleaned up correctly
+        try:
+            # will not throw for a clean logger
+            self._logger.check_empty_and_reset()
+        except:
+            self.assertTrue(False, "should not be reachable")
+
+if __name__ == '__main__':
+    testmain()


### PR DESCRIPTION
Integrate resource warnings with the FakeLogger - this involves registering the fake logger as the stream for captured warnings to be delivered to. Add some matching logic for "ResourceWarning: unclosed file ..." exception messages, pull out the line number and output file, and record this stuff. When the tests exits the teardown method checks whether any such records exists and if so throws loudly including these details in a well formatted message that should allow tracking down the cause.

The overarching goal here is so to ensure that any code executed under test cannot leave an open file and get away with it.