### PR TITLE
Do the minimum required to allow executing safeinput to work on Py 3.

### DIFF
--- a/envhelp/python2
+++ b/envhelp/python2
@@ -16,6 +16,10 @@ if [ -z "${DOCKER_BIN}" ]; then
     exit 1
 fi
 
+# default PYTHONPATH such that directly executing files in the repo "just works"
+# NOTE: this is hard-coded to the mount point used within the container
+PYTHONPATH='/usr/app/src'
+
 # default any variables for local development
 MIG_ENV=${MIG_ENV:-'local'}
 
@@ -40,4 +44,8 @@ echo
 
 # execute python2 within the image passing the supplied arguments
 
-${DOCKER_BIN} run -it --rm --mount type=bind,source=.,target=/usr/src/app --env "MIG_ENV=$MIG_ENV" "$IMAGEID" python2 "$@"
+${DOCKER_BIN} run -it --rm \
+    --mount type=bind,source=.,target=/usr/src/app \
+    --env "PYTHONPATH=$PYTHON_PATH" \
+    --env "MIG_ENV=$MIG_ENV" \
+    "$IMAGEID" python2 "$@"

--- a/envhelp/python3
+++ b/envhelp/python3
@@ -6,6 +6,7 @@ set -e
 
 SCRIPT_PATH=$(realpath "$0")
 SCRIPT_BASE=$(dirname -- "$SCRIPT_PATH")
+MIG_BASE=$(realpath "$SCRIPT_BASE/..")
 PYTHON3_BIN="$SCRIPT_BASE/venv/bin/python3"
 
 if [ ! -f "${PYTHON3_BIN}" ]; then
@@ -13,10 +14,13 @@ if [ ! -f "${PYTHON3_BIN}" ]; then
     exit 1
 fi
 
+# default PYTHONPATH such that directly executing files in the repo "just works"
+PYTHONPATH=${PYTHONPATH:-"$MIG_BASE"}
+
 # default any variables for local development
 MIG_ENV=${MIG_ENV:-'local'}
 
 echo "running with MIG_ENV='$MIG_ENV' under python 3"
 echo
 
-MIG_ENV="$MIG_ENV" "$PYTHON3_BIN" "$@"
+PYTHONPATH="$PYTHONPATH" MIG_ENV="$MIG_ENV" "$PYTHON3_BIN" "$@"

--- a/mig/shared/base.py
+++ b/mig/shared/base.py
@@ -29,6 +29,7 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+from past.builtins import basestring
 
 import base64
 import os

--- a/mig/shared/safeinput.py
+++ b/mig/shared/safeinput.py
@@ -44,12 +44,20 @@ import sys
 from email.utils import parseaddr, formataddr
 from string import ascii_letters, digits, printable
 from unicodedata import category, normalize, name as unicode_name
-import html
 
 try:
     import nbformat
 except ImportError:
     nbformat = None
+
+PY2 = sys.version_info[0] < 3
+
+escape_html = None
+if PY2:
+    from cgi import escape as escape_html
+else:
+    from html import escape as escape_html
+assert escape_html is not None
 
 from mig.shared.base import force_unicode, force_utf8
 from mig.shared.defaults import src_dst_sep, username_charset, \
@@ -322,7 +330,7 @@ def __wrap_unicode_val(char):
 # Public functions
 
 def html_escape(contents, quote=None):
-    """Uses html.escape() to encode contents in a html safe way. In that
+    """Use an stdlib escape to encode contents in a html safe way. In that
     way the resulting data can be included in a html page without risk
     of XSS vulnerabilities.
     The optional quote argument is passed as is to enable additional escaping
@@ -332,7 +340,7 @@ def html_escape(contents, quote=None):
     # We use html_escape as a general protection even though it is
     # mostly html request related
 
-    return html.escape(contents, quote)
+    return escape_html(contents, quote)
 
 
 def valid_printable(contents, min_length=0, max_length=-1):

--- a/mig/shared/safeinput.py
+++ b/mig/shared/safeinput.py
@@ -38,11 +38,13 @@ basis.
 from __future__ import print_function
 from __future__ import absolute_import
 
-import cgi
+import os
 import re
+import sys
 from email.utils import parseaddr, formataddr
 from string import ascii_letters, digits, printable
 from unicodedata import category, normalize, name as unicode_name
+import html
 
 try:
     import nbformat
@@ -319,16 +321,18 @@ def __wrap_unicode_val(char):
 
 # Public functions
 
-def html_escape(contents):
-    """Uses cgi.escape() to encode contents in a html safe way. In that
+def html_escape(contents, quote=None):
+    """Uses html.escape() to encode contents in a html safe way. In that
     way the resulting data can be included in a html page without risk
     of XSS vulnerabilities.
+    The optional quote argument is passed as is to enable additional escaping
+    of single and double quotes.
     """
 
     # We use html_escape as a general protection even though it is
-    # mostly html (cgi) related
+    # mostly html request related
 
-    return cgi.escape(contents)
+    return html.escape(contents, quote)
 
 
 def valid_printable(contents, min_length=0, max_length=-1):
@@ -2269,7 +2273,9 @@ class InputException(Exception):
         return force_utf8(force_unicode(self.value))
 
 
-if __name__ == '__main__':
+def main(_print=print):
+    print = _print # workaround print as reserved word on PY2
+
     for test_cn in ('Firstname Lastname', 'Test Æøå', 'Test Überh4x0r',
                     'Harry S. Truman',  u'Unicode æøå', "Invalid D'Angelo",
                     'Test Maybe Invalid Źacãŕ', 'Test Invalid ?',
@@ -2467,3 +2473,6 @@ if __name__ == '__main__':
     print("Rejected:")
     for (key, val) in rejected.items():
         print("\t%s: %s" % (key, val))
+
+if __name__ == '__main__':
+    main()

--- a/mig/shared/safeinput.py
+++ b/mig/shared/safeinput.py
@@ -38,7 +38,6 @@ basis.
 from __future__ import print_function
 from __future__ import absolute_import
 
-import os
 import re
 import sys
 from email.utils import parseaddr, formataddr

--- a/tests/test_mig_shared_safeinput.py
+++ b/tests/test_mig_shared_safeinput.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+import importlib
+import os
+import sys
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
+
+from support import MigTestCase, testmain
+
+
+class MigSharedSafeinput(MigTestCase):
+
+    def test_basic_import(self):
+        safeimport = importlib.import_module("mig.shared.safeinput")
+
+    def test_existing_main(self):
+        safeimport = importlib.import_module("mig.shared.safeinput")
+        safeimport.main(_print=lambda _: None)
+
+
+if __name__ == '__main__':
+    testmain()

--- a/tests/test_mig_shared_safeinput.py
+++ b/tests/test_mig_shared_safeinput.py
@@ -1,4 +1,29 @@
 # -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# addheader - add license header to all code modules.
+# Copyright (C) 2009-2024  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# --- END_HEADER ---
+#
 
 import importlib
 import os


### PR DESCRIPTION
Backport the switch from cgi.escape to html.escape so mig.shared.safeinput can be imported across versions. Wrap the existing library level main() code in a transitional test thereby confirming basic working while being fully aware that main() must still be converted into individual test cases.

Note that we avoid the need to mess with `sys.path` by instead relaying on: https://github.com/ucphhpc/migrid-sync/pull/60