### PR TITLE
Bringup of the configuration object cross-version and coarse coverage.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,5 @@ jobs:
           pip install --no-cache-dir -r requirements.txt
       - name: Run tests
         run: |
+          PYTHON_BIN=python ./envhelp/makeconfig test --python2
           MIG_ENV='local' python -m unittest discover -s tests/

--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,22 @@ distclean: clean
 	@rm -f ./tests/*.pyc
 
 .PHONY: test
-test: dependencies
+test: dependencies testconfig
 	@$(PYTHON_BIN) -m unittest discover -s tests/
 
 .PHONY: dependencies
 dependencies: ./envhelp/venv/pyvenv.cfg ./envhelp/py3.depends
+
+.PHONY: testconfig
+testconfig: ./envhelp/output/testconfs
+
+./envhelp/output/testconfs:
+	@echo "generating test configuration"
+	@./envhelp/makeconfig test --python2
+	@./envhelp/makeconfig test
+	@mkdir -p ./envhelp/output/certs
+	@mkdir -p ./envhelp/output/state
+	@mkdir -p ./envhelp/output/state/log
 
 ifeq ($(MIG_ENV),'local')
 ./envhelp/py3.depends: $(REQS_PATH) local-requirements.txt

--- a/envhelp/makeconfig
+++ b/envhelp/makeconfig
@@ -1,6 +1,29 @@
 #!/bin/sh
 #
-# Standalone wrapper for generating a test configuration.
+# --- BEGIN_HEADER ---
+#
+# makeconfig - standalone wrapper for generating a test configuration.
+# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# --- END_HEADER ---
+#
 
 set -e
 

--- a/envhelp/makeconfig
+++ b/envhelp/makeconfig
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Standalone wrapper for generating a test configuration.
+
+set -e
+
+SCRIPT_PATH=$(realpath "$0")
+SCRIPT_BASE=$(dirname -- "$SCRIPT_PATH")
+MIG_BASE=$(realpath "$SCRIPT_BASE/..")
+PYTHON_BIN=${PYTHON_BIN:-"$SCRIPT_BASE/venv/bin/python3"}
+PY=${PY:-'3'}
+
+# default PYTHONPATH such that importing files in the repo "just works"
+PYTHONPATH=${PYTHONPATH:-"$MIG_BASE"}
+
+# default any variables for local development
+MIG_ENV=${MIG_ENV:-'local'}
+
+MIG_ENV="$MIG_ENV" PY="$PY" "$PYTHON_BIN" "$SCRIPT_BASE/makeconfig.py" "$@"

--- a/envhelp/makeconfig.py
+++ b/envhelp/makeconfig.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# makeconfig.py - standalone test configuration generation
+# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# --- END_HEADER ---
+#
+
+"""Standalone test configuration generation."""
+
+
+from __future__ import print_function
+
+import os
+import sys
+
+sys.path.append(os.path.realpath(
+    os.path.join(os.path.dirname(__file__), "..")))
+
+from mig.shared.install import generate_confs
+
+_ENVHELP_OUTPUT_DIR = os.path.realpath(
+    os.path.join(os.path.dirname(__file__), "output"))
+_MAKECONFIG_ALLOWED = ["local", "test"]
+_PYTHON_MAJOR = os.environ.get('PY', '3')
+
+
+def _at(sequence, index=-1, default=None):
+    assert index > -1
+    try:
+        return sequence[index]
+    except IndexError:
+        return default
+
+
+def write_testconfig(env_name, is_py2=False):
+    confs_name = 'confs' if env_name == 'local' else '%sconfs' % (env_name,)
+    overrides = {
+        'destination': os.path.join(_ENVHELP_OUTPUT_DIR, confs_name),
+        'destination_suffix': "-py%s" % ('2' if is_py2 else '3',),
+    }
+    if is_py2:
+        overrides.update(**{
+            'mig_code': '/usr/src/app/mig',
+            'mig_certs': '/usr/src/app/envhelp/output/certs',
+            'mig_state': '/usr/src/app/envhelp/output/state',
+        })
+    generate_confs(_ENVHELP_OUTPUT_DIR, **overrides)
+
+
+def main_(argv):
+    env_name = _at(argv, index=1, default='')
+    arg_is_py2 = '--python2' in argv
+
+    if env_name == '':
+        raise RuntimeError(
+            'expected the environment name as a single argument')
+    if env_name not in _MAKECONFIG_ALLOWED:
+        raise RuntimeError('environment must be one of %s' %
+                           (_MAKECONFIG_ALLOWED,))
+
+    write_testconfig(env_name, is_py2=arg_is_py2)
+
+
+def main(argv=sys.argv):
+    try:
+        main_(argv)
+    except RuntimeError as e:
+        print('makeconfig: %s' % (str(e),))
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/envhelp/python2
+++ b/envhelp/python2
@@ -1,6 +1,29 @@
 #!/bin/sh
 #
-# Wrap python2 docker container for testing
+# --- BEGIN_HEADER ---
+#
+# python2 - wrap python2 docker container for testing
+# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# --- END_HEADER ---
+#
 
 set -e
 

--- a/envhelp/python3
+++ b/envhelp/python3
@@ -1,6 +1,29 @@
 #!/bin/sh
 #
-# Wrap python3 virtual environment for testing
+# --- BEGIN_HEADER ---
+#
+# python3 - wrap python3 virtual environment for testing
+# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# --- END_HEADER ---
+#
 
 set -e
 

--- a/mig/install/generateconfs.py
+++ b/mig/install/generateconfs.py
@@ -46,6 +46,7 @@ sys.path.append(dirname(dirname(dirname(os.path.abspath(__file__)))))
 
 # NOTE: moved mig imports into try/except to avoid autopep8 moving to top!
 try:
+    from mig.shared.defaults import MIG_BASE, MIG_ENV
     from mig.shared.install import generate_confs
 except ImportError:
     print("ERROR: the migrid modules must be in PYTHONPATH")
@@ -358,7 +359,18 @@ if '__main__' == __name__:
         # Remove default values to use generate_confs default values
         if val == 'DEFAULT':
             del settings[key]
-    options = generate_confs(**settings)
+
+    if os.getenv('MIG_ENV', 'default') == 'local':
+        output_path = os.path.join(MIG_BASE, 'envhelp/output')
+    else:
+        output_path = os.getcwd()
+        # set user and group to hard-coded bakcwards compatible values
+        settings.update(
+            user='mig',
+            group='mig'
+        )
+    options = generate_confs(output_path, **settings)
+
     # TODO: avoid reconstructing this path (also done inside generate_confs)
     instructions_path = os.path.join(options['destination_dir'],
                                      'instructions.txt')

--- a/mig/install/generateconfs.py
+++ b/mig/install/generateconfs.py
@@ -352,6 +352,15 @@ if '__main__' == __name__:
     if settings['destination_suffix'] == 'DEFAULT':
         suffix = "-%s" % datetime.datetime.now().isoformat()
         settings['destination_suffix'] = suffix
+    if os.getenv('MIG_ENV', 'default') == 'local':
+        output_path = os.path.join(MIG_BASE, 'envhelp/output')
+    elif settings['destination'] == 'DEFAULT' or \
+            not os.path.isabs(settings['destination']):
+        # Default to generate in subdir of CWD ...
+        output_path = os.getcwd()
+    else:
+        # ... but use verbatim passthrough for absolute destination
+        output_path = settings['destination']
     print('# Creating confs with:')
     # NOTE: force list to avoid problems with in-line edits
     for (key, val) in list(settings.items()):
@@ -360,15 +369,6 @@ if '__main__' == __name__:
         if val == 'DEFAULT':
             del settings[key]
 
-    if os.getenv('MIG_ENV', 'default') == 'local':
-        output_path = os.path.join(MIG_BASE, 'envhelp/output')
-    else:
-        output_path = os.getcwd()
-        # set user and group to hard-coded bakcwards compatible values
-        settings.update(
-            user='mig',
-            group='mig'
-        )
     options = generate_confs(output_path, **settings)
 
     # TODO: avoid reconstructing this path (also done inside generate_confs)

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -2486,11 +2486,17 @@ location.""" % self.config_file)
 
         # Init auth logger
 
+        auth_logger_logfile = None
+        if skip_log:
+            auth_logger_logfile = None
+        else:
+            auth_logger_logfile = self.user_auth_log
+
         if self.auth_logger_obj:
             self.auth_logger_obj.reopen()
         else:
             self.auth_logger_obj = Logger(
-                self.loglevel, logfile=self.user_auth_log, app='main-auth')
+                self.loglevel, logfile=auth_logger_logfile, app='main-auth')
         self.auth_logger = self.auth_logger_obj.logger
 
         # cert and key for generating a default proxy for nordugrid/ARC

--- a/mig/shared/defaults.py
+++ b/mig/shared/defaults.py
@@ -77,31 +77,6 @@ all_jobs = keyword_all
 any_protocol = keyword_any
 any_state = keyword_any
 
-mig_user = {
-    'default': 'mig',
-    'local': keyword_auto,
-}[MIG_ENV]
-
-mig_group = {
-    'default': 'mig',
-    'local': keyword_auto,
-}[MIG_ENV]
-
-default_source = {
-    'default': keyword_auto,
-    'local': os.path.join(MIG_BASE, "mig/install"),
-}[MIG_ENV]
-
-default_destination = {
-    'default': keyword_auto,
-    'local': os.path.join(MIG_BASE, "envhelp/output/confs"),
-}[MIG_ENV]
-
-default_enable_events = {
-    'default': True,
-    'local': False
-}[MIG_ENV]
-
 AUTH_NONE, AUTH_GENERIC, AUTH_CERTIFICATE = "None", "Generic", "X.509 Certificate"
 AUTH_OPENID_CONNECT, AUTH_OPENID_V2 = "OpenID Connect", "OpenID 2.0"
 

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -546,20 +546,18 @@ def generate_confs(
     destination_link = destination
     destination_dir = "%s%s" % (destination, destination_suffix)
 
+    # expand mig, certs and state paths relative to base if left to "AUTO"
+
     if mig_code == keyword_auto:
         expanded['mig_code'] = os.path.join(MIG_BASE, 'mig')
         mig_code = expanded['mig_code']
 
-    # expand any directory path specified "auto" relative to output location
-
     if mig_certs == keyword_auto:
-        expanded['mig_certs'] = os.path.join(
-            generateconfs_output_path, 'certs')
+        expanded['mig_certs'] = os.path.join(MIG_BASE, 'certs')
         mig_certs = expanded['mig_certs']
 
     if mig_state == keyword_auto:
-        expanded['mig_state'] = os.path.join(
-            generateconfs_output_path, 'state')
+        expanded['mig_state'] = os.path.join(MIG_BASE, 'state')
         mig_state = expanded['mig_state']
 
     # expand any user information marked as "auto" based on the environment

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -50,11 +50,10 @@ import subprocess
 import sys
 
 from mig.shared.defaults import default_http_port, default_https_port, \
-    auth_openid_mig_db, auth_openid_ext_db, STRONG_TLS_CIPHERS, \
+    auth_openid_mig_db, auth_openid_ext_db, MIG_BASE, STRONG_TLS_CIPHERS, \
     STRONG_TLS_CURVES, STRONG_SSH_KEXALGOS, STRONG_SSH_LEGACY_KEXALGOS, \
     STRONG_SSH_CIPHERS, STRONG_SSH_LEGACY_CIPHERS, STRONG_SSH_MACS, \
     STRONG_SSH_LEGACY_MACS, CRACK_USERNAME_REGEX, CRACK_WEB_REGEX, \
-    MIG_BASE, \
     keyword_any, keyword_auto
 from mig.shared.compat import ensure_native_string
 from mig.shared.fileio import read_file, read_file_lines, write_file, \
@@ -549,16 +548,13 @@ def generate_confs(
     # expand mig, certs and state paths relative to base if left to "AUTO"
 
     if mig_code == keyword_auto:
-        expanded['mig_code'] = os.path.join(MIG_BASE, 'mig')
-        mig_code = expanded['mig_code']
+        mig_code = expanded['mig_code'] = os.path.join(MIG_BASE, 'mig')
 
     if mig_certs == keyword_auto:
-        expanded['mig_certs'] = os.path.join(MIG_BASE, 'certs')
-        mig_certs = expanded['mig_certs']
+        mig_certs = expanded['mig_certs'] = os.path.join(MIG_BASE, 'certs')
 
     if mig_state == keyword_auto:
-        expanded['mig_state'] = os.path.join(MIG_BASE, 'state')
-        mig_state = expanded['mig_state']
+        mig_state = expanded['mig_state'] = os.path.join(MIG_BASE, 'state')
 
     # expand any user information marked as "auto" based on the environment
 

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -50,11 +50,11 @@ import subprocess
 import sys
 
 from mig.shared.defaults import default_http_port, default_https_port, \
-    MIG_BASE, mig_user, mig_group, default_source, default_destination, \
     auth_openid_mig_db, auth_openid_ext_db, STRONG_TLS_CIPHERS, \
     STRONG_TLS_CURVES, STRONG_SSH_KEXALGOS, STRONG_SSH_LEGACY_KEXALGOS, \
     STRONG_SSH_CIPHERS, STRONG_SSH_LEGACY_CIPHERS, STRONG_SSH_MACS, \
     STRONG_SSH_LEGACY_MACS, CRACK_USERNAME_REGEX, CRACK_WEB_REGEX, \
+    MIG_BASE, \
     keyword_any, keyword_auto
 from mig.shared.compat import ensure_native_string
 from mig.shared.fileio import read_file, read_file_lines, write_file, \
@@ -257,6 +257,7 @@ def template_remove(template_file, remove_pattern):
 
 
 _GENERATE_CONFS_NOFORWARD_KEYS = [
+    'generateconfs_output_path',
     'generateconfs_command',
     'source',
     'destination',
@@ -264,7 +265,6 @@ _GENERATE_CONFS_NOFORWARD_KEYS = [
     'group',
     'user',
     'timezone',
-    '_getcwd',
     '_getpwnam',
     '_prepare',
     '_writefiles',
@@ -273,12 +273,13 @@ _GENERATE_CONFS_NOFORWARD_KEYS = [
 
 
 def generate_confs(
+    generateconfs_output_path,
     # NOTE: make sure command line args with white-space are properly wrapped
     generateconfs_command=subprocess.list2cmdline(sys.argv),
-    source=default_source,
-    destination=default_destination,
-    user=mig_user,
-    group=mig_group,
+    source=keyword_auto,
+    destination=keyword_auto,
+    user=keyword_auto,
+    group=keyword_auto,
     timezone=keyword_auto,
     destination_suffix="",
     base_fqdn='',
@@ -315,9 +316,9 @@ def generate_confs(
     apache_log='/var/log/apache2',
     apache_worker_procs=256,
     openssh_version='7.4',
-    mig_code='/home/mig/mig',
-    mig_state='/home/mig/state',
-    mig_certs='/home/mig/certs',
+    mig_code=keyword_auto,
+    mig_state=keyword_auto,
+    mig_certs=keyword_auto,
     auto_add_cert_user=False,
     auto_add_oid_user=False,
     auto_add_oidc_user=False,
@@ -498,13 +499,15 @@ def generate_confs(
     ca_fqdn='',
     ca_user='mig-ca',
     ca_smtp='localhost',
-    _getcwd=os.getcwd,
     _getpwnam=pwd.getpwnam,
     _prepare=None,
     _writefiles=None,
     _instructions=None,
 ):
     """Generate Apache and MiG server confs with specified variables"""
+
+    assert os.path.isabs(
+        generateconfs_output_path), "output directory must be an absolute path"
 
     # TODO: override in signature as a non-functional follow-up change
     if _prepare is None:
@@ -521,29 +524,49 @@ def generate_confs(
                 _GENERATE_CONFS_NOFORWARD_KEYS}
 
     # expand any directory path specific as "auto" relative to CWD
-    thecwd = _getcwd()
 
     if source == keyword_auto:
         # use the templates from this copy of the code tree
         template_dir = os.path.join(MIG_BASE, "mig/install")
     else:
         # construct a path using the supplied value made absolute
-        template_dir = abspath(source, start=thecwd)
+        template_dir = abspath(source, start=generateconfs_output_path)
 
     if destination == keyword_auto:
         # write output into a confs folder within the CWD
-        destination = os.path.join(thecwd, 'confs')
+        destination = os.path.join(generateconfs_output_path, 'confs')
+    elif os.path.isabs(destination):
+        # take the caller at face-value and do not change the path
+        pass
     else:
         # construct a path from the supplied value made absolute
-        destination = abspath(destination, start=thecwd)
+        destination = abspath(destination, start=generateconfs_output_path)
 
     # finalize destination paths up-front
     destination_link = destination
     destination_dir = "%s%s" % (destination, destination_suffix)
 
+    if mig_code == keyword_auto:
+        expanded['mig_code'] = os.path.join(MIG_BASE, 'mig')
+        mig_code = expanded['mig_code']
+
+    # expand any directory path specified "auto" relative to output location
+
+    if mig_certs == keyword_auto:
+        expanded['mig_certs'] = os.path.join(
+            generateconfs_output_path, 'certs')
+        mig_certs = expanded['mig_certs']
+
+    if mig_state == keyword_auto:
+        expanded['mig_state'] = os.path.join(
+            generateconfs_output_path, 'state')
+        mig_state = expanded['mig_state']
+
     # expand any user information marked as "auto" based on the environment
+
     if user == keyword_auto:
         user = pwd.getpwuid(os.getuid())[0]
+
     if group == keyword_auto:
         group = grp.getgrgid(os.getgid())[0]
 

--- a/mig/unittest/testcore.py
+++ b/mig/unittest/testcore.py
@@ -42,21 +42,21 @@ from mig.shared.base import client_id_dir, client_dir_id, get_short_id, \
     invisible_path, allow_script, brief_list
 
 
+_LOCAL_MIG_BASE = '/usr/src/app' if PY2 else MIG_BASE # account for execution in container
 _PYTHON_MAJOR = '2' if PY2 else '3'
-_LOCAL_MIG_BASE = '/usr/src/app' if PY2 else MIG_BASE
-_LOCAL_CONF_DIR = os.path.join(MIG_BASE, "envhelp/output/testconfs-py%s" % (_PYTHON_MAJOR,))
-_LOCAL_CONF_FILE = os.path.join(_LOCAL_CONF_DIR, "MiGserver.conf")
-_LOCAL_CONF_SYMLINK = os.path.join(MIG_BASE, "envhelp/output/testconfs")
+_TEST_CONF_DIR = os.path.join(MIG_BASE, "envhelp/output/testconfs-py%s" % (_PYTHON_MAJOR,))
+_TEST_CONF_FILE = os.path.join(_TEST_CONF_DIR, "MiGserver.conf")
+_TEST_CONF_SYMLINK = os.path.join(MIG_BASE, "envhelp/output/testconfs")
 
 
 def _assert_local_config():
     try:
-        link_stat = os.lstat(_LOCAL_CONF_SYMLINK)
+        link_stat = os.lstat(_TEST_CONF_SYMLINK)
         assert stat.S_ISLNK(link_stat.st_mode)
-        configdir_stat = os.stat(_LOCAL_CONF_DIR)
+        configdir_stat = os.stat(_TEST_CONF_DIR)
         assert stat.S_ISDIR(configdir_stat.st_mode)
         config = ConfigParser()
-        config.read([_LOCAL_CONF_FILE])
+        config.read([_TEST_CONF_FILE])
         return config
     except Exception as exc:
         raise AssertionError('local configuration invalid or missing: %s' % (str(exc),))
@@ -78,7 +78,7 @@ def main(_exit=sys.exit):
     config_global_values = _assert_local_config_global_values(config)
 
     from mig.shared.conf import get_configuration_object
-    configuration = get_configuration_object(_LOCAL_CONF_FILE, skip_log=True)
+    configuration = get_configuration_object(_TEST_CONF_FILE, skip_log=True)
     logging.basicConfig(filename=None, level=logging.INFO,
                         format="%(asctime)s %(levelname)s %(message)s")
     configuration.logger = logging

--- a/mig/unittest/testcore.py
+++ b/mig/unittest/testcore.py
@@ -57,9 +57,6 @@ def _assert_local_config():
         assert stat.S_ISDIR(configdir_stat.st_mode)
         config = ConfigParser()
         config.read([_LOCAL_CONF_FILE])
-        #config_mig_base = os.path.dirname(config.get('GLOBAL', 'mig_path'))
-        #host_conf_dir = os.path.join(MIG_BASE, "envhelp/output/testconfs-dir")
-        #assert host_conf_dir == linkpath, 'bad symlink target'
         return config
     except Exception as exc:
         raise AssertionError('local configuration invalid or missing: %s' % (str(exc),))

--- a/mig/unittest/testcore.py
+++ b/mig/unittest/testcore.py
@@ -36,7 +36,7 @@ import time
 import logging
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), "../..")))
-from tests.support import MIG_BASE, PY2
+from tests.support import MIG_BASE, PY2, is_path_within
 
 from mig.shared.base import client_id_dir, client_dir_id, get_short_id, \
     invisible_path, allow_script, brief_list
@@ -67,19 +67,10 @@ def _assert_local_config_global_values(config):
 
     for path in ('mig_path', 'certs_path', 'state_path'):
         path_value = config_global_values.get(path)
-        if not _is_path_within(path_value, start=_LOCAL_MIG_BASE):
-            raise ValueError('local config contains bad path: %s=%s' % (path, path_value))
+        if not is_path_within(path_value, start=_LOCAL_MIG_BASE):
+            raise AssertionError('local config contains bad path: %s=%s' % (path, path_value))
 
     return config_global_values
-
-
-def _is_path_within(path, start=None, _msg=None):
-    try:
-        assert os.path.isabs(path), _msg
-        relative = os.path.relpath(path, start=start)
-    except:
-        return False
-    return not relative.startswith('..')
 
 
 def main(_exit=sys.exit):

--- a/mig/unittest/testcore.py
+++ b/mig/unittest/testcore.py
@@ -28,17 +28,69 @@
 """Unit tests for core helper functions"""
 from __future__ import print_function
 
+from configparser import ConfigParser
+import os
+import stat
 import sys
 import time
 import logging
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), "../..")))
+from tests.support import MIG_BASE, PY2
 
 from mig.shared.base import client_id_dir, client_dir_id, get_short_id, \
     invisible_path, allow_script, brief_list
 
 
-if __name__ == "__main__":
+_PYTHON_MAJOR = '2' if PY2 else '3'
+_LOCAL_MIG_BASE = '/usr/src/app' if PY2 else MIG_BASE
+_LOCAL_CONF_DIR = os.path.join(MIG_BASE, "envhelp/output/testconfs-py%s" % (_PYTHON_MAJOR,))
+_LOCAL_CONF_FILE = os.path.join(_LOCAL_CONF_DIR, "MiGserver.conf")
+_LOCAL_CONF_SYMLINK = os.path.join(MIG_BASE, "envhelp/output/testconfs")
+
+
+def _assert_local_config():
+    try:
+        link_stat = os.lstat(_LOCAL_CONF_SYMLINK)
+        assert stat.S_ISLNK(link_stat.st_mode)
+        configdir_stat = os.stat(_LOCAL_CONF_DIR)
+        assert stat.S_ISDIR(configdir_stat.st_mode)
+        config = ConfigParser()
+        config.read([_LOCAL_CONF_FILE])
+        #config_mig_base = os.path.dirname(config.get('GLOBAL', 'mig_path'))
+        #host_conf_dir = os.path.join(MIG_BASE, "envhelp/output/testconfs-dir")
+        #assert host_conf_dir == linkpath, 'bad symlink target'
+        return config
+    except Exception as exc:
+        raise AssertionError('local configuration invalid or missing: %s' % (str(exc),))
+
+
+def _assert_local_config_global_values(config):
+    config_global_values = dict(config.items('GLOBAL'))
+
+    for path in ('mig_path', 'certs_path', 'state_path'):
+        path_value = config_global_values.get(path)
+        if not _is_path_within(path_value, start=_LOCAL_MIG_BASE):
+            raise ValueError('local config contains bad path: %s=%s' % (path, path_value))
+
+    return config_global_values
+
+
+def _is_path_within(path, start=None, _msg=None):
+    try:
+        assert os.path.isabs(path), _msg
+        relative = os.path.relpath(path, start=start)
+    except:
+        return False
+    return not relative.startswith('..')
+
+
+def main(_exit=sys.exit):
+    config = _assert_local_config()
+    config_global_values = _assert_local_config_global_values(config)
+
     from mig.shared.conf import get_configuration_object
-    configuration = get_configuration_object()
+    configuration = get_configuration_object(_LOCAL_CONF_FILE, skip_log=True)
     logging.basicConfig(filename=None, level=logging.INFO,
                         format="%(asctime)s %(levelname)s %(message)s")
     configuration.logger = logging
@@ -66,15 +118,16 @@ if __name__ == "__main__":
     if client_id != test_id:
         print("ERROR: Expected match on IDs but found: %s vs %s" %
               (client_id, test_id))
-        sys.exit(1)
+        _exit(1)
     if client_dir != test_dir:
         print("ERROR: Expected match on dirs but found: %s vs %s" %
               (client_dir, test_dir))
-        sys.exit(1)
+        _exit(1)
     if client_short != test_short:
         print("ERROR: Expected match on %s but found: %s vs %s" %
               (short_alias, client_short, test_short))
-        sys.exit(1)
+        _exit(1)
+
 
     orig_id = '/X=ab/Y=cdef ghi/Z=klmn'
     client_dir = client_id_dir(orig_id)
@@ -106,12 +159,12 @@ if __name__ == "__main__":
     for path in legal:
         if invisible_path(path):
             print("ERROR: Expected visible on %s but not the case" % path)
-            sys.exit(1)
+            _exit(1)
     # print("check that these are invisible:")
     for path in illegal:
         if not invisible_path(path):
             print("ERROR: Expected invisible on %s but not the case" % path)
-            sys.exit(1)
+            _exit(1)
 
     print("Check script restrictions:")
     access_any = ['reqoid.py', 'docs.py', 'ls.py']
@@ -121,33 +174,36 @@ if __name__ == "__main__":
         if not allow:
             print("ERROR: Expected anon access to %s but not the case" %
                   script_name)
-            sys.exit(1)
+            _exit(1)
         (allow, msg) = allow_script(configuration, script_name, client_id)
         if not allow:
             print("ERROR: Expected auth access to %s but not the case" %
                   script_name)
-            sys.exit(1)
+            _exit(1)
     for script_name in access_auth:
         (allow, msg) = allow_script(configuration, script_name, '')
         if configuration.site_enable_gdp and allow:
             print("ERROR: Expected anon restrict to %s but not the case" %
                   script_name)
-            sys.exit(1)
+            _exit(1)
         (allow, msg) = allow_script(configuration, script_name, client_id)
         if not allow:
             print("ERROR: Expected auth access to %s but not the case" %
                   script_name)
-            sys.exit(1)
+            _exit(1)
 
     print("Check brief format list limit")
     for (size, outlen) in [(5, 15), (30, 58), (200, 63)]:
-        shortened = "%s" % brief_list(range(size))
+        shortened = "%s" % brief_list(list(range(size)))
         if len(shortened) != outlen:
             print("ERROR: Expected brief range %d list of length %d but not the case: %s" %
                   (size, outlen, len(shortened)))
-            sys.exit(1)
+            _exit(1)
 
     print("Completed shared base functions tests")
 
     print("Done running unit test on shared core functions")
-    sys.exit(0)
+    _exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/tests/support.py
+++ b/tests/support.py
@@ -174,6 +174,7 @@ class MigTestCase(TestCase):
     def setUp(self):
         if not self._skip_logging:
             self._reset_logging(stream=self.logger)
+        self.before_each()
 
     def tearDown(self):
         if not self._skip_logging:
@@ -190,6 +191,10 @@ class MigTestCase(TestCase):
                 os.remove(path)
             else:
                 continue
+
+    # hooks
+    def before_each(self):
+        pass
 
     def _reset_logging(self, stream):
         root_logger = logging.getLogger()
@@ -242,10 +247,13 @@ included:
         return relative_path
 
 
-def cleanpath(relative_path, test_case):
+def cleanpath(relative_path, test_case, start=None, skip_clean=False):
     assert isinstance(test_case, MigTestCase)
-    tmp_path = os.path.join(TEST_OUTPUT_DIR, relative_path)
-    test_case._cleanup_paths.add(tmp_path)
+    if start is None:
+        start = TEST_OUTPUT_DIR
+    tmp_path = os.path.join(start, relative_path)
+    if not skip_clean:
+        test_case._cleanup_paths.add(tmp_path)
     return tmp_path
 
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -239,12 +239,25 @@ included:
         else:
             return "file"
 
+    def assertPathWithin(self, path, start=None):
+        if not is_path_within(path, start=start):
+            raise AssertionError("path %s is not within directory %s" % (path, start))
+
     @staticmethod
     def pretty_display_path(absolute_path):
         assert os.path.isabs(absolute_path)
         relative_path = os.path.relpath(absolute_path, start=MIG_BASE)
         assert not relative_path.startswith('..')
         return relative_path
+
+
+def is_path_within(path, start=None, _msg=None):
+    try:
+        assert os.path.isabs(path), _msg
+        relative = os.path.relpath(path, start=start)
+    except:
+        return False
+    return not relative.startswith('..')
 
 
 def cleanpath(relative_path, test_case, start=None, skip_clean=False):

--- a/tests/support.py
+++ b/tests/support.py
@@ -263,7 +263,6 @@ def is_path_within(path, start=None, _msg=None):
 
 def cleanpath(relative_path, test_case):
     assert isinstance(test_case, MigTestCase)
-    assert not os.path.isabs(relative_path)
     tmp_path = os.path.join(TEST_OUTPUT_DIR, relative_path)
     test_case._cleanup_paths.add(tmp_path)
     return tmp_path

--- a/tests/support.py
+++ b/tests/support.py
@@ -241,7 +241,8 @@ included:
 
     def assertPathWithin(self, path, start=None):
         if not is_path_within(path, start=start):
-            raise AssertionError("path %s is not within directory %s" % (path, start))
+            raise AssertionError(
+                "path %s is not within directory %s" % (path, start))
 
     @staticmethod
     def pretty_display_path(absolute_path):

--- a/tests/support.py
+++ b/tests/support.py
@@ -261,13 +261,11 @@ def is_path_within(path, start=None, _msg=None):
     return not relative.startswith('..')
 
 
-def cleanpath(relative_path, test_case, start=None, skip_clean=False):
+def cleanpath(relative_path, test_case):
     assert isinstance(test_case, MigTestCase)
-    if start is None:
-        start = TEST_OUTPUT_DIR
-    tmp_path = os.path.join(start, relative_path)
-    if not skip_clean:
-        test_case._cleanup_paths.add(tmp_path)
+    assert not os.path.isabs(relative_path)
+    tmp_path = os.path.join(TEST_OUTPUT_DIR, relative_path)
+    test_case._cleanup_paths.add(tmp_path)
     return tmp_path
 
 

--- a/tests/test_mig_shared_install.py
+++ b/tests/test_mig_shared_install.py
@@ -131,8 +131,7 @@ class MigSharedInstall__generate_confs(MigTestCase):
         # arrange pre-existing symlink pointing nowhere
         os.symlink(nowhere_path, symlink_path)
 
-        generate_confs(self.output_path, destination=symlink_path,
-                       destination_suffix='-foobar')
+        generate_confs(self.output_path, destination_suffix='-foobar')
 
         generated_dir = os.path.realpath(symlink_path)
         self.assertEqual(generated_dir, expected_generated_dir)
@@ -248,6 +247,22 @@ class MigSharedInstall__generate_confs(MigTestCase):
                          '/current/working/directory/generate-confs')
         self.assertEqual(options['destination_dir'],
                          '/current/working/directory/generate-confs_suffix')
+
+    def test_options_for_destination_absolute(self):
+        options = generate_confs(
+            '/current/working/directory',
+            destination='/some/other/place/confs',
+            destination_suffix='_suffix',
+            _getpwnam=create_dummy_gpwnam(4321, 1234),
+            _prepare=noop,
+            _writefiles=noop,
+            _instructions=noop,
+        )
+
+        self.assertEqual(options['destination_link'],
+                         '/some/other/place/confs')
+        self.assertEqual(options['destination_dir'],
+                         '/some/other/place/confs_suffix')
 
 
 if __name__ == '__main__':

--- a/tests/test_mig_shared_install.py
+++ b/tests/test_mig_shared_install.py
@@ -114,7 +114,8 @@ class MigSharedInstall__generate_confs(MigTestCase):
 
     def test_creates_output_directory_and_adds_active_symlink(self):
         symlink_path = cleanpath('sharedinstall/confs', self, skip_clean=True)
-        folder_path = cleanpath('sharedinstall/confs-foobar', self, skip_clean=True)
+        folder_path = cleanpath(
+            'sharedinstall/confs-foobar', self, skip_clean=True)
 
         generate_confs(self.output_path, destination_suffix='-foobar')
 
@@ -130,13 +131,15 @@ class MigSharedInstall__generate_confs(MigTestCase):
         # arrange pre-existing symlink pointing nowhere
         os.symlink(nowhere_path, symlink_path)
 
-        generate_confs(self.output_path, destination=symlink_path, destination_suffix='-foobar')
+        generate_confs(self.output_path, destination=symlink_path,
+                       destination_suffix='-foobar')
 
         self.assertEqual(os.readlink(symlink_path), folder_path)
 
     def test_creates_output_directory_containing_a_standard_local_configuration(self):
         fixture_dir = fixturepath("confs-stdlocal")
-        expected_generated_dir = cleanpath('sharedinstall/confs-stdlocal', self, skip_clean=True)
+        expected_generated_dir = cleanpath(
+            'sharedinstall/confs-stdlocal', self, skip_clean=True)
         symlink_path = temppath('sharedinstall/confs', self, skip_clean=True)
 
         generate_confs(

--- a/tests/test_mig_shared_install.py
+++ b/tests/test_mig_shared_install.py
@@ -35,7 +35,8 @@ import sys
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
 
-from support import MIG_BASE, MigTestCase, testmain, temppath, cleanpath, fixturepath, is_path_within
+from support import MIG_BASE, TEST_OUTPUT_DIR, MigTestCase, \
+    testmain, temppath, cleanpath, fixturepath, is_path_within
 
 from mig.shared.defaults import keyword_auto
 from mig.shared.install import determine_timezone, generate_confs
@@ -110,24 +111,23 @@ class MigSharedInstall__generate_confs(MigTestCase):
     """Unit test helper for the migrid code pointed to in class name"""
 
     def before_each(self):
-        self.output_path = temppath('sharedinstall', self)
+        self.output_path = TEST_OUTPUT_DIR
 
     def test_creates_output_directory_and_adds_active_symlink(self):
-        symlink_path = cleanpath('sharedinstall/confs', self, skip_clean=True)
-        folder_path = cleanpath(
-            'sharedinstall/confs-foobar', self, skip_clean=True)
+        symlink_path = cleanpath('confs', self)
+        folder_path = cleanpath('confs-foobar', self)
 
         generate_confs(self.output_path, destination_suffix='-foobar')
 
-        path_kind = self.assertPathExists('sharedinstall/confs-foobar')
+        path_kind = self.assertPathExists('confs-foobar')
         self.assertEqual(path_kind, "dir")
-        path_kind = self.assertPathExists('sharedinstall/confs')
+        path_kind = self.assertPathExists('confs')
         self.assertEqual(path_kind, "symlink")
 
     def test_creates_output_directory_and_repairs_active_symlink(self):
-        symlink_path = temppath('xxxconfs', self)
-        folder_path = cleanpath('xxxconfs-foobar', self)
-        nowhere_path = temppath('xxxconfs-nowhere', self, skip_clean=True)
+        symlink_path = temppath('confs', self)
+        folder_path = cleanpath('confs-foobar', self)
+        nowhere_path = temppath('confs-nowhere', self)
         # arrange pre-existing symlink pointing nowhere
         os.symlink(nowhere_path, symlink_path)
 
@@ -138,9 +138,8 @@ class MigSharedInstall__generate_confs(MigTestCase):
 
     def test_creates_output_directory_containing_a_standard_local_configuration(self):
         fixture_dir = fixturepath("confs-stdlocal")
-        expected_generated_dir = cleanpath(
-            'sharedinstall/confs-stdlocal', self, skip_clean=True)
-        symlink_path = temppath('sharedinstall/confs', self, skip_clean=True)
+        expected_generated_dir = cleanpath('confs-stdlocal', self)
+        symlink_path = temppath('confs', self)
 
         generate_confs(
             self.output_path,

--- a/tests/test_mig_shared_install.py
+++ b/tests/test_mig_shared_install.py
@@ -114,8 +114,8 @@ class MigSharedInstall__generate_confs(MigTestCase):
         self.output_path = TEST_OUTPUT_DIR
 
     def test_creates_output_directory_and_adds_active_symlink(self):
-        symlink_path = cleanpath('confs', self)
-        folder_path = cleanpath('confs-foobar', self)
+        symlink_path = temppath('confs', self)
+        cleanpath('confs-foobar', self)
 
         generate_confs(self.output_path, destination_suffix='-foobar')
 
@@ -125,8 +125,8 @@ class MigSharedInstall__generate_confs(MigTestCase):
         self.assertEqual(path_kind, "symlink")
 
     def test_creates_output_directory_and_repairs_active_symlink(self):
+        expected_generated_dir = cleanpath('confs-foobar', self)
         symlink_path = temppath('confs', self)
-        folder_path = cleanpath('confs-foobar', self)
         nowhere_path = temppath('confs-nowhere', self)
         # arrange pre-existing symlink pointing nowhere
         os.symlink(nowhere_path, symlink_path)
@@ -134,7 +134,8 @@ class MigSharedInstall__generate_confs(MigTestCase):
         generate_confs(self.output_path, destination=symlink_path,
                        destination_suffix='-foobar')
 
-        self.assertEqual(os.readlink(symlink_path), folder_path)
+        generated_dir = os.path.realpath(symlink_path)
+        self.assertEqual(generated_dir, expected_generated_dir)
 
     def test_creates_output_directory_containing_a_standard_local_configuration(self):
         fixture_dir = fixturepath("confs-stdlocal")

--- a/tests/test_mig_unittest_testcore.py
+++ b/tests/test_mig_unittest_testcore.py
@@ -31,7 +31,7 @@ import importlib
 import os
 import sys
 
-sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), "..")))
 
 from support import MigTestCase, testmain
 

--- a/tests/test_mig_unittest_testcore.py
+++ b/tests/test_mig_unittest_testcore.py
@@ -2,7 +2,7 @@
 #
 # --- BEGIN_HEADER ---
 #
-# addheader - add license header to all code modules.
+# test_mig_unittest_testcore - unit test of the corresponding mig unittest module
 # Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.

--- a/tests/test_mig_unittest_testcore.py
+++ b/tests/test_mig_unittest_testcore.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# addheader - add license header to all code modules.
+# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# --- END_HEADER ---
+#
+
+"""Temporary wrapper allowing the inclusion of testcore into the automated suite."""
+
+import importlib
+import os
+import sys
+
+sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
+
+from support import MigTestCase, testmain
+
+from mig.unittest.testcore import main as testcore_main
+
+
+class MigUnittestTestcore(MigTestCase):
+
+    def test_existing_main(self):
+        def raise_on_error_exit(exit_code, identifying_message=None):
+            if exit_code != 0:
+                if identifying_message is None:
+                    identifying_message = 'unknown'
+                raise AssertionError(
+                    'failure in unittest/testcore: %s' % (identifying_message,))
+
+        print("") # account for wrapped tests printing to console
+
+        testcore_main(_exit=raise_on_error_exit)
+
+
+if __name__ == '__main__':
+    testmain()


### PR DESCRIPTION
Arrange environment specific test configurations such that codepaths
that depend upon it (i.e call the get_configuration_object() function)
can be used under test. Do this by providing an explicit config making
facility as part of the enviromnent helpers which operates based on an
environment name e.g. "local" and "test".

For cross-version support the test configuration must be adapted for
differences in paths (specifically Python 2 where execution occurs
within a container and thus container-relative paths are necessary).
Support a --python2 command line argument in makeconfig which causes
the paths adjusted as necessary.

Add a wrapper to utilise the pre-existing testcore unit tests as part
of the automatde test suite. This is done in order to exercise some
codepaths that depend on a valid configuration object. Note though
that this approach can likely be used as an examplar of the wrapping
necessary to expose existing tests.