### PR TITLE
Enforce no errors were logged within the fake logger and add after_each.

### DIFF
--- a/tests/test_mig_shared_fileio.py
+++ b/tests/test_mig_shared_fileio.py
@@ -58,17 +58,23 @@ class MigSharedFileio__write_chunk(MigTestCase):
         cleanpath(os.path.dirname(DUMMY_FILE_WRITECHUNK), self)
 
     def test_return_false_on_invalid_data(self):
+        self.logger.forgive_errors()
+
         # NOTE: we make sure to disable any forced stringification here
         did_succeed = fileio.write_chunk(self.tmp_path, 1234, 0, self.logger,
                                          force_string=False)
         self.assertFalse(did_succeed)
 
     def test_return_false_on_invalid_offset(self):
+        self.logger.forgive_errors()
+
         did_succeed = fileio.write_chunk(self.tmp_path, DUMMY_BYTES, -42,
                                          self.logger)
         self.assertFalse(did_succeed)
 
     def test_return_false_on_invalid_dir(self):
+        self.logger.forgive_errors()
+
         os.makedirs(self.tmp_path)
 
         did_succeed = fileio.write_chunk(self.tmp_path, 1234, 0, self.logger)
@@ -138,18 +144,24 @@ class MigSharedFileio__write_file(MigTestCase):
         cleanpath(os.path.dirname(DUMMY_FILE_WRITEFILE), self)
 
     def test_return_false_on_invalid_data(self):
+        self.logger.forgive_errors()
+
         # NOTE: we make sure to disable any forced stringification here
         did_succeed = fileio.write_file(1234, self.tmp_path, self.logger,
                                         force_string=False)
         self.assertFalse(did_succeed)
 
     def test_return_false_on_invalid_dir(self):
+        self.logger.forgive_errors()
+
         os.makedirs(self.tmp_path)
 
         did_succeed = fileio.write_file(DUMMY_BYTES, self.tmp_path, self.logger)
         self.assertFalse(did_succeed)
 
     def test_return_false_on_missing_dir(self):
+        self.logger.forgive_errors()
+
         did_succeed = fileio.write_file(DUMMY_BYTES, self.tmp_path, self.logger,
                                         make_parent=False)
         self.assertFalse(did_succeed)


### PR DESCRIPTION
A good deal of our code reports internal errors via the logging infrastructure. As this code comes under test it is all too possible that an a simple assertion against an output condition (an http status 200 for example) would actually hide the truth that the code being tested did not in fact succeed in what it was doing, thus there is a need to validate that did in fact work.

Address this by adding the necessary glue in the support library to enforce that no error logging calls were made to the fake logger upon completing a test case. Note that much of the infrastructure for doing so was already present and these changes simply add the enforcement i.e. arrange an assertion failure if necessary containing details of the logged errors.