### PR TITLE
Address variation in the casing of the algo prefix in openssl certificate fingerprint output

### DIFF
--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -1924,8 +1924,9 @@ openssl genrsa -out %(__DAEMON_KEYCERT__)s 2048""" % user_dict)
             openssl_proc = subprocess_popen(
                 openssl_cmd, stdout=subprocess_pipe)
             raw_sha256 = openssl_proc.stdout.read().strip()
-            daemon_keycert_sha256 = raw_sha256.replace("SHA256 Fingerprint=",
-                                                       "")
+            # NOTE: openssl outputs something like 'SHA256 Fingerprint=BLA'
+            #       but algo part case may vary - split and take last part.
+            daemon_keycert_sha256 = raw_sha256.split(" Fingerprint=", 1)[-1]
         except Exception as exc:
             print("ERROR: failed to extract sha256 fingerprint of %s: %s" %
                   (key_path, exc))


### PR DESCRIPTION
Address variation in the casing of the algo prefix in `openssl` certificate fingerprint output.

On old installations the `openssl` output was on a `SHA256 Fingerprint=DE:AD:BE:EF:...` format, but at least in Rocky9 the algo prefix changed to lower case as in `sha256 Fingerprint=DE:AD:BE:EF:...`. 
As we parse that output in `generateconfs.py` and we assumed the former format, we would end up with the prefix included in the `user_davs_key_sha256` and `user_ftps_key_sha256` values.

This fix completely drops the algo part from the parsing to work in both cases.