### PR TITLE
A couple of python3 fixes for the edituser and editgdpuser helper tools

### DIFF
--- a/mig/server/editgdpuser.py
+++ b/mig/server/editgdpuser.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # editgdpuser - Edit a MiG GDP user
-# Copyright (C) 2003-2022  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -146,9 +146,9 @@ if '__main__' == __name__:
         sys.exit(1)
 
     # Remove empty value fields
-
-    for (key, val) in user_dict.items():
-        if not val:
+    # NOTE: force list copy here as we delete inline below
+    for key in list(user_dict):
+        if not user_dict[key]:
             del user_dict[key]
 
     if account_state:

--- a/mig/server/edituser.py
+++ b/mig/server/edituser.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # edituser - Edit a MiG user
-# Copyright (C) 2003-2022  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -168,9 +168,9 @@ if '__main__' == __name__:
         user_dict['role'] = role
 
     # Remove empty value fields
-
-    for (key, val) in user_dict.items():
-        if not val:
+    # NOTE: force list copy here as we delete inline below
+    for key in list(user_dict):
+        if not user_dict[key]:
             del user_dict[key]
 
     if verbose:


### PR DESCRIPTION
Address the python3 bug in `edituser` indirectly reported by AU. 

Python3 does not allow iterating over a dictionary with `dict.items()` and deleting entries in-line, because `items()` returns an iterator rather than the list python2 did. Simply force a list copy to iterate over instead.
The same issue was found copy+pasted in `editgdpuser`, so now fixed there, too.