### PR TITLE
Tune ssh/sftp security settings to fit current clients/server versions

### DIFF
--- a/mig/install/openssh-MiG-sftp-subsys-template.conf
+++ b/mig/install/openssh-MiG-sftp-subsys-template.conf
@@ -38,6 +38,7 @@ HostKey __MIG_CERTS__/__SFTP_SUBSYS_ADDRESS__/server.key
 
 # IMPORTANT: these are *generated* hardened values based on generateconf
 # invocation. Any permanent changes need to be made there.
+HostKeyAlgorithms __OPENSSH_HOSTKEYALGOS__
 KexAlgorithms __OPENSSH_KEXALGOS__
 Ciphers __OPENSSH_CIPHERS__
 MACs __OPENSSH_MACS__

--- a/mig/shared/defaults.py
+++ b/mig/shared/defaults.py
@@ -451,8 +451,8 @@ STRONG_TLS_LEGACY_CIPHERS = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-
 # TODO: add curve 'X25519' as first choice once we reach openssl-1.1?
 STRONG_TLS_CURVES = "prime256v1:secp384r1:secp521r1"
 
-# Strong SSH key-exchange (Kex), cipher and message auth code (MAC) settings to
-# allow in OpenSSH and native Paramiko SFTP daemons (on OpenSSH format).
+# SSH hostkey, key-exchange (Kex), cipher and message auth code (MAC) settings
+# to allow in OpenSSH and native Paramiko SFTP daemons (on OpenSSH format).
 # NOTE: harden in line with Mozilla recommendations for modern versions:
 # https://wiki.mozilla.org/Security/Guidelines/OpenSSH#Configuration
 # Additional hardening based on https://github.com/arthepsy/ssh-audit
@@ -460,24 +460,32 @@ STRONG_TLS_CURVES = "prime256v1:secp384r1:secp521r1"
 # older versions can relatively safely fall back to instead use the
 # diffie-hellman-group-exchange-sha256 as long as the moduli tuning from
 # https://infosec.mozilla.org/guidelines/openssh is applied.
-# Tested to work with popular recent clients on the main platforms:
+# NOTE: DH group14 may also have weak modulus so leave it out.
+# Tested to work with popular clients on the main platforms:
 # OpenSSH-6.6.1+, LFTP-4.4.13+, FileZilla-3.24+, WinSCP-5.13.3+ and PuTTY-0.70+
-# NOTE: CentOS-6 still comes with OpenSSH-5.3 without strong Kex+MAC support
-# thus it's necessary to fake legacy ssh version to support any such clients.
-STRONG_SSH_KEXALGOS = "curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512"
-BEST_SSH_LEGACY_KEXALGOS = "curve25519-sha256@libssh.org"
-SAFE_SSH_LEGACY_KEXALGOS = "diffie-hellman-group-exchange-sha256"
-STRONG_SSH_LEGACY_KEXALGOS = ",".join([BEST_SSH_LEGACY_KEXALGOS,
-                                       SAFE_SSH_LEGACY_KEXALGOS])
+# NOTE: CentOS 7 comes with OpenSSH-7.4 with medium Kex+MAC support
+# but it's necessary to fake legacy ssh version to support older clients.
+# NOTE: ssh-rsa is the deprecated SHA1 based RSA host key exchange. Rely on the
+# modern rsa-sha2-(512|256) algorithms instead where available. Unfortunately
+# ssh-rsa itself cannot be removed on legacy systems without also removing the
+# modern SHA256 versions, too. So keep it last and let client pick best there.
+STRONG_SSH_HOSTKEYALGOS = "ssh-ed25519,rsa-sha2-512,rsa-sha2-256"
+LEGACY_SSH_HOSTKEYALGOS = ",".join([STRONG_SSH_HOSTKEYALGOS, "ssh-rsa"])
+FALLBACK_SSH_HOSTKEYALGOS = LEGACY_SSH_HOSTKEYALGOS
+STRONG_SSH_KEXALGOS = "curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,diffie-hellman-group16-sha512"
+# NOTE: fall back to relatively safe DH group-exchange-sha256 on old paramiko etc.
+LEGACY_SSH_KEXALGOS = ",".join([STRONG_SSH_KEXALGOS,
+                                "diffie-hellman-group-exchange-sha256"])
+FALLBACK_SSH_KEXALGOS = LEGACY_SSH_KEXALGOS
 STRONG_SSH_CIPHERS = "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
-# NOTE: strong cipher support go way back - just reuse
-STRONG_SSH_LEGACY_CIPHERS = BEST_SSH_LEGACY_CIPHERS = SAFE_SSH_LEGACY_CIPHERS = STRONG_SSH_CIPHERS
+# NOTE: avoid chacha20-poly1305@openssh.com to mitigate Terrapin issue on old servers
+LEGACY_SSH_CIPHERS = "aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
+FALLBACK_SSH_CIPHERS = LEGACY_SSH_CIPHERS
 STRONG_SSH_MACS = "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com"
-# NOTE: extend strong MACS with the best possible alternatives on old paramiko
+LEGACY_SSH_MACS = STRONG_SSH_MACS
+# NOTE: fall back to safe MACS with the best possible alternatives on ancient paramiko
 #       to avoid falling back to really bad ones
-BEST_SSH_LEGACY_MACS = STRONG_SSH_MACS
-SAFE_SSH_LEGACY_MACS = "hmac-sha2-512,hmac-sha2-256"
-STRONG_SSH_LEGACY_MACS = ",".join([BEST_SSH_LEGACY_MACS, SAFE_SSH_LEGACY_MACS])
+FALLBACK_SSH_MACS = ",".join([LEGACY_SSH_MACS, "hmac-sha2-512,hmac-sha2-256"])
 
 # Detect and ban cracking attempts and unauthorized vulnerability scans
 # A pattern to match usernames unambiguously identifying cracking attempts

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -52,10 +52,12 @@ import sys
 
 from mig.shared.defaults import default_http_port, default_https_port, \
     auth_openid_mig_db, auth_openid_ext_db, MIG_BASE, STRONG_TLS_CIPHERS, \
-    STRONG_TLS_CURVES, STRONG_SSH_KEXALGOS, STRONG_SSH_LEGACY_KEXALGOS, \
-    STRONG_SSH_CIPHERS, STRONG_SSH_LEGACY_CIPHERS, STRONG_SSH_MACS, \
-    STRONG_SSH_LEGACY_MACS, CRACK_USERNAME_REGEX, CRACK_WEB_REGEX, \
-    keyword_any, keyword_auto
+    STRONG_TLS_CURVES, STRONG_SSH_HOSTKEYALGOS, STRONG_SSH_KEXALGOS, \
+    STRONG_SSH_CIPHERS, STRONG_SSH_MACS, LEGACY_SSH_HOSTKEYALGOS, \
+    LEGACY_SSH_KEXALGOS, LEGACY_SSH_CIPHERS, LEGACY_SSH_MACS, \
+    FALLBACK_SSH_HOSTKEYALGOS, FALLBACK_SSH_KEXALGOS, FALLBACK_SSH_CIPHERS, \
+    FALLBACK_SSH_MACS, CRACK_USERNAME_REGEX, CRACK_WEB_REGEX, keyword_any, \
+    keyword_auto
 from mig.shared.compat import ensure_native_string
 from mig.shared.fileio import read_file, read_file_lines, write_file, \
     write_file_lines
@@ -1134,16 +1136,24 @@ cert, oid and sid based https!
     user_dict['__APACHE_CURVES__'] = STRONG_TLS_CURVES
 
     # We use raw string comparison here which seems to work alright for X.Y.Z
-    if user_dict['__OPENSSH_VERSION__'] >= "7.3":
-        # Use current strong Kex/Cipher/MAC settings for openssh >=7.3
+    if user_dict['__OPENSSH_VERSION__'] >= "8.0":
+        # Use current strong HostKey/Kex/Cipher/MAC settings for openssh >=8.0
+        user_dict['__OPENSSH_HOSTKEYALGOS__'] = STRONG_SSH_HOSTKEYALGOS
         user_dict['__OPENSSH_KEXALGOS__'] = STRONG_SSH_KEXALGOS
         user_dict['__OPENSSH_CIPHERS__'] = STRONG_SSH_CIPHERS
         user_dict['__OPENSSH_MACS__'] = STRONG_SSH_MACS
+    elif user_dict['__OPENSSH_VERSION__'] >= "7.4":
+        # Fall back to best legacy HostKey/Kex/Cipher/MAC for openssh >=7.4
+        user_dict['__OPENSSH_HOSTKEYALGOS__'] = LEGACY_SSH_HOSTKEYALGOS
+        user_dict['__OPENSSH_KEXALGOS__'] = LEGACY_SSH_KEXALGOS
+        user_dict['__OPENSSH_CIPHERS__'] = LEGACY_SSH_CIPHERS
+        user_dict['__OPENSSH_MACS__'] = LEGACY_SSH_MACS
     else:
-        # Fall back to legacy Kex/Cipher/MAC for openssh <7.3
-        user_dict['__OPENSSH_KEXALGOS__'] = STRONG_SSH_LEGACY_KEXALGOS
-        user_dict['__OPENSSH_CIPHERS__'] = STRONG_SSH_LEGACY_CIPHERS
-        user_dict['__OPENSSH_MACS__'] = STRONG_SSH_LEGACY_MACS
+        # Fall back to best available HostKey/Kex/Cipher/MAC for openssh <7.4
+        user_dict['__OPENSSH_HOSTKEYALGOS__'] = FALLBACK_SSH_HOSTKEYALGOS
+        user_dict['__OPENSSH_KEXALGOS__'] = FALLBACK_SSH_KEXALGOS
+        user_dict['__OPENSSH_CIPHERS__'] = FALLBACK_SSH_CIPHERS
+        user_dict['__OPENSSH_MACS__'] = FALLBACK_SSH_MACS
 
     # We know that login with one of these common usernames is a password
     # cracking attempt since our own username format differs.

--- a/tests/fixture/confs-stdlocal/sshd_config-MiG-sftp-subsys
+++ b/tests/fixture/confs-stdlocal/sshd_config-MiG-sftp-subsys
@@ -38,8 +38,9 @@ HostKey /home/mig/certs//server.key
 
 # IMPORTANT: these are *generated* hardened values based on generateconf
 # invocation. Any permanent changes need to be made there.
-KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+HostKeyAlgorithms ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,diffie-hellman-group16-sha512,diffie-hellman-group-exchange-sha256
+Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
 
 # Logging


### PR DESCRIPTION
Rework SSH/SFTP security settings to also cover hostkey algo and to fit modern client and server installations now that CentOS/RHEL 7 is EoL.

Rename and split hostkey, key exchange, cipher and MAC handling into 3 security levels (strong, legacy and weak). Try them in turn on the paramiko server to pick best available while warning about weaknesses and bailing out if no safe transport security is available.
Assign them to openssh+sftpsubsys service based on prior knowledge about the provided openssh_version support.
Mitigate the Terrapin vulnerability (CVE-2023-48795) on platforms where it is not already handled upstream.

Removes the deprecated ssh-rsa hostkey algorithm from sftpsubsys on modern platforms.
Relegate the weak hmac-sha2-512 and hmac-sha2-256 MACs from legacy to only last resort use.