### PR TITLE
Adjust the recently exposed permanent_freeze arg to support space-separated string values

### DIFF
--- a/mig/install/generateconfs.py
+++ b/mig/install/generateconfs.py
@@ -192,6 +192,7 @@ def main(argv, _generate_confs=generate_confs):
         'log_level',
         'twofactor_mandatory_protos',
         'twofactor_auth_apps',
+        'permanent_freeze',
         'freeze_to_tape',
         'status_system_match',
         'duplicati_protocols',
@@ -289,14 +290,13 @@ def main(argv, _generate_confs=generate_confs):
         'enable_sitestatus',
         'daemon_pubkey_from_dns',
         'seafile_ro_access',
-        'permanent_freeze',
         'public_use_https',
         'prefer_python3',
         'io_account_expire',
         'gdp_email_notify',
     ]
     names = str_names + int_names + bool_names
-    settings = {}
+    settings, options, result = {}, {}, {}
     default_val = 'DEFAULT'
     # Force values to expected type
     for key in names:
@@ -345,7 +345,7 @@ def main(argv, _generate_confs=generate_confs):
         else:
             print('Error: command line option %r not supported!' % opt_name)
             usage(names)
-            sys.exit(1)
+            return 1
 
     if args:
         print('Error: non-option arguments are no longer supported!')
@@ -372,7 +372,7 @@ def main(argv, _generate_confs=generate_confs):
         if val == 'DEFAULT':
             del settings[key]
 
-    options = _generate_confs(output_path, **settings)
+    (options, result) = _generate_confs(output_path, **settings)
 
     # TODO: avoid reconstructing this path (also done inside generate_confs)
     instructions_path = os.path.join(options['destination_dir'],

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -591,7 +591,7 @@ def generate_confs(
     user_dict = _prepare(options, **expanded)
     _writefiles(options, user_dict)
     _instructions(options, user_dict)
-    return options
+    return (options, user_dict)
 
 
 def _generate_confs_prepare(
@@ -1046,13 +1046,7 @@ def _generate_confs_prepare(
     user_dict['__SMTP_SERVER__'] = smtp_server
     user_dict['__SMTP_SENDER__'] = smtp_sender
     user_dict['__LOG_LEVEL__'] = log_level
-
-    if isinstance(permanent_freeze, basestring):
-        permanent_freeze = permanent_freeze.split(' ')
-    elif isinstance(permanent_freeze, bool):
-        permanent_freeze = ['yes' if permanent_freeze else 'no']
-    user_dict['__PERMANENT_FREEZE__'] = ' '.join(permanent_freeze)
-
+    user_dict['__PERMANENT_FREEZE__'] = permanent_freeze
     user_dict['__FREEZE_TO_TAPE__'] = freeze_to_tape
     user_dict['__STATUS_SYSTEM_MATCH__'] = status_system_match
     user_dict['__IMNOTIFY_ADDRESS__'] = imnotify_address

--- a/tests/test_mig_install_generateconfs.py
+++ b/tests/test_mig_install_generateconfs.py
@@ -53,9 +53,9 @@ def create_fake_generate_confs(return_dict=None):
     """Fake generate confs helper"""
     def _generate_confs(*args, **kwargs):
         if return_dict:
-            return return_dict
+            return (return_dict, {})
         else:
-            return {}
+            return ({}, {})
     return _generate_confs
 
 
@@ -68,9 +68,8 @@ class MigInstallGenerateconfs__main(MigTestCase):
         with open(os.path.join(expected_generated_dir, "instructions.txt"),
                   "w"):
             pass
-        fake_generate_confs = create_fake_generate_confs(dict(
-            destination_dir=expected_generated_dir
-        ))
+        fake_generate_confs = create_fake_generate_confs(
+            dict(destination_dir=expected_generated_dir))
         test_arguments = ['--permanent_freeze', 'yes']
 
         exit_code = main(test_arguments, _generate_confs=fake_generate_confs)

--- a/tests/test_mig_shared_install.py
+++ b/tests/test_mig_shared_install.py
@@ -197,7 +197,7 @@ class MigSharedInstall__generate_confs(MigTestCase):
             return args[0]
         capture_defaulted.kwargs = None
 
-        options = generate_confs(
+        (options, _) = generate_confs(
             '/some/arbitrary/path',
             _getpwnam=create_dummy_gpwnam(4321, 1234),
             _prepare=capture_defaulted,
@@ -237,23 +237,24 @@ class MigSharedInstall__generate_confs(MigTestCase):
         expected_generated_dir = cleanpath('confs-stdlocal', self)
         symlink_path = temppath('confs', self)
 
-        generate_confs(
-            self.output_path,
-            destination=symlink_path,
-            destination_suffix='-stdlocal',
-            permanent_freeze=('foo', 'bar', 'baz'),
-            _getpwnam=create_dummy_gpwnam(4321, 1234),
-        )
+        for arg_val in ('yes', 'no', 'foo bar baz'):
+            generate_confs(
+                self.output_path,
+                destination=symlink_path,
+                destination_suffix='-stdlocal',
+                permanent_freeze=arg_val,
+                _getpwnam=create_dummy_gpwnam(4321, 1234),
+            )
 
-        relative_file = 'confs-stdlocal/MiGserver.conf'
-        self.assertPathExists('confs-stdlocal/MiGserver.conf')
+            relative_file = 'confs-stdlocal/MiGserver.conf'
+            self.assertPathExists('confs-stdlocal/MiGserver.conf')
 
-        actual_file = outputpath(relative_file)
-        self.assertConfigKey(
-            actual_file, 'SITE', 'permanent_freeze', expected='foo bar baz')
+            actual_file = outputpath(relative_file)
+            self.assertConfigKey(
+                actual_file, 'SITE', 'permanent_freeze', expected=arg_val)
 
     def test_options_for_source_auto(self):
-        options = generate_confs(
+        (options, _) = generate_confs(
             '/some/arbitrary/path',
             source=keyword_auto,
             _getpwnam=create_dummy_gpwnam(4321, 1234),
@@ -266,7 +267,7 @@ class MigSharedInstall__generate_confs(MigTestCase):
         self.assertEqual(options['template_dir'], expected_template_dir)
 
     def test_options_for_source_relative(self):
-        options = generate_confs(
+        (options, _) = generate_confs(
             '/current/working/directory/mig/install',
             source='.',
             _getpwnam=create_dummy_gpwnam(4321, 1234),
@@ -279,7 +280,7 @@ class MigSharedInstall__generate_confs(MigTestCase):
                          '/current/working/directory/mig/install')
 
     def test_options_for_destination_auto(self):
-        options = generate_confs(
+        (options, _) = generate_confs(
             '/some/arbitrary/path',
             destination=keyword_auto,
             destination_suffix='_suffix',
@@ -295,7 +296,7 @@ class MigSharedInstall__generate_confs(MigTestCase):
                          '/some/arbitrary/path/confs_suffix')
 
     def test_options_for_destination_relative(self):
-        options = generate_confs(
+        (options, _) = generate_confs(
             '/current/working/directory',
             destination='generate-confs',
             destination_suffix='_suffix',
@@ -311,7 +312,7 @@ class MigSharedInstall__generate_confs(MigTestCase):
                          '/current/working/directory/generate-confs_suffix')
 
     def test_options_for_destination_absolute(self):
-        options = generate_confs(
+        (options, _) = generate_confs(
             '/current/working/directory',
             destination='/some/other/place/confs',
             destination_suffix='_suffix',


### PR DESCRIPTION
PR104 basically exposed permanent_freeze for the CLI, but handling the value as a boolean. The actual production use relies on the space-separated list of strings for selecting individual Archive flavors to write protect like:
`--permanent_freeze="freeze backup"`

Adjust the type of the arg from bool to string and simplify the handling as the value is just passed as-is to the generated MiGserver.conf and effectively parsed in shared.configuration on use.

Mangle the calling API a bit to enable the caller to easily work with the parsed result in addition to the options dict.