### PR TITLE
Replace now deprecated logging warn function calls with warning ones

### DIFF
--- a/mig/shared/functionality/mkdir.py
+++ b/mig/shared/functionality/mkdir.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # mkdir - create directory in user home
-# Copyright (C) 2003-2020  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -175,8 +175,8 @@ CSRF-filtered POST requests to prevent unintended updates'''
                 # partial match:
                 # ../*/* is technically allowed to match own files.
 
-                logger.warn('%s tried to %s %s restricted path! (%s)'
-                            % (client_id, op_name, abs_path, pattern))
+                logger.warning('%s tried to %s %s restricted path! (%s)' %
+                               (client_id, op_name, abs_path, pattern))
                 continue
             match.append(abs_path)
 

--- a/mig/shared/functionality/rangefileaccess.py
+++ b/mig/shared/functionality/rangefileaccess.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # rangefileaccess - read or write byte range inside file
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -363,8 +363,8 @@ def main(client_id, user_arguments_dict, environ=None):
                 # partial match:
                 # ../*/* is technically allowed to match own files.
 
-                logger.warn('%s tried to %s %s restricted path! (%s)'
-                            % (client_id, op_name, abs_path, pattern))
+                logger.warning('%s tried to %s %s restricted path! (%s)' %
+                               (client_id, op_name, abs_path, pattern))
                 continue
             match.append(abs_path)
 

--- a/mig/shared/map.py
+++ b/mig/shared/map.py
@@ -3,7 +3,7 @@
 #
 # map.py - Collection of map related functions
 #
-# Copyright (C) 2003-2019  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -22,10 +22,12 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 """A shared collection of map helper functions"""
+
 from __future__ import absolute_import
 
-import os
 import fcntl
+import os
+
 from mig.shared.serial import load
 
 
@@ -50,7 +52,7 @@ def load_system_map(configuration, kind, do_lock):
         map_stamp = os.path.getmtime(map_path)
 
     except IOError:
-        configuration.logger.warn("No %s map to load" % kind)
+        configuration.logger.warning("No %s map to load" % kind)
         entity_map = {}
         map_stamp = -1
     if do_lock:

--- a/mig/shared/pwcrypto.py
+++ b/mig/shared/pwcrypto.py
@@ -5,7 +5,7 @@
 #
 #
 # pwcrypto - helpers for password and crypto including for encryption and hashing
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -414,7 +414,7 @@ def _aesgcm_aad_helper(prefix, date_format=AAD_DEFAULT_STAMP, size=32):
     using '%Y%m%d%H'.
     """
     crypt_counter = datetime.datetime.now().strftime(date_format)
-    val = b' '*size + b'%s' % prefix
+    val = b' ' * size + b'%s' % prefix
     val += b'%s' % crypt_counter
     return val[-size:]
 
@@ -690,8 +690,8 @@ def verify_reset_token(configuration, user_dict, token, auth_type,
     try:
         assure_reset_supported(configuration, user_dict, auth_type)
     except ValueError as vae:
-        _logger.warn("verify %s reset token %s failed: %s" % (auth_type, token,
-                                                              vae))
+        _logger.warning("verify %s reset token %s failed: %s" %
+                        (auth_type, token, vae))
         return False
 
     token_stamp, token_hash = parse_reset_token(configuration, token,

--- a/mig/shared/vgridaccess.py
+++ b/mig/shared/vgridaccess.py
@@ -107,7 +107,7 @@ def load_entity_map(configuration, kind, do_lock, caching):
         _logger.info("after %s map load from %s" % (kind, map_path))
         map_stamp = os.path.getmtime(map_path)
     except IOError:
-        _logger.warn("No %s map to load" % kind)
+        _logger.warning("No %s map to load" % kind)
         entity_map = {}
         map_stamp = -1
     if do_lock:

--- a/mig/shared/workflows.py
+++ b/mig/shared/workflows.py
@@ -3,7 +3,7 @@
 #
 # workflows.py - Collection of workflows related functions
 #
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -3394,7 +3394,7 @@ def __create_task_parameter_file(configuration, vgrid, pattern,
     except Exception as err:
         msg = "Failed to create the task parameter " \
               "file: %s, data: %s, err: %s" % (path, parameter_dict, err)
-        _logger.warn(msg)
+        _logger.warning(msg)
         return (False, msg)
 
     return (True, '')
@@ -3608,7 +3608,7 @@ def get_workflow_trigger(configuration, vgrid, rule_id=None, recursive=False):
     if not status:
         msg = "Failed to find triggers in vgrid '%s', err '%s'" % (vgrid,
                                                                    triggers)
-        _logger.warn(msg)
+        _logger.warning(msg)
         return (False, msg)
 
     if rule_id:


### PR DESCRIPTION
Replace a number of `logger.warn` calls with `logger.warning` calls to remove deprecation warnings.