### PR TITLE
Make the recently added compat module standalone.

### DIFF
--- a/mig/shared/compat.py
+++ b/mig/shared/compat.py
@@ -31,13 +31,19 @@ ease their subsequent removal.
 """
 
 from __future__ import absolute_import
+from past.builtins import basestring
 
 import codecs
 import sys
 
 PY2 = sys.version_info[0] < 3
+_TYPE_UNICODE = type(u"")
 
-from mig.shared.base import STR_KIND, _force_default_coding
+
+def _is_unicode(val):
+    """Return boolean indicating if the value is a unicode string.
+    """
+    return (type(val) == _TYPE_UNICODE)
 
 
 def ensure_native_string(string_or_bytes):
@@ -50,7 +56,6 @@ def ensure_native_string(string_or_bytes):
     valid textual string) will trigger a UnicodeDecodeError on PY3.
     Force the same to occur on PY2.
     """
-    textual_output = _force_default_coding(string_or_bytes, STR_KIND)
     if PY2:
         # Simulate decoding done by PY3 to trigger identical exceptions
         # note the use of a forced "utf8" encoding value: this function
@@ -58,5 +63,9 @@ def ensure_native_string(string_or_bytes):
         # into strings that are defined in the source code. In Python 3
         # these are mandated to be UTF-8, and thus decoding as "utf8" is
         # what will be attempted on supplied input. Match it.
-        codecs.decode(textual_output, "utf8")
+        textual_output = codecs.encode(string_or_bytes, 'utf8')
+    elif not _is_unicode(string_or_bytes):
+        textual_output = str(string_or_bytes, 'utf8')
+    else:
+        textual_output = string_or_bytes
     return textual_output

--- a/tests/test_mig_shared_compat.py
+++ b/tests/test_mig_shared_compat.py
@@ -33,20 +33,30 @@ import sys
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
 from support import MigTestCase, testmain
 
-from mig.shared.compat import ensure_native_string
+from mig.shared.compat import PY2, ensure_native_string
 
 DUMMY_BYTECHARS = b'DEADBEEF'
 DUMMY_BYTESRAW = binascii.unhexlify('DEADBEEF') # 4 bytes
+DUMMY_UNICODE = u'UniCode123½¾µßðþđŋħĸþł@ª€£$¥©®'
 
 class MigSharedCompat__ensure_native_string(MigTestCase):
     # TODO: Add docstrings to this class and its methods
     def test_char_bytes_conversion(self):
         actual = ensure_native_string(DUMMY_BYTECHARS)
+        self.assertIs(type(actual), str)
         self.assertEqual(actual, 'DEADBEEF')
 
     def test_raw_bytes_conversion(self):
         with self.assertRaises(UnicodeDecodeError):
             ensure_native_string(DUMMY_BYTESRAW)
+
+    def test_unicode_conversion(self):
+        actual = ensure_native_string(DUMMY_UNICODE)
+        self.assertEqual(type(actual), str)
+        if PY2:
+            self.assertEqual(actual, DUMMY_UNICODE.encode("utf8"))
+        else:
+            self.assertEqual(actual, DUMMY_UNICODE)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Work since the introduction of ensure_native_string() has shown that being able to make use the function is limited by its inclusion of the base package. Allow the function to be used everywhere by using only the Python standard library for its operation.

This sidesteps any potential for circular imports and ensures well tested string conversion is available for the _definition_ of e.g. base itself.