### PR TITLE
Prevent unique_id user database field problem in GDP mode

### DIFF
--- a/mig/shared/gdp/base.py
+++ b/mig/shared/gdp/base.py
@@ -3204,10 +3204,12 @@ def create_project_user(
         mig_user_dict['comment'] = "GDP autocreated user for project: %r" \
             % project_name
         mig_user_dict['openid_names'] = aliases
+        # Blank out the remaining fields not to copy from main user
         mig_user_dict['auth'] = ['']
         mig_user_dict['short_id'] = ''
         mig_user_dict['old_password'] = ''
         mig_user_dict['password'] = ''
+        mig_user_dict['unique_id'] = ''
         mig_user_db_path = default_db_path(configuration)
         try:
             create_user(mig_user_dict, configuration.config_file,

--- a/mig/shared/useradm.py
+++ b/mig/shared/useradm.py
@@ -667,6 +667,8 @@ change."""
         openid_names.append(short_id)
     add_names = []
 
+    # TODO: should GDP project users actually get their OWN unique_id, too?
+    #       They inadvertently copied the main user unique_id for a while.
     # NOTE: careful to skip GDP project users in openid and unique_id setup
     if not configuration.site_enable_gdp or \
             not is_gdp_user(configuration, client_id):
@@ -675,9 +677,11 @@ change."""
             add_names.append(user[configuration.user_openid_alias])
 
         # Make sure unique_id is really unique in user DB
+        # Explicitly skip GDP users to avoid stale leftovers (see TODO above)
         all_unique = [i['unique_id'] for (_, i) in user_db.items() if
                       i.get('unique_id', None) and
-                      i['distinguished_name'] != client_id]
+                      i['distinguished_name'] != client_id and
+                      not is_gdp_user(configuration, i['distinguished_name'])]
         found_unique = False
         for _ in range(4):
             user['unique_id'] = user.get('unique_id', False)


### PR DESCRIPTION
Fix an issue with the new unique_id user database field inadvertently being passed onto the related GDP project users and then causing failure to e.g. reset password, because that copy would then be identical to the value associated with the main user and detected as an illegal ID collision. Blank out the unique_id during GDP user creation and skip any such existing values in the collision check.
Added notes about reconsidering if GDP project users should actually get a unique ID assigned as well in the future as briefly discussed internally.