### PR TITLE
Do the minimum required to allow executing safeinput to work on Py3.

### DIFF
--- a/mig/shared/base.py
+++ b/mig/shared/base.py
@@ -29,6 +29,7 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+from past.builtins import basestring
 
 import base64
 import os

--- a/mig/shared/compat.py
+++ b/mig/shared/compat.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# support - helper functions for unit testing
+# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# -- END_HEADER ---
+#
+
+"""This file contains an assortment of compatibility functions whose
+lifetime is intentionally intended to be time limited."""
+
+from __future__ import absolute_import
+import codecs
+import sys
+
+PY2 = sys.version_info[0] < 3
+
+from mig.shared.base import STR_KIND, _force_default_coding
+
+
+def ensure_native_string(string_or_bytes):
+    """Given a supplied input which can be either a string or bytes
+    return a representation string operations while ensuring that its
+    contents represent a valid series of textual characters.
+
+    Arrange identical operation across python 2 and 3 - specifically,
+    the presence of invalid UTF-8 bytes (thus the input not being a
+    valid textual string) will trigger a UnicodeDecodeError on PY3.
+    Force the same to occur on PY2.
+    """
+    textual_output = _force_default_coding(string_or_bytes, STR_KIND)
+    if PY2:
+        # Simulate decoding done by PY3 to trigger identical exceptions
+        # note the used of a forced "utf8" encoding value: this function
+        # is generally used to wrap, for example, substitutions of values
+        # into strings that are defined in the source code. In Python 3
+        # these are mandated to be UTF-8, and thus decoding as "utf8" is
+        # what will be attempted on supplied input. Match it.
+        codecs.decode(textual_output, "utf8")
+    return textual_output

--- a/mig/shared/safeinput.py
+++ b/mig/shared/safeinput.py
@@ -38,11 +38,13 @@ basis.
 from __future__ import print_function
 from __future__ import absolute_import
 
-import cgi
+import os
 import re
+import sys
 from email.utils import parseaddr, formataddr
 from string import ascii_letters, digits, printable
 from unicodedata import category, normalize, name as unicode_name
+import html
 
 try:
     import nbformat
@@ -319,16 +321,18 @@ def __wrap_unicode_val(char):
 
 # Public functions
 
-def html_escape(contents):
-    """Uses cgi.escape() to encode contents in a html safe way. In that
+def html_escape(contents, quote=None):
+    """Uses html.escape() to encode contents in a html safe way. In that
     way the resulting data can be included in a html page without risk
     of XSS vulnerabilities.
+    The optional quote argument is passed as is to enable additional escaping
+    of single and double quotes.
     """
 
     # We use html_escape as a general protection even though it is
-    # mostly html (cgi) related
+    # mostly html request related
 
-    return cgi.escape(contents)
+    return html.escape(contents, quote)
 
 
 def valid_printable(contents, min_length=0, max_length=-1):
@@ -2269,7 +2273,9 @@ class InputException(Exception):
         return force_utf8(force_unicode(self.value))
 
 
-if __name__ == '__main__':
+def main(_print=print):
+    print = _print # workaround print as reserved word on PY2
+
     for test_cn in ('Firstname Lastname', 'Test Æøå', 'Test Überh4x0r',
                     'Harry S. Truman',  u'Unicode æøå', "Invalid D'Angelo",
                     'Test Maybe Invalid Źacãŕ', 'Test Invalid ?',
@@ -2467,3 +2473,6 @@ if __name__ == '__main__':
     print("Rejected:")
     for (key, val) in rejected.items():
         print("\t%s: %s" % (key, val))
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_mig_shared_compat.py
+++ b/tests/test_mig_shared_compat.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+import binascii
+import os
+import sys
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
+from support import MigTestCase, testmain
+
+from mig.shared.compat import \
+    ensure_native_string
+
+DUMMY_BYTECHARS = b'DEADBEEF'
+DUMMY_BYTESRAW = binascii.unhexlify('DEADBEEF') # 4 bytes
+
+class MigSharedCompat__ensure_native_string(MigTestCase):
+    def test_char_bytes_conversion(self):
+        actual = ensure_native_string(DUMMY_BYTECHARS)
+        self.assertEqual(actual, 'DEADBEEF')
+
+    def test_raw_bytes_conversion(self):
+        with self.assertRaises(UnicodeDecodeError):
+            ensure_native_string(DUMMY_BYTESRAW)
+
+
+if __name__ == '__main__':
+    testmain()

--- a/tests/test_mig_shared_safeinput.py
+++ b/tests/test_mig_shared_safeinput.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+import importlib
+import os
+import sys
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
+
+from support import MigTestCase, testmain
+
+
+class MigSharedSafeinput(MigTestCase):
+
+    def test_basic_import(self):
+        safeimport = importlib.import_module("mig.shared.safeinput")
+
+    def test_existing_main(self):
+        safeimport = importlib.import_module("mig.shared.safeinput")
+        safeimport.main(_print=lambda _: None)
+
+
+if __name__ == '__main__':
+    testmain()


### PR DESCRIPTION
Backport the switch from cgi.escape to html.escape so mig.shared.safeinput
can be imported across versions. Wrap the existing library level main()
code in a transitional test thereby confirming basic working.

Note that main() must still be converted into individual test cases.