### PR TITLE
WiP: assign updates to existing published frozen archives to integrate errata and related work

### DIFF
--- a/mig/assets/css/V3/style.css
+++ b/mig/assets/css/V3/style.css
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # style - Core UI V3 specific but skin-independent styling
-# Copyright (C) 2003-2019  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -807,4 +807,12 @@ var, sampl, code {
 */
 .table-responsive .table td, .table-responsive .table th {
     padding: 0.5rem  1.2rem;
+}
+
+/* Highligt replacement and supplement information for published Archives */
+.archive-update-header {
+    background-color: #ffcc00; /* Yellow for attention */
+    padding: 10px;
+    border: 1px solid #ff9900;
+    margin-bottom: 20px;
 }

--- a/mig/shared/defaults.py
+++ b/mig/shared/defaults.py
@@ -306,6 +306,7 @@ public_archive_dir = 'archives'
 public_archive_index = 'published-archive.html'
 public_archive_files = 'published-files.json'
 public_archive_doi = 'published-doi.json'
+public_archive_updates = 'published-updates.json'
 public_doi_index = 'archive-doi-index.html'
 
 edit_lock_suffix = '.editor_lock__'

--- a/mig/shared/output.py
+++ b/mig/shared/output.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # output - general formatting of backend output objects
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -28,6 +28,7 @@
 """Helper functions to generate output in format specified by the client"""
 
 from __future__ import absolute_import
+from past.builtins import basestring
 
 import os
 import sys
@@ -363,7 +364,7 @@ ___%s___
             header = [['ID', 'Path']]
             optional_cols = [('access', 'Access'), ('created', 'Created'),
                              ('active', 'Active'), ('owner', 'Owner'),
-                             ('invites', 'Invites'),  ('expire', 'Expire'),
+                             ('invites', 'Invites'), ('expire', 'Expire'),
                              ('single_file', 'Single file'),
                              ]
             content_keys = ['share_id', 'path']
@@ -1730,8 +1731,9 @@ Show archive with file checksums - might take quite a while to calculate:
             lines.append("""    </div>
 </div>""")
 
-            show_updating, show_edit, show_register = 3 * ['hidden']
-            edit_link, finalize_link, register_link = 3 * \
+            show_updating, show_edit, show_register, show_updates = 4 * \
+                ['hidden']
+            edit_link, finalize_link, register_link, updates_link = 4 * \
                 ['<!-- filled by AJAX-->']
             if i.get('state', '') == keyword_updating:
                 show_updating = ''
@@ -1745,6 +1747,9 @@ Show archive with file checksums - might take quite a while to calculate:
             if i.get('registerdoi_link', ''):
                 register_link = html_link(i['registerdoi_link'])
                 show_register = ''
+            if i.get('assignupdates_link', ''):
+                updates_link = html_link(i['assignupdates_link'])
+                show_updates = ''
 
             lines.append("""
 <div class='updatearchive %s'>
@@ -1770,10 +1775,19 @@ want to reference the contents in a publication.
 %s
 <p id='registerdoibutton'>%s</p>
 </div>
+<div class='assignupdates %s'>
+<p>
+You can assign updates to already finalized published archives. This may be
+useful in case you fouund errors in the existing archive or want to reference
+the already published contents in another archive.
+</p>
+<p id='assignupdatesbutton'>%s</p>
+</div>
 <div class='vertical-spacer'></div>
 </div>
 """ % (show_updating, show_edit, edit_link, finalize_link, show_register,
-                configuration.site_freeze_doi_text, register_link))
+                configuration.site_freeze_doi_text, register_link,
+                show_updates, updates_link))
 
         elif i['object_type'] == 'freezestatus':
             # We only use this element for scripted archive creation
@@ -1894,7 +1908,7 @@ want to reference the contents in a publication.
             skip_list = i.get('skip_list', [])
             optional_cols = [('access', 'Access'), ('created', 'Created'),
                              ('active', 'Active'), ('owner', 'Owner'),
-                             ('invites', 'Invites'),  ('expire', 'Expire'),
+                             ('invites', 'Invites'), ('expire', 'Expire'),
                              ('single_file', 'Single file'),
                              ]
             # IMPORTANT: AdBlock Plus hides elements with class sharelink(s)
@@ -2849,10 +2863,10 @@ def format_output(
 def format_timedelta(timedelta):
     """Formats timedelta as '[Years,] [days,] HH:MM:SS'"""
     years = timedelta.days // 365
-    days = timedelta.days - (years*365)
+    days = timedelta.days - (years * 365)
     hours = timedelta.seconds // 3600
-    minutes = (timedelta.seconds-(hours*3600)) // 60
-    seconds = timedelta.seconds - (hours*3600) - (minutes*60)
+    minutes = (timedelta.seconds - (hours * 3600)) // 60
+    seconds = timedelta.seconds - (hours * 3600) - (minutes * 60)
 
     hours_str = "%s" % hours
     if hours < 10:


### PR DESCRIPTION
Initial rough outline of the components and parts needed to support the requested feature of letting users assign a sort of updates to their already finalized/frozen published archives.
The fundamental issue is that the original MUST remain in place due to any DOI and code-of-conduct policies. So any updates e.g. to replace or supplement existing archives must leave the original intact and only e.g. add informational pointers between the involved archives. In that way people finding the original e.g. through a DOI will get informed about later errata and people landing at the errata archive can trace the history.
Another important note is that the original archive may already be backed up to long-term storage like tape and cannot easily be modified. So changes to the published archive should be minimal and to the extent possible also self-healing in case of disaster recovery from long-term storage.

In practice users will get a new `Assign Update` button on the show archive page for finalized archives similar to the existing `Register DOI` button there. When using that update button they should be presented with a dialog to mark the current archive as a replacement for another existing (selected) archive of theirs. 
The registration of that relation involves writing the information to disk and specifically generate a `published-updates.json` file inside the published archive folders that the landing pages will then AJAX-query and use to display Archive replacement information and links. That is, both involved archives should get that information into their `published-updates.json` in the process in order to make the linking bilateral.

The same method can potentially be extended to cover similar functionality for users to assign a published archive to supplement another existing published frozen one.