### PR TITLE
Ensure viable PYTHONPATH when executing environmentally configured python.

### DIFF
--- a/envhelp/python2
+++ b/envhelp/python2
@@ -16,6 +16,10 @@ if [ -z "${DOCKER_BIN}" ]; then
     exit 1
 fi
 
+# default PYTHONPATH such that directly executing files in the repo "just works"
+# NOTE: this is hard-coded to the mount point used within the container
+PYTHONPATH='/usr/app/src'
+
 # default any variables for local development
 MIG_ENV=${MIG_ENV:-'local'}
 
@@ -40,4 +44,8 @@ echo
 
 # execute python2 within the image passing the supplied arguments
 
-${DOCKER_BIN} run -it --rm --mount type=bind,source=.,target=/usr/src/app --env "MIG_ENV=$MIG_ENV" "$IMAGEID" python2 "$@"
+${DOCKER_BIN} run -it --rm \
+    --mount type=bind,source=.,target=/usr/src/app \
+    --env "PYTHONPATH=$PYTHON_PATH" \
+    --env "MIG_ENV=$MIG_ENV" \
+    "$IMAGEID" python2 "$@"

--- a/envhelp/python3
+++ b/envhelp/python3
@@ -6,6 +6,7 @@ set -e
 
 SCRIPT_PATH=$(realpath "$0")
 SCRIPT_BASE=$(dirname -- "$SCRIPT_PATH")
+MIG_BASE=$(realpath "$SCRIPT_BASE/..")
 PYTHON3_BIN="$SCRIPT_BASE/venv/bin/python3"
 
 if [ ! -f "${PYTHON3_BIN}" ]; then
@@ -13,10 +14,13 @@ if [ ! -f "${PYTHON3_BIN}" ]; then
     exit 1
 fi
 
+# default PYTHONPATH such that directly executing files in the repo "just works"
+PYTHONPATH=${PYTHONPATH:-"$MIG_BASE"}
+
 # default any variables for local development
 MIG_ENV=${MIG_ENV:-'local'}
 
 echo "running with MIG_ENV='$MIG_ENV' under python 3"
 echo
 
-MIG_ENV="$MIG_ENV" "$PYTHON3_BIN" "$@"
+PYTHONPATH="$PYTHONPATH" MIG_ENV="$MIG_ENV" "$PYTHON3_BIN" "$@"


### PR DESCRIPTION
Doing so means that we support the ability to execute arbitrary scripts within the tree directly via our wrappers - which one needs to do anyway to have a full assortment of the requisite dependencies - while avoiding the need to alter sys.path in non-test files.

While here drop an __init__.py file in the tests folder thus allowing tests to be accessible as modules in the tests.<filename> and thus allows easily specifying specific tests to be run with unitttest.