### PR TITLE
Fine-grained control over user permission to automatically sign up

### DIFF
--- a/mig/install/MiGserver-template.conf
+++ b/mig/install/MiGserver-template.conf
@@ -25,6 +25,11 @@ auto_add_filter_fields = __AUTO_ADD_FILTER_FIELDS__
 # default is to skip each such character. Other valid options include hexlify
 # to encode each such character with the corresponding hex codepoint.
 auto_add_filter_method = __AUTO_ADD_FILTER_METHOD__
+# Optional limit on users who may sign up through autocreate without operator
+# interaction. Defaults to allow ANY distinguished name if unset but only for
+# auth methods explicitly enabled with auto_add_X_user. Space separated list of
+# user field and regexp-filter pattern pairs separated by colons.
+auto_add_user_permit = __AUTO_ADD_USER_PERMIT__
 # Default account expiry unless set. Renew and web login extends by default.
 cert_valid_days = __CERT_VALID_DAYS__
 oid_valid_days = __OID_VALID_DAYS__

--- a/mig/install/generateconfs.py
+++ b/mig/install/generateconfs.py
@@ -70,6 +70,7 @@ if '__main__' == __name__:
         'destination_suffix',
         'auto_add_filter_fields',
         'auto_add_filter_method',
+        'auto_add_user_permit',
         'base_fqdn',
         'public_fqdn',
         'public_alias_fqdn',

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # accountreq - helpers for certificate/OpenID account requests
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -1241,6 +1241,17 @@ sudo su - %s
 ./mig/server/rejectuser.py -a %s -C -u '%s' -r 'missing required info'""" % \
         (mig_user, configuration.server_fqdn, kind, req_path)
     return cmd_helpers
+
+
+def auto_add_user_allowed(configuration, user_dict):
+    """Check if user with user_dict is allowed to sign up without operator
+    approval e.g. using autocreate based on optional configuration limits.
+    """
+
+    for (key, val) in configuration.auto_add_user_permit:
+        if not re.match(val, user_dict.get(key, 'NO SUCH FIELD')):
+            return False
+    return True
 
 
 def peers_permit_allowed(configuration, user_dict):

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -137,6 +137,7 @@ def fix_missing(config_file, verbose=True):
         'auto_add_oid_user': False,
         'auto_add_oidc_user': False,
         'auto_add_resource': False,
+        'auto_add_user_permit': 'distinguished_name:.*',
         'auto_add_filter_method': '',
         'auto_add_filter_fields': '',
         'server_fqdn': fqdn,
@@ -670,6 +671,7 @@ class Configuration:
     auto_add_oid_user = False
     auto_add_oidc_user = False
     auto_add_resource = False
+    auto_add_user_permit = [('distinguished_name', '.*')]
     auto_add_filter_method = ''
     auto_add_filter_fields = []
 
@@ -2524,6 +2526,12 @@ location.""" % self.config_file)
         if config.has_option('GLOBAL', 'auto_add_resource'):
             self.auto_add_resource = config.getboolean('GLOBAL',
                                                        'auto_add_resource')
+        # Limit sign up without operator interaction using ID fields regex.
+        # For autocreate auto_add_X_user must be True and auto_add_user_permit
+        # specification must match actual user on all given fields.
+        if config.has_option('GLOBAL', 'auto_add_user_permit'):
+            req = config.get('GLOBAL', 'auto_add_user_permit').split()
+            self.auto_add_user_permit = [i.split(':', 2) for i in req]
 
         # Apply requested automatic filtering of selected auto add user fields
         if config.has_option('GLOBAL', 'auto_add_filter_method'):

--- a/mig/shared/functionality/autocreate.py
+++ b/mig/shared/functionality/autocreate.py
@@ -44,6 +44,7 @@ import os
 import time
 
 from mig.shared import returnvalues
+from mig.shared.accountreq import auto_add_user_allowed
 from mig.shared.accountstate import default_account_expire
 from mig.shared.bailout import filter_output_objects
 from mig.shared.base import client_id_dir, canonical_user, mask_creds, \
@@ -724,6 +725,16 @@ accepting create matching supplied ID!'''})
             or auth_type == AUTH_OPENID_CONNECT and \
             configuration.auto_add_oidc_user:
         fill_user(user_dict)
+
+        if not auto_add_user_allowed(configuration, user_dict):
+            logger.warning('autocreate not permitted for %s' % client_id)
+            output_objects.append({
+                'object_type': 'error_text', 'text':
+                """Your credentials do not fit the automatic account sign up
+criteria permitted on this site.
+Please contact the %(short_title)s support (%(support_email)s) if you think it
+should be enabled.""" % fill_helper})
+            return (output_objects, returnvalues.ERROR)
 
         # IMPORTANT: do NOT log credentials
         logger.info('create user: %s' % mask_creds(user_dict))

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -238,6 +238,7 @@ def generate_confs(
     auto_add_oidc_user=False,
     auto_add_filter_fields='',
     auto_add_filter_method='skip',
+    auto_add_user_permit='distinguished_name:.*',
     cert_valid_days=365,
     oid_valid_days=365,
     oidc_valid_days=365,
@@ -503,6 +504,7 @@ def generate_confs(
     user_dict['__AUTO_ADD_OIDC_USER__'] = "%s" % auto_add_oidc_user
     user_dict['__AUTO_ADD_FILTER_FIELDS__'] = auto_add_filter_fields
     user_dict['__AUTO_ADD_FILTER_METHOD__'] = auto_add_filter_method
+    user_dict['__AUTO_ADD_USER_PERMIT__'] = auto_add_user_permit
     user_dict['__CERT_VALID_DAYS__'] = "%s" % cert_valid_days
     user_dict['__OID_VALID_DAYS__'] = "%s" % oid_valid_days
     user_dict['__OIDC_VALID_DAYS__'] = "%s" % oidc_valid_days
@@ -946,7 +948,8 @@ cert, oid and sid based https!
         sys_timezone = None
         try:
             timezone_cmd = ["/usr/bin/timedatectl", "status"]
-            timezone_proc = subprocess_popen(timezone_cmd, stdout=subprocess_pipe)
+            timezone_proc = subprocess_popen(
+                timezone_cmd, stdout=subprocess_pipe)
             for line in timezone_proc.stdout.readlines():
                 line = ensure_native_string(line.strip())
                 if not line.startswith("Time zone: "):
@@ -964,11 +967,13 @@ cert, oid and sid based https!
     user_dict['__SEAFILE_TIMEZONE__'] = timezone
 
     if seafile_secret == keyword_auto:
-        seafile_secret = ensure_native_string(base64.b64encode(os.urandom(32))).lower()
+        seafile_secret = ensure_native_string(
+            base64.b64encode(os.urandom(32))).lower()
     user_dict['__SEAFILE_SECRET_KEY__'] = seafile_secret
 
     if seafile_ccnetid == keyword_auto:
-        seafile_ccnetid = ensure_native_string(base64.b64encode(os.urandom(20))).lower()
+        seafile_ccnetid = ensure_native_string(
+            base64.b64encode(os.urandom(20))).lower()
     user_dict['__SEAFILE_CCNET_ID__'] = seafile_ccnetid
 
     user_dict['__SEAFILE_SHORT_NAME__'] = short_title.replace(' ', '-')
@@ -1742,7 +1747,6 @@ ssh-keygen -f %(__DAEMON_KEYCERT__)s -y > %(__DAEMON_PUBKEY__)s""" % user_dict)
         crypto_salt = ensure_native_string(base64.b16encode(os.urandom(16)))
     user_dict['__CRYPTO_SALT__'] = crypto_salt
 
-
     # Greedy match trailing space for all the values to uncomment stuff
     strip_trailing_space = ['__IF_SEPARATE_PORTS__', '__APACHE_PRE2.4__',
                             '__APACHE_RECENT__']
@@ -2164,6 +2168,7 @@ def create_user(
     auto_add_oidc_user = False
     auto_add_filter_fields = ''
     auto_add_filter_method = 'skip'
+    auto_add_user_permit = 'distinguished_name:.*'
     cert_valid_days = 365
     oid_valid_days = 365
     oidc_valid_days = 365
@@ -2310,6 +2315,7 @@ echo '/home/%s/state/sss_home/MiG-SSS/hda.img      /home/%s/state/sss_home/mnt  
         auto_add_oidc_user,
         auto_add_filter_fields,
         auto_add_filter_method,
+        auto_add_user_permit,
         cert_valid_days,
         oid_valid_days,
         oidc_valid_days,

--- a/tests/fixture/confs-stdlocal/MiGserver.conf
+++ b/tests/fixture/confs-stdlocal/MiGserver.conf
@@ -25,6 +25,11 @@ auto_add_filter_fields =
 # default is to skip each such character. Other valid options include hexlify
 # to encode each such character with the corresponding hex codepoint.
 auto_add_filter_method = skip
+# Optional limit on users who may sign up through autocreate without operator
+# interaction. Defaults to allow ANY distinguished name if unset but only for
+# auth methods explicitly enabled with auto_add_X_user. Space separated list of
+# user field and regexp-filter pattern pairs separated by colons.
+auto_add_user_permit = distinguished_name:.*
 # Default account expiry unless set. Renew and web login extends by default.
 cert_valid_days = 365
 oid_valid_days = 365


### PR DESCRIPTION
Implement fine-grained control over the permission of users to sign up using e.g. `autocreate` when the corresponding `auto_add_X_user` setting is enabled. Offers regex filtering on individual user ID fields as manually submitted by user or forwarded by the ID provider of the user when external authentication sources are enabled.
This is particularly useful if the ID provider has a huge user base and only some of them should be able to sign up without operator approval.