### PR TITLE
Integrate autopep8 into the Makefile and set default baseline options.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+ifndef MIG_ENV
+	MIG_ENV = 'local'
+endif
 ifeq ($(PY),2)
 	PYTHON_BIN = './envhelp/python2'
 else
@@ -17,6 +20,14 @@ info:
 	@echo "'make test'      - run the test suite"
 	@echo "'make PY=2 test' - run the test suite (python 2)"
 
+.PHONY: fmt
+fmt:
+ifneq ($(MIG_ENV),'local')
+	@echo "unavailable outside local development environment"
+	@exit 1
+endif
+	$(PYTHON_BIN) -m autopep8 --ignore E402 -i
+
 .PHONY: clean
 clean:
 	@rm -f ./envhelp/py2.imageid
@@ -35,10 +46,19 @@ test: dependencies
 .PHONY: dependencies
 dependencies: ./envhelp/venv/pyvenv.cfg ./envhelp/py3.depends
 
+ifeq ($(MIG_ENV),'local')
+./envhelp/py3.depends: $(REQS_PATH) local-requirements.txt
+else
 ./envhelp/py3.depends: $(REQS_PATH)
+endif
 	@rm -f ./envhelp/py3.depends
 	@echo "installing dependencies from $(REQS_PATH)"
 	@./envhelp/venv/bin/pip3 install -r $(REQS_PATH)
+ifeq ($(MIG_ENV),'local')
+	@echo ""
+	@echo "installing development dependencies"
+	@./envhelp/venv/bin/pip3 install -r local-requirements.txt
+endif
 	@touch ./envhelp/py3.depends
 
 ./envhelp/venv/pyvenv.cfg:

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -1,0 +1,3 @@
+# migrid dependencies on a format suitable for pip install as described on
+# https://pip.pypa.io/en/stable/reference/requirement-specifiers/
+autopep8


### PR DESCRIPTION
We are currently in a situation of wanting to make sure that out codebase is autopep8 clean but there is no "standardised" way of ensuing this. Take the opportunity to codify this in a new `make fmt` target - arrange the autopep8 dependency as additional local dependency and invoke it via the envhelp infrastructure.

As part of this commit we configure autopep8 with an option to ignore E402 which disables the re-arrangement of imports - this is relevant to us as we carefully arrange import order and the current workaround (wrapping an extra try-except around the imports with a comment that says its to trick autopep8) is pretty messy in terms of the source code.