### PR TITLE
Make timezone parsing more portable and robust

### DIFF
--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -944,20 +944,40 @@ cert, oid and sid based https!
     user_dict['__DUPLICATI_PROTOCOLS__'] = ' '.join(prio_duplicati_protocols)
 
     if timezone == keyword_auto:
-        # attempt to detect the timezone
+        # Attempt to detect the timezone in various known portable ways
         sys_timezone = None
-        try:
-            timezone_cmd = ["/usr/bin/timedatectl", "status"]
-            timezone_proc = subprocess_popen(
-                timezone_cmd, stdout=subprocess_pipe)
-            for line in timezone_proc.stdout.readlines():
-                line = ensure_native_string(line.strip())
-                if not line.startswith("Time zone: "):
-                    continue
-                sys_timezone = line.replace("Time zone: ", "").split(" ", 1)[0]
-        except OSError as exc:
-            # warn about any issues executing the command but continue
-            pass
+
+        env_timezone = os.environ.get('TZ', None)
+        timezone_link = '/etc/localtime'
+        timezone_mark = '/zoneinfo/'
+        timezone_cmd = ["/usr/bin/timedatectl", "status"]
+        if env_timezone:
+            # Use TZ env value directly if set
+            sys_timezone = env_timezone
+        elif os.path.exists(timezone_link):
+            # Parse /etc/localtime link to e.g. /usr/share/zoneinfo/Europe/Rome
+            # into Europe/Rome .
+            active_timezone = os.path.realpath(timezone_link).split(timezone_mark)
+            if active_timezone[1:]:
+                sys_timezone = active_timezone[-1]
+        elif os.path.exists(timezone_cmd[0]):
+            # Parse Time zone: LOCATION (ALIAS, OFFSET) output of timedatectl
+            # into just LOCATION.
+            try:
+                timezone_proc = subprocess_popen(
+                    timezone_cmd, stdout=subprocess_pipe)
+                for line in timezone_proc.stdout.readlines():
+                    line = ensure_native_string(line.strip())
+                    if not line.startswith("Time zone: "):
+                        continue
+                    sys_timezone = line.replace("Time zone: ", "").split(" ", 1)[0]
+            except OSError as exc:
+                # warn about any issues executing the command but continue
+                print("WARNING: failed to extract time zone with %s : %s" % \
+                      (' '.join(timezone_cmd), exc))
+        else:
+            print("WARNING: no more known ways to extract time zone")
+
         if sys_timezone is None:
             print("WARNING: failed to extract system time zone; defaulting to UTC")
             sys_timezone = 'UTC'

--- a/tests/test_mig_shared_install.py
+++ b/tests/test_mig_shared_install.py
@@ -37,7 +37,7 @@ sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
 
 from support import MigTestCase, testmain, temppath, cleanpath, fixturepath
 
-from mig.shared.install import generate_confs
+from mig.shared.install import determine_timezone, generate_confs
 
 class DummyPwInfo:
     """Wrapper to assist in create_dummy_gpwnam"""
@@ -52,6 +52,46 @@ def create_dummy_gpwnam(pw_uid, pw_gid):
 
     dummy = DummyPwInfo(pw_uid, pw_gid)
     return lambda _: dummy
+
+
+def noop(*args, **kwargs):
+    pass
+
+
+class MigSharedInstall__determine_timezone(MigTestCase):
+    """Coverage of timezone determination."""
+
+    def test_determines_tz_via_environ(self):
+        example_environ = {
+            'TZ': 'Example/Enviromnent'
+        }
+        timezone = determine_timezone(_environ=example_environ)
+
+        self.assertEqual(timezone, 'Example/Enviromnent')
+
+    def test_determines_tz_via_localtime(self):
+        def exists_localtime(value):
+            saw_call = value == '/etc/localtime'
+            exists_localtime.was_called = saw_call
+            return saw_call
+        exists_localtime.was_called = False
+
+        timezone = determine_timezone(_environ={}, _path_exists=exists_localtime)
+
+        self.assertTrue(exists_localtime.was_called)
+        self.assertIsNotNone(timezone)
+
+    def test_determines_tz_via_timedatectl(self):
+        def exists_timedatectl(value):
+            saw_call = value == '/usr/bin/timedatectl'
+            exists_timedatectl.was_called = saw_call
+            return saw_call
+        exists_timedatectl.was_called = False
+
+        timezone = determine_timezone(_environ={}, _path_exists=exists_timedatectl, _print=noop)
+
+        self.assertTrue(exists_timedatectl.was_called)
+        self.assertIsNotNone(timezone)
 
 
 class MigSharedInstall__generate_confs(MigTestCase):

--- a/tests/test_mig_shared_install.py
+++ b/tests/test_mig_shared_install.py
@@ -93,6 +93,11 @@ class MigSharedInstall__determine_timezone(MigTestCase):
         self.assertTrue(exists_timedatectl.was_called)
         self.assertIsNotNone(timezone)
 
+    def test_determines_tz_utc_fallback(self):
+        timezone = determine_timezone(_environ={}, _path_exists=lambda _: False, _print=noop)
+
+        self.assertEqual(timezone, 'UTC')
+
 
 class MigSharedInstall__generate_confs(MigTestCase):
     """Unit test helper for the migrid code pointed to in class name"""

--- a/tests/test_mig_shared_install.py
+++ b/tests/test_mig_shared_install.py
@@ -39,6 +39,7 @@ from support import MigTestCase, testmain, temppath, cleanpath, fixturepath
 
 from mig.shared.install import determine_timezone, generate_confs
 
+
 class DummyPwInfo:
     """Wrapper to assist in create_dummy_gpwnam"""
 
@@ -61,6 +62,12 @@ def noop(*args, **kwargs):
 class MigSharedInstall__determine_timezone(MigTestCase):
     """Coverage of timezone determination."""
 
+    def test_determines_tz_utc_fallback(self):
+        timezone = determine_timezone(
+            _environ={}, _path_exists=lambda _: False, _print=noop)
+
+        self.assertEqual(timezone, 'UTC')
+
     def test_determines_tz_via_environ(self):
         example_environ = {
             'TZ': 'Example/Enviromnent'
@@ -76,7 +83,8 @@ class MigSharedInstall__determine_timezone(MigTestCase):
             return saw_call
         exists_localtime.was_called = False
 
-        timezone = determine_timezone(_environ={}, _path_exists=exists_localtime)
+        timezone = determine_timezone(
+            _environ={}, _path_exists=exists_localtime)
 
         self.assertTrue(exists_localtime.was_called)
         self.assertIsNotNone(timezone)
@@ -88,15 +96,11 @@ class MigSharedInstall__determine_timezone(MigTestCase):
             return saw_call
         exists_timedatectl.was_called = False
 
-        timezone = determine_timezone(_environ={}, _path_exists=exists_timedatectl, _print=noop)
+        timezone = determine_timezone(
+            _environ={}, _path_exists=exists_timedatectl, _print=noop)
 
         self.assertTrue(exists_timedatectl.was_called)
         self.assertIsNotNone(timezone)
-
-    def test_determines_tz_utc_fallback(self):
-        timezone = determine_timezone(_environ={}, _path_exists=lambda _: False, _print=noop)
-
-        self.assertEqual(timezone, 'UTC')
 
 
 class MigSharedInstall__generate_confs(MigTestCase):


### PR DESCRIPTION
Make timezone parsing in generateconfs more portable and robust to make it work even inside docker and similar sparse envs where `timedatectl` is not available.
Tries `TZ` environment, `/etc/localtime` symlink to zone file and existing `timedatectl` command in turn.

Fixes issue with `make PY=2 test` spewing errors because docker doesn't have `timedatectl` included.