### PR TITLE
Fix endless user ID mangling loop leading to Internal Server Error in issue 101

### DIFF
--- a/mig/install/apache-MiG-template.conf
+++ b/mig/install/apache-MiG-template.conf
@@ -1026,23 +1026,23 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
     RewriteCond %{REQUEST_URI} ^/cert_redirect/
     RewriteCond %{LA-U:ENV:SSL_CLIENT_S_DN} !^$
     RewriteRule ^/cert_redirect/(.*) /cert_mangle/${escape:$1} [C]
-    RewriteRule ^/cert_mangle/(.*) %{LA-U:ENV:SSL_CLIENT_S_DN}/cert_mangle/$1 [NE,N]
+    RewriteRule ^/cert_mangle/(.*) /cert_mangle/%{LA-U:ENV:SSL_CLIENT_S_DN}/cert_mangle/$1 [NE,N]
 
     # Keep replacing space in DN with underscore
     
-    RewriteRule ^(.*)\ (.*)/cert_mangle/(.*)$ $1_$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)\ (.*)/cert_mangle/(.*)$ /cert_mangle/$1_$2/cert_mangle/$3 [N]
     
     # Keep replacing slash in DN with plus
     
-    RewriteRule ^(.*)/(.*)/cert_mangle/(.*)$ $1+$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)/(.*)/cert_mangle/(.*)$ /cert_mangle/$1+$2/cert_mangle/$3 [N]
 
     # Keep replacing double backslash from utf8 chars in DN with actual char
     # E.g. to replace the 'oslash' letter on the form \\xC3\\xB8 with %C3%B8
 
-    RewriteRule ^(.*)\\x(..)(.*)/cert_mangle/(.*)$ $1${unescape:%$2}$3/cert_mangle/$4 [N]
+    RewriteRule ^/cert_mangle/(.*)\\x(..)(.*)/cert_mangle/(.*)$ /cert_mangle/$1${unescape:%$2}$3/cert_mangle/$4 [N]
 
     # Finally remove certificate marker and unescape previously escaped path
-    RewriteRule ^(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [N]
+    RewriteRule ^/cert_mangle/(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [N]
 
     # Prevent e.g. symlinks escaping user chroots once past cert mangling.
     # Apache starts chkuserroot prg as a shared daemon for all requests from this
@@ -1485,23 +1485,23 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
     RewriteCond %{REQUEST_URI} ^/cert_redirect/
     RewriteCond %{LA-U:ENV:SSL_CLIENT_S_DN} !^$
     RewriteRule ^/cert_redirect/(.*) /cert_mangle/${escape:$1} [C]
-    RewriteRule ^/cert_mangle/(.*) %{LA-U:ENV:SSL_CLIENT_S_DN}/cert_mangle/$1 [NE,N]
+    RewriteRule ^/cert_mangle/(.*) /cert_mangle/%{LA-U:ENV:SSL_CLIENT_S_DN}/cert_mangle/$1 [NE,N]
 
     # Keep replacing space in DN with underscore
     
-    RewriteRule ^(.*)\ (.*)/cert_mangle/(.*)$ $1_$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)\ (.*)/cert_mangle/(.*)$ /cert_mangle/$1_$2/cert_mangle/$3 [N]
     
     # Keep replacing slash in DN with plus
     
-    RewriteRule ^(.*)/(.*)/cert_mangle/(.*)$ $1+$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)/(.*)/cert_mangle/(.*)$ /cert_mangle/$1+$2/cert_mangle/$3 [N]
 
     # Keep replacing double backslash from utf8 chars in DN with actual char
     # E.g. to replace the 'oslash' letter on the form \\xC3\\xB8 with %C3%B8
 
-    RewriteRule ^(.*)\\x(..)(.*)/cert_mangle/(.*)$ $1${unescape:%$2}$3/cert_mangle/$4 [N]
+    RewriteRule ^/cert_mangle/(.*)\\x(..)(.*)/cert_mangle/(.*)$ /cert_mangle/$1${unescape:%$2}$3/cert_mangle/$4 [N]
 
     # Finally remove certificate marker and unescape previously escaped path
-    RewriteRule ^(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [N]
+    RewriteRule ^/cert_mangle/(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [N]
     
     # Prevent e.g. symlinks escaping user chroots once past cert mangling.
     # Apache starts chkuserroot prg as a shared daemon for all requests from this
@@ -2165,15 +2165,15 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
     RewriteCond %{LA-U:REMOTE_USER} !^$
     RewriteRule ^/cert_redirect/(.*) /cert_mangle/${escape:$1} [C]
     RewriteRule ^/cert_mangle/(.*) /strip_provider/%{LA-U:REMOTE_USER}/cert_mangle/$1 [NE,C]
-    RewriteRule ^/strip_provider/__MIG_OID_PROVIDER_ID__/*(.+)/cert_mangle/(.*) $1/cert_mangle/$2 [NE,N]
+    RewriteRule ^/strip_provider/__MIG_OID_PROVIDER_ID__/*(.+)/cert_mangle/(.*) /cert_mangle/$1/cert_mangle/$2 [NE,N]
 
     # Keep replacing space in DN with underscore
     
-    RewriteRule ^(.*)\ (.*)/cert_mangle/(.*)$ $1_$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)\ (.*)/cert_mangle/(.*)$ /cert_mangle/$1_$2/cert_mangle/$3 [N]
     
     # Keep replacing slash in DN with plus
     
-    RewriteRule ^(.*)/(.*)/cert_mangle/(.*)$ $1+$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)/(.*)/cert_mangle/(.*)$ /cert_mangle/$1+$2/cert_mangle/$3 [N]
 
     # Finally remove certificate marker and unescape previously escaped path
     # IMPORTANT: all major browsers have trouble to some extent when accessing
@@ -2187,7 +2187,7 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
     # NOTE: we proxy here to make sure we only target cert mangled paths.
     # It does NOT mean that we skip chroot check below as that will still
     # happen in the new request caused by the proxy'ing.
-    RewriteRule ^(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [P]
+    RewriteRule ^/cert_mangle/(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [P]
 
     # Prevent e.g. symlinks escaping user chroots once past cert mangling.
     # Apache starts chkuserroot prg as a shared daemon for all requests from this
@@ -2767,15 +2767,15 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
     RewriteCond %{LA-U:REMOTE_USER} !^$
     RewriteRule ^/cert_redirect/(.*) /cert_mangle/${escape:$1} [C]
     RewriteRule ^/cert_mangle/(.*) /strip_provider/%{LA-U:REMOTE_USER}/cert_mangle/$1 [NE,C]
-    RewriteRule ^/strip_provider/__EXT_OID_PROVIDER_ID__/*(.+)/cert_mangle/(.*) $1/cert_mangle/$2 [NE,N]
+    RewriteRule ^/strip_provider/__EXT_OID_PROVIDER_ID__/*(.+)/cert_mangle/(.*) /cert_mangle/$1/cert_mangle/$2 [NE,N]
 
     # Keep replacing space in DN with underscore
     
-    RewriteRule ^(.*)\ (.*)/cert_mangle/(.*)$ $1_$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)\ (.*)/cert_mangle/(.*)$ /cert_mangle/$1_$2/cert_mangle/$3 [N]
     
     # Keep replacing slash in DN with plus
     
-    RewriteRule ^(.*)/(.*)/cert_mangle/(.*)$ $1+$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)/(.*)/cert_mangle/(.*)$ /cert_mangle/$1+$2/cert_mangle/$3 [N]
 
     # Finally remove certificate marker and unescape previously escaped path
     # IMPORTANT: all major browsers have trouble to some extent when accessing
@@ -2789,7 +2789,7 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
     # NOTE: we proxy here to make sure we only target cert mangled paths.
     # It does NOT mean that we skip chroot check below as that will still
     # happen in the new request caused by the proxy'ing.
-    RewriteRule ^(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [P]
+    RewriteRule ^/cert_mangle/(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [P]
 
     # Prevent e.g. symlinks escaping user chroots once past cert mangling.
     # Apache starts chkuserroot prg as a shared daemon for all requests from this
@@ -3693,15 +3693,15 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
     RewriteCond %{REQUEST_URI} ^/cert_redirect/
     RewriteCond %{LA-U:REMOTE_USER} !^$
     RewriteRule ^/cert_redirect/(.*) /cert_mangle/${escape:$1} [C]
-    RewriteRule ^/cert_mangle/(.*) %{LA-U:REMOTE_USER}/cert_mangle/$1 [NE,N]
+    RewriteRule ^/cert_mangle/(.*) /cert_mangle/%{LA-U:REMOTE_USER}/cert_mangle/$1 [NE,N]
 
     # Keep replacing space in DN with underscore
     
-    RewriteRule ^(.*)\ (.*)/cert_mangle/(.*)$ $1_$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)\ (.*)/cert_mangle/(.*)$ /cert_mangle/$1_$2/cert_mangle/$3 [N]
     
     # Keep replacing slash in DN with plus
     
-    RewriteRule ^(.*)/(.*)/cert_mangle/(.*)$ $1+$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)/(.*)/cert_mangle/(.*)$ /cert_mangle/$1+$2/cert_mangle/$3 [N]
 
     # Finally remove certificate marker and unescape previously escaped path
     # IMPORTANT: all major browsers have trouble to some extent when accessing
@@ -3716,7 +3716,7 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
     # NOTE: we proxy here to make sure we only target cert mangled paths.
     # It does NOT mean that we skip chroot check below as that will still
     # happen in the new request caused by the proxy'ing.
-    RewriteRule ^(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [P]
+    RewriteRule ^/cert_mangle/(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [P]
 
     # Prevent e.g. symlinks escaping user chroots once past cert mangling.
     # Apache starts chkuserroot prg as a shared daemon for all requests from this

--- a/tests/fixture/confs-stdlocal/MiG.conf
+++ b/tests/fixture/confs-stdlocal/MiG.conf
@@ -1026,23 +1026,23 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
     RewriteCond %{REQUEST_URI} ^/cert_redirect/
     RewriteCond %{LA-U:ENV:SSL_CLIENT_S_DN} !^$
     RewriteRule ^/cert_redirect/(.*) /cert_mangle/${escape:$1} [C]
-    RewriteRule ^/cert_mangle/(.*) %{LA-U:ENV:SSL_CLIENT_S_DN}/cert_mangle/$1 [NE,N]
+    RewriteRule ^/cert_mangle/(.*) /cert_mangle/%{LA-U:ENV:SSL_CLIENT_S_DN}/cert_mangle/$1 [NE,N]
 
     # Keep replacing space in DN with underscore
     
-    RewriteRule ^(.*)\ (.*)/cert_mangle/(.*)$ $1_$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)\ (.*)/cert_mangle/(.*)$ /cert_mangle/$1_$2/cert_mangle/$3 [N]
     
     # Keep replacing slash in DN with plus
     
-    RewriteRule ^(.*)/(.*)/cert_mangle/(.*)$ $1+$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)/(.*)/cert_mangle/(.*)$ /cert_mangle/$1+$2/cert_mangle/$3 [N]
 
     # Keep replacing double backslash from utf8 chars in DN with actual char
     # E.g. to replace the 'oslash' letter on the form \\xC3\\xB8 with %C3%B8
 
-    RewriteRule ^(.*)\\x(..)(.*)/cert_mangle/(.*)$ $1${unescape:%$2}$3/cert_mangle/$4 [N]
+    RewriteRule ^/cert_mangle/(.*)\\x(..)(.*)/cert_mangle/(.*)$ /cert_mangle/$1${unescape:%$2}$3/cert_mangle/$4 [N]
 
     # Finally remove certificate marker and unescape previously escaped path
-    RewriteRule ^(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [N]
+    RewriteRule ^/cert_mangle/(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [N]
 
     # Prevent e.g. symlinks escaping user chroots once past cert mangling.
     # Apache starts chkuserroot prg as a shared daemon for all requests from this
@@ -1485,23 +1485,23 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
     RewriteCond %{REQUEST_URI} ^/cert_redirect/
     RewriteCond %{LA-U:ENV:SSL_CLIENT_S_DN} !^$
     RewriteRule ^/cert_redirect/(.*) /cert_mangle/${escape:$1} [C]
-    RewriteRule ^/cert_mangle/(.*) %{LA-U:ENV:SSL_CLIENT_S_DN}/cert_mangle/$1 [NE,N]
+    RewriteRule ^/cert_mangle/(.*) /cert_mangle/%{LA-U:ENV:SSL_CLIENT_S_DN}/cert_mangle/$1 [NE,N]
 
     # Keep replacing space in DN with underscore
     
-    RewriteRule ^(.*)\ (.*)/cert_mangle/(.*)$ $1_$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)\ (.*)/cert_mangle/(.*)$ /cert_mangle/$1_$2/cert_mangle/$3 [N]
     
     # Keep replacing slash in DN with plus
     
-    RewriteRule ^(.*)/(.*)/cert_mangle/(.*)$ $1+$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)/(.*)/cert_mangle/(.*)$ /cert_mangle/$1+$2/cert_mangle/$3 [N]
 
     # Keep replacing double backslash from utf8 chars in DN with actual char
     # E.g. to replace the 'oslash' letter on the form \\xC3\\xB8 with %C3%B8
 
-    RewriteRule ^(.*)\\x(..)(.*)/cert_mangle/(.*)$ $1${unescape:%$2}$3/cert_mangle/$4 [N]
+    RewriteRule ^/cert_mangle/(.*)\\x(..)(.*)/cert_mangle/(.*)$ /cert_mangle/$1${unescape:%$2}$3/cert_mangle/$4 [N]
 
     # Finally remove certificate marker and unescape previously escaped path
-    RewriteRule ^(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [N]
+    RewriteRule ^/cert_mangle/(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [N]
     
     # Prevent e.g. symlinks escaping user chroots once past cert mangling.
     # Apache starts chkuserroot prg as a shared daemon for all requests from this
@@ -2165,15 +2165,15 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
     RewriteCond %{LA-U:REMOTE_USER} !^$
     RewriteRule ^/cert_redirect/(.*) /cert_mangle/${escape:$1} [C]
     RewriteRule ^/cert_mangle/(.*) /strip_provider/%{LA-U:REMOTE_USER}/cert_mangle/$1 [NE,C]
-    RewriteRule ^/strip_provider//*(.+)/cert_mangle/(.*) $1/cert_mangle/$2 [NE,N]
+    RewriteRule ^/strip_provider//*(.+)/cert_mangle/(.*) /cert_mangle/$1/cert_mangle/$2 [NE,N]
 
     # Keep replacing space in DN with underscore
     
-    RewriteRule ^(.*)\ (.*)/cert_mangle/(.*)$ $1_$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)\ (.*)/cert_mangle/(.*)$ /cert_mangle/$1_$2/cert_mangle/$3 [N]
     
     # Keep replacing slash in DN with plus
     
-    RewriteRule ^(.*)/(.*)/cert_mangle/(.*)$ $1+$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)/(.*)/cert_mangle/(.*)$ /cert_mangle/$1+$2/cert_mangle/$3 [N]
 
     # Finally remove certificate marker and unescape previously escaped path
     # IMPORTANT: all major browsers have trouble to some extent when accessing
@@ -2187,7 +2187,7 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
     # NOTE: we proxy here to make sure we only target cert mangled paths.
     # It does NOT mean that we skip chroot check below as that will still
     # happen in the new request caused by the proxy'ing.
-    RewriteRule ^(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [P]
+    RewriteRule ^/cert_mangle/(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [P]
 
     # Prevent e.g. symlinks escaping user chroots once past cert mangling.
     # Apache starts chkuserroot prg as a shared daemon for all requests from this
@@ -2767,15 +2767,15 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
     RewriteCond %{LA-U:REMOTE_USER} !^$
     RewriteRule ^/cert_redirect/(.*) /cert_mangle/${escape:$1} [C]
     RewriteRule ^/cert_mangle/(.*) /strip_provider/%{LA-U:REMOTE_USER}/cert_mangle/$1 [NE,C]
-    RewriteRule ^/strip_provider//*(.+)/cert_mangle/(.*) $1/cert_mangle/$2 [NE,N]
+    RewriteRule ^/strip_provider//*(.+)/cert_mangle/(.*) /cert_mangle/$1/cert_mangle/$2 [NE,N]
 
     # Keep replacing space in DN with underscore
     
-    RewriteRule ^(.*)\ (.*)/cert_mangle/(.*)$ $1_$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)\ (.*)/cert_mangle/(.*)$ /cert_mangle/$1_$2/cert_mangle/$3 [N]
     
     # Keep replacing slash in DN with plus
     
-    RewriteRule ^(.*)/(.*)/cert_mangle/(.*)$ $1+$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)/(.*)/cert_mangle/(.*)$ /cert_mangle/$1+$2/cert_mangle/$3 [N]
 
     # Finally remove certificate marker and unescape previously escaped path
     # IMPORTANT: all major browsers have trouble to some extent when accessing
@@ -2789,7 +2789,7 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
     # NOTE: we proxy here to make sure we only target cert mangled paths.
     # It does NOT mean that we skip chroot check below as that will still
     # happen in the new request caused by the proxy'ing.
-    RewriteRule ^(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [P]
+    RewriteRule ^/cert_mangle/(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [P]
 
     # Prevent e.g. symlinks escaping user chroots once past cert mangling.
     # Apache starts chkuserroot prg as a shared daemon for all requests from this
@@ -3693,15 +3693,15 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
     RewriteCond %{REQUEST_URI} ^/cert_redirect/
     RewriteCond %{LA-U:REMOTE_USER} !^$
     RewriteRule ^/cert_redirect/(.*) /cert_mangle/${escape:$1} [C]
-    RewriteRule ^/cert_mangle/(.*) %{LA-U:REMOTE_USER}/cert_mangle/$1 [NE,N]
+    RewriteRule ^/cert_mangle/(.*) /cert_mangle/%{LA-U:REMOTE_USER}/cert_mangle/$1 [NE,N]
 
     # Keep replacing space in DN with underscore
     
-    RewriteRule ^(.*)\ (.*)/cert_mangle/(.*)$ $1_$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)\ (.*)/cert_mangle/(.*)$ /cert_mangle/$1_$2/cert_mangle/$3 [N]
     
     # Keep replacing slash in DN with plus
     
-    RewriteRule ^(.*)/(.*)/cert_mangle/(.*)$ $1+$2/cert_mangle/$3 [N]
+    RewriteRule ^/cert_mangle/(.*)/(.*)/cert_mangle/(.*)$ /cert_mangle/$1+$2/cert_mangle/$3 [N]
 
     # Finally remove certificate marker and unescape previously escaped path
     # IMPORTANT: all major browsers have trouble to some extent when accessing
@@ -3716,7 +3716,7 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
     # NOTE: we proxy here to make sure we only target cert mangled paths.
     # It does NOT mean that we skip chroot check below as that will still
     # happen in the new request caused by the proxy'ing.
-    RewriteRule ^(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [P]
+    RewriteRule ^/cert_mangle/(.+)/cert_mangle/(.*)$ /$1/${unescape:$2} [P]
 
     # Prevent e.g. symlinks escaping user chroots once past cert mangling.
     # Apache starts chkuserroot prg as a shared daemon for all requests from this


### PR DESCRIPTION
Added robustness in /cert_redirect/ URL rewrites by completely enclosing the user ID part to be rewritten in `/cert_mangling/` markers and thereby also prevent any automatic leading slash addition from interfering with our `/` to `+` rewrites when mapping from X509 IDs to the filesystem user home. This should address the Internal Server Error as seen on rocky8+ from [issue 101](https://github.com/ucphhpc/migrid-sync/issues/101).