### PR TITLE
Create structured constants for validation dicts used for openid auth.

### DIFF
--- a/mig/shared/compat.py
+++ b/mig/shared/compat.py
@@ -55,6 +55,31 @@ def _is_unicode(val):
     return (type(val) == _TYPE_UNICODE)
 
 
+def encode_ascii_string(unicode_string):
+    """Given a supplied input which can be either a string or bytes
+    return a representation that is gauranteed to be an ASCII string
+    in which any unicode characters are escaped. Output is suitable
+    for use in situations in Python 2 that are required to be ASCII
+    but we want to preserve any contained unicode characters e.g.
+    exception messages.
+    """
+
+    assert _is_unicode(unicode_string)
+
+    if PY2:
+        prepared_string = bytearray(unicode_string, 'utf8')
+    else:
+        prepared_string = unicode_string
+
+    encoded_latin1 = codecs.decode(prepared_string, 'raw_unicode_escape')
+    encoded_ascii = list(encoded_latin1)
+    for index, character in enumerate(encoded_latin1):
+        character_ord = ord(character)
+        if character_ord > 127:
+            encoded_ascii[index] = "\%s" % hex(character_ord)[1:]
+    return ''.join(encoded_ascii)
+
+
 def ensure_native_string(string_or_bytes):
     """Given a supplied input which can be either a string or bytes
     return a representation providing string operations while ensuring that

--- a/mig/shared/defaults.py
+++ b/mig/shared/defaults.py
@@ -32,6 +32,8 @@ from string import ascii_lowercase, ascii_uppercase, digits
 import os
 import sys
 
+from mig.shared.localtypes import AsciiEnum
+
 MIG_BASE = os.path.realpath(os.path.join(os.path.dirname(__file__), '../..'))
 MIG_ENV = os.getenv('MIG_ENV', 'default')
 
@@ -79,6 +81,13 @@ any_state = keyword_any
 
 AUTH_NONE, AUTH_GENERIC, AUTH_CERTIFICATE = "None", "Generic", "X.509 Certificate"
 AUTH_OPENID_CONNECT, AUTH_OPENID_V2 = "OpenID Connect", "OpenID 2.0"
+
+class AUTH(AsciiEnum):
+    NONE = AUTH_NONE
+    GENERIC = AUTH_GENERIC
+    CERTIFICATE = AUTH_CERTIFICATE
+    OPENID_CONNECT = AUTH_OPENID_CONNECT
+    OPENID_V2 = AUTH_OPENID_V2
 
 AUTH_MIG_OID = "Site %s" % AUTH_OPENID_V2
 AUTH_EXT_OID = "Ext %s" % AUTH_OPENID_V2

--- a/mig/shared/localtypes.py
+++ b/mig/shared/localtypes.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# support - helper functions for unit testing
+# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# -- END_HEADER ---
+#
+
+from __future__ import print_function
+from past.builtins import basestring
+import codecs
+import enum
+
+from mig.shared.compat import encode_ascii_string
+
+""" A module containing a set of commonly used local data strutures.
+
+The use of no internal dependencies ensures the provided primitives
+can be used as the basis for defining any other parts of the system.
+"""
+
+
+def _isascii(value):
+    """Given a string establish that is conatains only plain ascii.
+    """
+    assert isinstance(value, basestring)
+    return not any((b > 0x7f for b in bytearray(value, 'utf8')))
+
+
+class AsciiEnum(str, enum.Enum):
+    """
+    Enum where members behave as strings and are reuired to contain only ascii.
+    """
+
+    def __new__(cls, *values):
+        if len(values) != 1:
+            raise TypeError('only a single argument is supported')
+        thestring = values[0]
+        if not isinstance(thestring, basestring):
+            raise AsciiEnum._value_error_prefixing_escaped_value(thestring, 'is not a string')
+        if not _isascii(thestring):
+            raise AsciiEnum._value_error_prefixing_escaped_value(thestring, 'is not pure ascii')
+        member = str.__new__(cls, thestring)
+        member._value_ = thestring
+        return member
+
+    @staticmethod
+    def _value_error_prefixing_escaped_value(prefix, partial_message, is_string=True):
+        if is_string:
+            escaped_prefix = encode_ascii_string(prefix)
+        else:
+            escaped_prefix = prefix
+        return ValueError("%r %s" % (escaped_prefix, partial_message))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # migrid core dependencies on a format suitable for pip install as described on
 # https://pip.pypa.io/en/stable/reference/requirement-specifiers/
+enum34
 future
 # NOTE: python-3.6 and earlier versions require older pyotp, whereas 3.7+
 #       should work with any modern version. We tested 2.9.0 to work.

--- a/tests/test_mig_shared_defaults.py
+++ b/tests/test_mig_shared_defaults.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# addheader - add license header to all code modules.
+# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# --- END_HEADER ---
+#
+
+"""Unit tests covering defined defaults."""
+
+import importlib
+import os
+import sys
+import types
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
+
+from support import MigTestCase, testmain
+
+
+class MigSharedDefaults(MigTestCase):
+
+    def test_basic_import(self):
+        mod = importlib.import_module("mig.shared.defaults")
+        self.assertIsInstance(mod, types.ModuleType)
+
+
+if __name__ == '__main__':
+    testmain()

--- a/tests/test_mig_shared_functionality_autocreate.py
+++ b/tests/test_mig_shared_functionality_autocreate.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# addheader - add license header to all code modules.
+# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# --- END_HEADER ---
+#
+
+"""Unit tests for the WSGI autocreate handler."""
+
+import importlib
+import os
+import sys
+import types
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
+
+from support import MigTestCase, testmain
+
+
+class MigSharedDefaults(MigTestCase):
+
+    def test_basic_import(self):
+        mod = importlib.import_module("mig.shared.functionality.autocreate")
+        self.assertIsInstance(mod, types.ModuleType)
+
+
+if __name__ == '__main__':
+    testmain()

--- a/tests/test_mig_shared_localtypes.py
+++ b/tests/test_mig_shared_localtypes.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# addheader - add license header to all code modules.
+# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# --- END_HEADER ---
+#
+
+"""Unit tests for the shared package of local types."""
+
+from past.builtins import basestring
+import codecs
+import sys
+
+from tests.support import MigTestCase, testmain
+
+from mig.shared.localtypes import AsciiEnum
+
+
+PY2 = sys.version_info[0] == 2
+
+
+def as_string_of_unicode(value):
+    assert isinstance(value, basestring)
+    if not is_string_of_unicode(value):
+        assert PY2, "unreachable unless Python 2"
+        return unicode(codecs.decode(value, 'utf8'))
+    return value
+
+
+def is_string_of_unicode(value):
+    return type(value) == type(u'')
+
+
+DUMMY_UNICODE = u'UniCode123½¾µßðþđŋħĸþł@ª€£$¥©®'
+
+
+class MigSharedLocaltypes__AsciiEnum(MigTestCase):
+    def test_defines_the_number_of_cases_specified(self):
+        class TheEnum(AsciiEnum):
+            SomeCase = 'some case'
+            OtherCase = 'other case'
+            ZzzCase = 'all the zzz'
+
+        self.assertEqual(len(TheEnum), 3)
+
+    def test_defines_cases_that_behave_as_strings(self):
+        class TheEnum(AsciiEnum):
+            SomeCase = 'some case'
+            OtherCase = 'other case'
+
+        self.assertEqual(TheEnum.SomeCase, 'some case')
+        self.assertEqual(TheEnum.OtherCase, 'other case')
+
+    def test_disallows_unicode_keys(self):
+        with self.assertRaises(Exception) as cm:
+            class TheEnum(AsciiEnum):
+                SomeCase = DUMMY_UNICODE
+
+        theexception = cm.exception
+
+        expected_message = "'UniCode123\\\\xc2\\\\xbd\\\\xc2\\\\xbe\\\\xc2\\\\xb5\\\\xc3\\\\x9f\\\\xc3\\\\xb0\\\\xc3\\\\xbe\\\\xc4\\\\x91\\\\xc5\\\\x8b\\\\xc4\\\\xa7\\\\xc4\\\\xb8\\\\xc3\\\\xbe\\\\xc5\\\\x82@\\\\xc2\\\\xaa\\\\xe2\\\\x82\\\\xac\\\\xc2\\\\xa3$\\\\xc2\\\\xa5\\\\xc2\\\\xa9\\\\xc2\\\\xae' is not pure ascii"
+        if PY2:
+            # repr of unicode strings includes a leading "u" to signify the type
+            expected_message = "u" + expected_message
+        self.assertEqual(theexception.__str__(), expected_message)
+
+
+if __name__ == '__main__':
+    testmain()


### PR DESCRIPTION
The validation of openid auth parameters is achieved by the use of a generic validation routine which is passed differing 'definition' dictionaries based on which open id auth mode is in use.

Previously these dictionaries were buried cases within what amounted to a switch over the auth mode. In addition we note the auth mode is an enumerated set of values and a large number of codepaths take action based on which of the set is activated.

Make the auth mode an enumerated constant. In order to support add an `AsciiEnum` type which is based on the official documentation suggested implementation for an enumeration whose values behave as strings within comparisons. We use the officially backported `enum34` package to add enum to Python 2 and base the new type on 

Use the existing constants as the values of the new auth constants such that they can be used interchangeably in cases where the originals were used to support gradual replacement. Use the cases of this enumeration as keys into a dictionary which maps them to the relevant validation definition dictionary.