### PR TITLE
Address sandbox resource crashes and fragile legacy /dev/urandom use

### DIFF
--- a/mig/server/jobscriptgenerator.py
+++ b/mig/server/jobscriptgenerator.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # jobscriptgenerator - dynamically generate job script right before job handout
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -182,8 +182,8 @@ def create_job_script(
     # TODO: hexlify is an awfully space wasting URL-safe encoding.
     #       We should just use something like the proposed secure method from
     #       http://stackoverflow.com/a/23728630/2213647
-    sessionid = hexlify(open('/dev/urandom').read(session_id_bytes))
-    iosessionid = hexlify(open('/dev/urandom').read(session_id_bytes))
+    sessionid = hexlify(os.urandom(session_id_bytes))
+    iosessionid = hexlify(os.urandom(session_id_bytes))
     helper_dict_filename = os.path.join(configuration.resource_home,
                                         unique_resource_name,
                                         'empty_job_helper_dict.%s' % exe)
@@ -475,7 +475,7 @@ def create_arc_job(
         return (None, 'Error. empty job for ARC?')
 
     # generate random session ID:
-    sessionid = hexlify(open('/dev/urandom').read(session_id_bytes))
+    sessionid = hexlify(os.urandom(session_id_bytes))
     logger.debug('session ID (for creating links): %s' % sessionid)
 
     client_dir = client_id_dir(client_id)

--- a/mig/shared/confparser.py
+++ b/mig/shared/confparser.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # confparser - parse resource configurations
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -34,6 +34,7 @@
 from __future__ import absolute_import
 
 from mig.shared.conf import get_configuration_object
+from mig.shared.fileio import write_file
 from mig.shared.parser import parse, check_types
 from mig.shared.refunctions import is_runtime_environment, get_re_dict
 from mig.shared.resconfkeywords import get_keywords_dict as \
@@ -77,6 +78,7 @@ def run(configuration, localfile_spaces, unique_resource_name,
 
     if not configuration:
         configuration = get_configuration_object()
+    _logger = configuration.logger
 
     (status, msg, conf) = get_resource_config_dict(configuration,
                                                    localfile_spaces)
@@ -230,12 +232,6 @@ owner and ask if you can be included in the %s.""" %
     else:
         return (True, 'Everything ok')
 
-    try:
-        fsock = open(filename, 'w')
-        st = dumps(conf, 0)
-        fsock.write(st)
-        fsock.close()
-    except Exception as err:
-        return (False, "Fatal error: could not open %r for writing!\n Msg: %s"
-                % (filename, err))
+    if not write_file(dumps(conf, 0), filename, _logger):
+        return (False, "Fatal error: could not open %r for writing!" % filename)
     return (True, 'Everything ok, config updated')

--- a/mig/shared/functionality/ssscreateimg.py
+++ b/mig/shared/functionality/ssscreateimg.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # ssscreateimg - Back end to SSS zip generator
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -92,7 +92,7 @@ def main(client_id, user_arguments_dict):
     win_solution = accepted['win_solution'][-1]
     vgrid_list = accepted['vgrid']
     cputime = 1000000
-    sandboxkey = hexlify(open('/dev/urandom').read(32))
+    sandboxkey = hexlify(os.urandom(32))
     ip_address = 'UNKNOWN'
     if 'REMOTE_ADDR' in os.environ:
         ip_address = os.environ['REMOTE_ADDR']

--- a/mig/shared/resource.py
+++ b/mig/shared/resource.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # resource - resource configuration functions
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -49,7 +49,8 @@ except ImportError:
 from mig.shared.base import client_id_dir
 from mig.shared.confparser import get_resource_config_dict, run
 from mig.shared.defaults import exe_leader_name, keyword_auto
-from mig.shared.fileio import pickle, move, walk
+from mig.shared.fileio import pickle, move, walk, write_file, read_file_lines, \
+    write_file_lines
 from mig.shared.modified import mark_resource_modified, mark_vgrid_modified
 from mig.shared.pwcrypto import make_simple_hash
 from mig.shared.resconfkeywords import get_resource_specs, get_exenode_specs, \
@@ -826,6 +827,7 @@ def empty_resource_config(configuration):
 def write_resource_config(configuration, resource_conf, conf_path):
     """Write resource_conf dictionary settings into conf_path on disk"""
 
+    _logger = configuration.logger
     lines = []
     for (field, __) in get_resource_specs(configuration):
         value = resource_conf.get(field, None)
@@ -866,9 +868,7 @@ def write_resource_config(configuration, resource_conf, conf_path):
     if not os.path.isdir(os.path.dirname(conf_path)):
         os.makedirs(os.path.dirname(conf_path))
 
-    conf_fd = open(conf_path, 'w')
-    conf_fd.write('\n'.join(lines))
-    conf_fd.close()
+    write_file('\n'.join(lines), conf_path, _logger)
 
     return lines
 
@@ -1038,6 +1038,7 @@ def create_resource_conf(
     relative path it will prefixed with the resource_pending dir of the
     client_id.
     """
+    _logger = configuration.logger
     if new_resource:
         msg = """
 Trying to create configuration for new resource: '%s.%d' from file '%s':
@@ -1077,7 +1078,7 @@ Failure:
             """
 Failure:
   resource_name: '%s'
-  does'nt match hosturl: '%s'
+  doesn't match hosturl: '%s'
   in configfile: '%s'"""\
              % (resource_name, config_dict['HOSTURL'], pending_file)
         return (False, msg)
@@ -1094,21 +1095,13 @@ Failure:
                 pending_file)
         return (False, msg)
 
-    try:
-        fr = open(pending_file, 'r')
-        fw = open(tmpfile, 'w')
-        readline = fr.readline()
-        while len(readline) > 0:
-            fw.write(readline.replace(keyword_auto, "%d" %
-                                      resource_identifier))
-            readline = fr.readline()
-        fw.close()
-        fr.close()
-    except Exception as err:
-
-        msg += \
-            'Failed to apply hostidentifier to configfile. Failure: %s'\
-            % err
+    pending_lines = read_file_lines(pending_file, _logger)
+    replaced_lines = []
+    for line in pending_lines:
+        replaced_lines.append(line.replace(keyword_auto, "%d" %
+                                           resource_identifier))
+    if not write_file_lines(replaced_lines, tmpfile, _logger):
+        msg += 'Failed to apply hostidentifier to configfile.'
         return (False, msg)
 
     unique_resource_name = "%s.%d" % (resource_name, resource_identifier)

--- a/mig/shared/sandbox.py
+++ b/mig/shared/sandbox.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # sandbox - shared sandbox helpers
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -35,7 +35,7 @@ import tempfile
 from mig.shared.base import hexlify
 from mig.shared.conf import get_configuration_object
 from mig.shared.defaults import default_vgrid, keyword_auto
-from mig.shared.fileio import make_symlink
+from mig.shared.fileio import make_symlink, write_named_tempfile
 from mig.shared.resource import create_resource
 from mig.shared.serial import load, dump
 
@@ -173,10 +173,7 @@ vgrid=%s
     # write the conf string to a temporary conf file
     # create_resource removes the tempfile automatically
 
-    tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    tmp_file.write(res_conf_string)
-    tmp_file.close()
-    pending_file = tmp_file.name
+    pending_file = write_named_tempfile(configuration, res_conf_string)
 
     (status, id_msg) = create_resource(configuration, sandboxkey,
                                        resource_name, pending_file)
@@ -190,6 +187,7 @@ vgrid=%s
 
     exe_pgid_file = configuration.resource_home + unique_resource_name\
         + os.sep + 'EXE_%s.PGID' % exe_name
+
     try:
         fd = open(exe_pgid_file, 'w')
         fd.write('stopped')
@@ -314,10 +312,7 @@ vgrid=%s
     # write the conf string to a temporary conf file
     # create_resource removes the tempfile automatically
 
-    tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    tmp_file.write(res_conf_string)
-    tmp_file.close()
-    pending_file = tmp_file.name
+    pending_file = write_named_tempfile(configuration, res_conf_string)
 
     (status, id_msg) = create_resource(configuration, sandboxkey,
                                        resource_name, pending_file)
@@ -368,7 +363,7 @@ def get_resource(client_id, configuration, logger):
 
         # Generate key, and set cookie
 
-        sandboxkey = hexlify(open('/dev/urandom').read(32))
+        sandboxkey = hexlify(os.urandom(32))
         cookie = 'Set-Cookie: ' + __MIG_ONECLICK_COOKIE__ + '='\
             + sandboxkey + '; '\
             + 'expires=Thu 31-Jan-2099 12:00:00 GMT; path=/; '\


### PR DESCRIPTION
Replace the use of the old fragile `open('/dev/urandom').read(N)` calls with modern `os.urandom(N)` calls to also avoid the inherent str vs bytes issues of the former form between python 2 and 3.
Migrate a couple of old open+op+close uses with corresponding fileio methods.
Should address issue #161 among others.