### PR TITLE
Introduce structured arg parsing and reimpelement generateconfs atop it.

### DIFF
--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -500,6 +500,9 @@ _DEFAULTS = SimpleNamespace(
 )
 
 
+_GENERATE_CONFS_DEFAULTS = _DEFAULTS.__dict__
+
+
 def generate_confs(
     generateconfs_output_path,
     # NOTE: make sure command line args with white-space are properly wrapped
@@ -509,7 +512,7 @@ def generate_confs(
     user=keyword_auto,
     group=keyword_auto,
     timezone=keyword_auto,
-    destination_suffix="",
+    destination_suffix=keyword_auto,
     base_fqdn=_DEFAULTS.base_fqdn,
     public_fqdn=_DEFAULTS.public_fqdn,
     public_alias_fqdn=_DEFAULTS.public_alias_fqdn,
@@ -763,6 +766,9 @@ def generate_confs(
     else:
         # construct a path using the supplied value made absolute
         template_dir = abspath(source, start=generateconfs_output_path)
+
+    if destination_suffix == keyword_auto:
+        destination_suffix = "-%s" % datetime.datetime.now().isoformat()
 
     if destination == keyword_auto:
         # write output into a confs folder within the CWD

--- a/mig/shared/minimist.py
+++ b/mig/shared/minimist.py
@@ -1,0 +1,34 @@
+import argparse
+
+
+_EMPTY_DICT = {}
+_NO_DEFAULT = object()
+
+def _arg_name_to_flag(arg_name):
+    return ''.join(('--', arg_name))
+
+
+def _arg_name_to_default(arg_name, _defaults):
+    try:
+        return _defaults[arg_name]
+    except KeyError:
+        return None
+
+
+def minimist(prog, description, epilog, string=[], boolean=[], integers=[], _defaults=None):
+    parser = argparse.ArgumentParser(prog, allow_abbrev=False)
+
+    if _defaults is None:
+        _defaults = {}
+
+    for arg_name in boolean:
+        parser.add_argument(_arg_name_to_flag(arg_name), action='store_true')
+
+    for arg_name in string:
+        arg_default = _defaults.get(arg_name, None)
+        parser.add_argument(_arg_name_to_flag(arg_name), default=arg_default)
+
+    for arg_name in integers:
+        parser.add_argument(_arg_name_to_flag(arg_name), type=int)
+
+    return parser

--- a/tests/test_mig_install_generateconfs.py
+++ b/tests/test_mig_install_generateconfs.py
@@ -71,7 +71,8 @@ class MigInstallGenerateconfs(MigTestCase):
     def test_consistent_parameters(self):
         mismatched = _GENERATE_CONFS_PARAMETERS - set(_PARAMETERS)
         self.assertEqual(len(mismatched), 0,
-                         "defined parameters do not match generate_confs()")
+                         "defined parameters do not match generate_confs()\n"
+                         "mismatched: %s" % (''.join(mismatched),))
 
 
 class MigInstallGenerateconfs__main(MigTestCase):


### PR DESCRIPTION
Prior work made the defaults used for command line arguments in the
generateconfs utility accessible as a structure. Make use of this to
jettison our custom code and instead use all the user-facing niceties
of the argparse library.

This commit introduces a argument parsing wrapper for local use named
minimist in a nod to the node library of the same name from which we
largely borrow the externally facing API. It was remarkably suitable
for our purposes and a close match to our existing code which operates
in terms of arrays of argument names which must be treated a certain
way i.e. string, boolean, etc.

Depends on: https://github.com/ucphhpc/migrid-sync/pull/83