### PR TITLE
Fix a regression in auth.log handling from grid_X daemons

### DIFF
--- a/mig/shared/conf.py
+++ b/mig/shared/conf.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # conf - Server configuration handling
-# Copyright (C) 2003-2017  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -26,6 +26,7 @@
 #
 
 """Configuration functions"""
+
 from __future__ import absolute_import
 
 import os
@@ -34,9 +35,11 @@ import sys
 from mig.shared.fileio import unpickle
 
 
-def get_configuration_object(config_file=None, skip_log=False):
+def get_configuration_object(config_file=None, skip_log=False,
+                             disable_auth_log=False):
     """Simple helper to call the general configuration init. Optional skip_log
-    argument is passed on to allow skipping the default log initialization.
+    and disable_auth_log arguments are passed on to allow skipping the default
+    log initialization and disabling auth log for unit tests.
     """
     from mig.shared.configuration import Configuration
     if config_file:
@@ -50,7 +53,8 @@ def get_configuration_object(config_file=None, skip_log=False):
         else:
             _config_file = os.path.join(app_dir, '..', 'server',
                     'MiGserver.conf')
-    configuration = Configuration(_config_file, False, skip_log)
+    configuration = Configuration(_config_file, False, skip_log,
+                                  disable_auth_log)
     return configuration
 
 

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -685,20 +685,21 @@ class Configuration:
 
     # constructor
 
-    def __init__(self, config_file, verbose=False, skip_mig_log=False,
-                 skip_gdp_log=False, skip_auth_log=False):
+    def __init__(self, config_file, verbose=False, skip_log=False,
+                 disable_auth_log=False):
         self.config_file = config_file
-        self.reload_config(verbose, skip_mig_log, skip_gdp_log, skip_auth_log)
+        self.reload_config(verbose, skip_log, disable_auth_log)
 
-    def reload_config(self, verbose, skip_mig_log=False, skip_gdp_log=False,
-                      skip_auth_log=False):
-        """Re-read and parse configuration file. Optional skip_X_log args
-        initializes corresponding logger to use the NullHandler in order to
+    def reload_config(self, verbose, skip_log=False, disable_auth_log=False):
+        """Re-read and parse configuration file. Optional skip_log arg
+        initializes default logger(s) to use the NullHandler in order to
         avoid uninitialized log while not really touching log files or causing
-        stdio output. The skip_mig_log is used to disable logging to mig.log
-        from griddaemons, which already set up their own per-daemon log.
-        The others are likely only needed e.g. in unit testing and such places
-        where log makes little sense.
+        stdio output. It is mainly used to disable logging to mig.log from
+        grid_X daemons, which already set up their own per-daemon log for the
+        purpose.
+        The optional disable_auth_log is a workaround ONLY to be used inside a
+        few unit tests where auth.log is really only in the way. It should
+        NEVER be set in code used for production.
         """
 
         try:
@@ -739,7 +740,7 @@ location.""" % self.config_file)
             self.logfile = 'mig.log'
             self.loglevel = 'info'
 
-        if skip_mig_log:
+        if skip_log:
             self.log_path = None
         else:
             self.log_path = os.path.join(self.log_dir, self.logfile)
@@ -2076,7 +2077,7 @@ location.""" % self.config_file)
         syslog_gdp = None
         if config.has_option('SITE', 'enable_gdp'):
             self.site_enable_gdp = config.getboolean('SITE', 'enable_gdp')
-            if not skip_gdp_log and self.site_enable_gdp:
+            if not skip_log and self.site_enable_gdp:
                 syslog_gdp = SYSLOG_GDP
         else:
             self.site_enable_gdp = False
@@ -2491,7 +2492,7 @@ location.""" % self.config_file)
 
         # Init auth logger
 
-        if skip_auth_log:
+        if disable_auth_log:
             self.user_auth_log = None
 
         if self.auth_logger_obj:

--- a/mig/unittest/testcore.py
+++ b/mig/unittest/testcore.py
@@ -78,7 +78,8 @@ def main(_exit=sys.exit):
     config_global_values = _assert_local_config_global_values(config)
 
     from mig.shared.conf import get_configuration_object
-    configuration = get_configuration_object(_TEST_CONF_FILE, skip_log=True)
+    configuration = get_configuration_object(_TEST_CONF_FILE, skip_log=True,
+                                             disable_auth_log=True)
     logging.basicConfig(filename=None, level=logging.INFO,
                         format="%(asctime)s %(levelname)s %(message)s")
     configuration.logger = logging


### PR DESCRIPTION
Rework the old `skip_log` arg to more specifically handle the individual mig, auth and gdp logs. We used to only rely on `skip_log` for skipping `mig.log` init in daemons already doing their own logging to individual `DAEMON.log` files. It was later extended to also cover gdp log init in configuration. However, it turns out it breaks `auth.log` if we interpret it as a general "do not init logs at all" as is the case since merging PR77.

On a related note we probably want to look into the case of skipping gdp log init, which hinges on the same `skip_log` variable and thus does not init the corresponding log in the daemon init code. AFAICT `gdp.log` is in fact still handled from daemons despite the `skip_log` exclusion. Likely because it is still explicitly handled in griddaemons auth or session code. Maybe something to investigate and simplify in a follow-up.

NOTE: this PR originally also broke the `test_mig_unittest_testcore.MigUnittestTestcore` test because with the new default it then expects `auth.log` to be used even in the test. That was addressed with the changes in the latest commit, however, and unit tests should succeed again.