### PR TITLE
Miscellaneous cleanups within tests and support library.

### DIFF
--- a/mig/install/generateconfs.py
+++ b/mig/install/generateconfs.py
@@ -64,7 +64,7 @@ Where supported options include -h/--help for this help or the conf settings:
 ''' % (sys.argv[0], '\n'.join(lines)))
 
 
-def main(argv, _generate_confs=generate_confs):
+def main(argv, _generate_confs=generate_confs, _print=print):
     str_names = [
         'source',
         'destination',
@@ -317,7 +317,7 @@ def main(argv, _generate_confs=generate_confs):
         elif opt_name in bool_names and val:
             settings[opt_name] = (val.strip().lower() in ['1', 'true', 'yes'])
         else:
-            print('Error: environment options %r not supported!' % opt_name)
+            _print('Error: environment options %r not supported!' % opt_name)
             usage(names)
             return 1
 
@@ -327,7 +327,7 @@ def main(argv, _generate_confs=generate_confs):
     try:
         (opts, args) = getopt.getopt(argv, flag_str, opts_str)
     except getopt.GetoptError as exc:
-        print('Error: ', exc.msg)
+        _print('Error: ', exc.msg)
         usage(names)
         return 1
 
@@ -343,13 +343,13 @@ def main(argv, _generate_confs=generate_confs):
         elif opt_name in bool_names:
             settings[opt_name] = (val.strip().lower() in ['1', 'true', 'yes'])
         else:
-            print('Error: command line option %r not supported!' % opt_name)
+            _print('Error: command line option %r not supported!' % opt_name)
             usage(names)
             return 1
 
     if args:
-        print('Error: non-option arguments are no longer supported!')
-        print(" ... found: %s" % args)
+        _print('Error: non-option arguments are no longer supported!')
+        _print(" ... found: %s" % args)
         usage(names)
         return 1
     if settings['destination_suffix'] == 'DEFAULT':
@@ -364,10 +364,10 @@ def main(argv, _generate_confs=generate_confs):
     else:
         # ... but use verbatim passthrough for absolute destination
         output_path = settings['destination']
-    print('# Creating confs with:')
+    _print('# Creating confs with:')
     # NOTE: force list to avoid problems with in-line edits
     for (key, val) in list(settings.items()):
-        print('%s: %s' % (key, val))
+        _print('%s: %s' % (key, val))
         # Remove default values to use generate_confs default values
         if val == 'DEFAULT':
             del settings[key]
@@ -381,9 +381,9 @@ def main(argv, _generate_confs=generate_confs):
         instructions_fd = open(instructions_path, "r")
         instructions = instructions_fd.read()
         instructions_fd.close()
-        print(instructions)
+        _print(instructions)
     except Exception as exc:
-        print("ERROR: could not read generated instructions: %s" % exc)
+        _print("ERROR: could not read generated instructions: %s" % exc)
         return 1
     return 0
 

--- a/mig/shared/jupyter.py
+++ b/mig/shared/jupyter.py
@@ -106,7 +106,7 @@ def gen_balancer_proxy_template(url, define, name, member_hosts,
     return template
 
 
-def gen_openid_template(url, define, auth_type):
+def gen_openid_template(url, define, auth_type, _print=print):
     """Generates an openid 2.0 or connect apache configuration section template
     for a particular jupyter service.
     url: Setting the url_path to where the jupyter service is to be located.
@@ -124,7 +124,7 @@ def gen_openid_template(url, define, auth_type):
         'define': define,
         'auth_type': auth_type
     }
-    print("filling in jupyter gen_openid_template with helper: (%s)" % fill_helpers)
+    _print("filling in jupyter gen_openid_template with helper: (%s)" % fill_helpers)
 
     template = """
 <IfDefine %(define)s>

--- a/mig/unittest/testcore.py
+++ b/mig/unittest/testcore.py
@@ -84,9 +84,7 @@ def main(_exit=sys.exit):
                         format="%(asctime)s %(levelname)s %(message)s")
     configuration.logger = logging
 
-    print("Running unit test on shared core functions")
-
-    print("Testing shared base functions")
+    print("Running unit test on shared core functions ..")
 
     short_alias = 'email'
     test_clients = [
@@ -189,9 +187,8 @@ def main(_exit=sys.exit):
                   (size, outlen, len(shortened)))
             _exit(1)
 
-    print("Completed shared base functions tests")
+    print("Running unit test on shared core functions DONE")
 
-    print("Done running unit test on shared core functions")
     _exit(0)
 
 if __name__ == "__main__":

--- a/tests/test_mig_install_generateconfs.py
+++ b/tests/test_mig_install_generateconfs.py
@@ -59,6 +59,10 @@ def create_fake_generate_confs(return_dict=None):
     return _generate_confs
 
 
+def noop(*args):
+    pass
+
+
 class MigInstallGenerateconfs__main(MigTestCase):
     """Unit test helper for the migrid code pointed to in class name"""
 
@@ -72,7 +76,7 @@ class MigInstallGenerateconfs__main(MigTestCase):
             dict(destination_dir=expected_generated_dir))
         test_arguments = ['--permanent_freeze', 'yes']
 
-        exit_code = main(test_arguments, _generate_confs=fake_generate_confs)
+        exit_code = main(test_arguments, _generate_confs=fake_generate_confs, _print=noop)
         self.assertEqual(exit_code, 0)
 
 

--- a/tests/test_mig_shared_compat.py
+++ b/tests/test_mig_shared_compat.py
@@ -31,8 +31,7 @@ import binascii
 import os
 import sys
 
-sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
-from support import MigTestCase, testmain
+from tests.support import MigTestCase, testmain
 
 from mig.shared.compat import PY2, ensure_native_string
 

--- a/tests/test_mig_shared_install.py
+++ b/tests/test_mig_shared_install.py
@@ -36,11 +36,8 @@ import os
 import pwd
 import sys
 
-sys.path.append(os.path.realpath(
-    os.path.join(os.path.dirname(__file__), "..")))
-
-from support import MIG_BASE, TEST_OUTPUT_DIR, MigTestCase, \
-    testmain, temppath, cleanpath, fixturepath, is_path_within, outputpath
+from tests.support import MIG_BASE, TEST_OUTPUT_DIR, MigTestCase, \
+    testmain, temppath, cleanpath, fixturepath, is_path_within
 
 from mig.shared.defaults import keyword_auto
 from mig.shared.install import determine_timezone, generate_confs
@@ -223,10 +220,8 @@ class MigSharedInstall__generate_confs(MigTestCase):
             _getpwnam=create_dummy_gpwnam(4321, 1234),
         )
 
-        relative_file = 'confs-stdlocal/MiGserver.conf'
-        self.assertPathExists('confs-stdlocal/MiGserver.conf')
+        actual_file = self.assertFileExists('confs-stdlocal/MiGserver.conf')
 
-        actual_file = outputpath(relative_file)
         self.assertConfigKey(
             actual_file, 'SITE', 'datasafety_link', expected='TEST_DATASAFETY_LINK')
         self.assertConfigKey(
@@ -246,10 +241,8 @@ class MigSharedInstall__generate_confs(MigTestCase):
                 _getpwnam=create_dummy_gpwnam(4321, 1234),
             )
 
-            relative_file = 'confs-stdlocal/MiGserver.conf'
-            self.assertPathExists('confs-stdlocal/MiGserver.conf')
+            actual_file = self.assertFileExists('confs-stdlocal/MiGserver.conf')
 
-            actual_file = outputpath(relative_file)
             self.assertConfigKey(
                 actual_file, 'SITE', 'permanent_freeze', expected=arg_val)
 

--- a/tests/test_mig_shared_jupyter.py
+++ b/tests/test_mig_shared_jupyter.py
@@ -39,11 +39,16 @@ from tests.support import TEST_OUTPUT_DIR, MigTestCase, FakeConfiguration, \
 from mig.shared.jupyter import gen_openid_template
 
 
+def noop(*args):
+    pass
+
+
 class MigSharedJupyter(MigTestCase):
     """Wrap unit tests for the corresponding module"""
 
     def test_jupyter_gen_openid_template_openid_auth(self):
-        filled = gen_openid_template("/some-jupyter-url", "MyDefine", "OpenID")
+        filled = gen_openid_template(
+            "/some-jupyter-url", "MyDefine", "OpenID", _print=noop)
         expected = """
 <IfDefine MyDefine>
     <Location /some-jupyter-url>
@@ -57,8 +62,9 @@ class MigSharedJupyter(MigTestCase):
         self.assertEqual(filled, expected)
 
     def test_jupyter_gen_openid_template_oidc_auth(self):
-        filled = gen_openid_template("/some-jupyter-url", "MyDefine",
-                                     "openid-connect")
+        filled = gen_openid_template(
+            "/some-jupyter-url", "MyDefine", "openid-connect", _print=noop)
+
         expected = """
 <IfDefine MyDefine>
     <Location /some-jupyter-url>
@@ -72,40 +78,24 @@ class MigSharedJupyter(MigTestCase):
         self.assertEqual(filled, expected)
 
     def test_jupyter_gen_openid_template_invalid_url_type(self):
-        rejected = False
-        try:
+        with self.assertRaises(AssertionError):
             filled = gen_openid_template(None, "MyDefine",
-                                         "no-such-auth-type")
-        except AssertionError as err:
-            rejected = True
-        self.assertTrue(rejected)
+                                         "openid-connect")
 
     def test_jupyter_gen_openid_template_invalid_define_type(self):
-        rejected = False
-        try:
+        with self.assertRaises(AssertionError):
             filled = gen_openid_template("/some-jupyter-url", None,
                                          "no-such-auth-type")
-        except AssertionError as err:
-            rejected = True
-        self.assertTrue(rejected)
 
-    def test_jupyter_gen_openid_template_invalid_auth_type(self):
-        rejected = False
-        try:
+    def test_jupyter_gen_openid_template_missing_auth_type(self):
+        with self.assertRaises(AssertionError):
             filled = gen_openid_template("/some-jupyter-url", "MyDefine",
                                          None)
-        except AssertionError as err:
-            rejected = True
-        self.assertTrue(rejected)
 
-    def test_jupyter_gen_openid_template_invalid_auth_val(self):
-        rejected = False
-        try:
+    def test_jupyter_gen_openid_template_invalid_auth_type(self):
+        with self.assertRaises(AssertionError):
             filled = gen_openid_template("/some-jupyter-url", "MyDefine",
                                          "no-such-auth-type")
-        except AssertionError as err:
-            rejected = True
-        self.assertTrue(rejected)
 
     # TODO: add more coverage of module
 

--- a/tests/test_mig_shared_safeinput.py
+++ b/tests/test_mig_shared_safeinput.py
@@ -33,9 +33,8 @@ import os
 import sys
 from past.builtins import basestring
 
-sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
+from tests.support import MigTestCase, testmain
 
-from support import MigTestCase, testmain
 from mig.shared.safeinput import main as safeinput_main, InputException, \
     filter_commonname, valid_commonname
 

--- a/tests/test_mig_shared_serial.py
+++ b/tests/test_mig_shared_serial.py
@@ -30,9 +30,8 @@
 import os
 import sys
 
-sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), ".")))
+from tests.support import MigTestCase, temppath, testmain
 
-from support import MigTestCase, temppath, testmain
 from mig.shared.serial import *
 
 class BasicSerial(MigTestCase):

--- a/tests/test_mig_unittest_testcore.py
+++ b/tests/test_mig_unittest_testcore.py
@@ -31,9 +31,7 @@ import importlib
 import os
 import sys
 
-sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), "..")))
-
-from support import MigTestCase, testmain
+from tests.support import MigTestCase, testmain
 
 from mig.unittest.testcore import main as testcore_main
 

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -3,7 +3,7 @@ import os
 import sys
 import unittest
 
-from support import MigTestCase, PY2, testmain, temppath
+from tests.support import MigTestCase, PY2, testmain, temppath
 
 
 class SupportTestCase(MigTestCase):


### PR DESCRIPTION
- make all tests import tests.support and thus remove sys.path fiddling
- move cleanpath() ensure_dir argument to temp_path() and collapse them
- remove outputpath() function
- add assertFileExists() assertion and use it to sinplify callsites
- silence junk printed to stdout due to code coming under test that directly calls print()
- use assertRaises() in place of hand rolling assertion capture in tests for some of the jupyter related logic
- apply review notes to recently added transferfunction locking tests and attempt to clarify cases via a common setup block and some splitting