### PR TITLE
Permit users with explicit peer acceptance to auto sign up even if they are filtered by auto_add_user_permit

### DIFF
--- a/mig/install/MiGserver-template.conf
+++ b/mig/install/MiGserver-template.conf
@@ -30,6 +30,12 @@ auto_add_filter_method = __AUTO_ADD_FILTER_METHOD__
 # auth methods explicitly enabled with auto_add_X_user. Space separated list of
 # user field and regexp-filter pattern pairs separated by colons.
 auto_add_user_permit = __AUTO_ADD_USER_PERMIT__
+# Optional limit on users who may sign up through autocreate without operator
+# interaction if a valid peer exists. Defaults to allow ANY distinguished name
+# if unset but only for auth methods explicitly enabled with auto_add_X_user.
+# Space separated list of user field and regexp-filter pattern pairs separated
+# by colons.
+auto_add_user_with_peer = __AUTO_ADD_USER_WITH_PEER__
 # Default account expiry unless set. Renew and web login extends by default.
 cert_valid_days = __CERT_VALID_DAYS__
 oid_valid_days = __OID_VALID_DAYS__

--- a/mig/install/generateconfs.py
+++ b/mig/install/generateconfs.py
@@ -72,6 +72,7 @@ def main(argv, _generate_confs=generate_confs, _print=print):
         'auto_add_filter_fields',
         'auto_add_filter_method',
         'auto_add_user_permit',
+        'auto_add_user_with_peer',
         'base_fqdn',
         'public_fqdn',
         'public_alias_fqdn',

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -1243,15 +1243,39 @@ sudo su - %s
     return cmd_helpers
 
 
-def auto_add_user_allowed(configuration, user_dict):
+def __auto_add_user_allowed(configuration, user_dict, permit_list):
     """Check if user with user_dict is allowed to sign up without operator
-    approval e.g. using autocreate based on optional configuration limits.
+    approval e.g. using autocreate based on optional configuration limits in
+    given permit_list of fields and regex values. Always fail if permit_list
+    is empty.
     """
 
-    for (key, val) in configuration.auto_add_user_permit:
+    if not permit_list:
+        return False
+    for (key, val) in permit_list:
         if not re.match(val, user_dict.get(key, 'NO SUCH FIELD')):
             return False
     return True
+
+
+def auto_add_user_allowed_direct(configuration, user_dict):
+    """Check if user with user_dict is allowed to sign up directly e.g. using
+    autocreate without operator or peer approval. The check is based on
+    optional configuration limits and must match all such permit expressions.
+    """
+    return __auto_add_user_allowed(configuration, user_dict,
+                                   configuration.auto_add_user_permit)
+
+
+def auto_add_user_allowed_with_peer(configuration, user_dict):
+    """Check if user with user_dict is allowed to sign up with peer acceptance
+    e.g. using autocreate without explicit operator approval. The check is
+    based on optional configuration limits and must match all such permit
+    expressions.
+    """
+
+    return __auto_add_user_allowed(configuration, user_dict,
+                                   configuration.auto_add_user_with_peer)
 
 
 def peers_permit_allowed(configuration, user_dict):

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -139,6 +139,7 @@ def fix_missing(config_file, verbose=True):
         'auto_add_oidc_user': False,
         'auto_add_resource': False,
         'auto_add_user_permit': 'distinguished_name:.*',
+        'auto_add_user_with_peer': 'distinguished_name:.*',
         'auto_add_filter_method': '',
         'auto_add_filter_fields': '',
         'server_fqdn': fqdn,
@@ -671,6 +672,7 @@ _CONFIGURATION_DEFAULTS = {
     'auto_add_oidc_user': False,
     'auto_add_resource': False,
     'auto_add_user_permit': [('distinguished_name', '.*')],
+    'auto_add_user_with_peer': [('distinguished_name', '.*')],
     'auto_add_filter_method': '',
     'auto_add_filter_fields': [],
 
@@ -2605,12 +2607,21 @@ location.""" % self.config_file)
         if config.has_option('GLOBAL', 'auto_add_resource'):
             self.auto_add_resource = config.getboolean('GLOBAL',
                                                        'auto_add_resource')
-        # Limit sign up without operator interaction using ID fields regex.
+        # Limit direct sign up without operator interaction using ID field and
+        # regex pairs.
         # For autocreate auto_add_X_user must be True and auto_add_user_permit
         # specification must match actual user on all given fields.
         if config.has_option('GLOBAL', 'auto_add_user_permit'):
             req = config.get('GLOBAL', 'auto_add_user_permit').split()
             self.auto_add_user_permit = [i.split(':', 2) for i in req]
+        # Limit peer accepted sign up without operator interaction using ID
+        # field and regex pairs.
+        # For autocreate auto_add_X_user must be True and
+        # auto_add_user_with_peer specification must match actual user on all
+        # given fields. Plus an active peer acceptance to match must exist.
+        if config.has_option('GLOBAL', 'auto_add_user_with_peer'):
+            req = config.get('GLOBAL', 'auto_add_user_with_peer').split()
+            self.auto_add_user_with_peer = [i.split(':', 2) for i in req]
 
         # Apply requested automatic filtering of selected auto add user fields
         if config.has_option('GLOBAL', 'auto_add_filter_method'):

--- a/mig/shared/functionality/autocreate.py
+++ b/mig/shared/functionality/autocreate.py
@@ -33,7 +33,7 @@ OpenID Connect logins.
    Also see req-/extcertaction.py
    Differences:
      - automatic upload of a proxy certificate when provided
-     - no special check for KU organization
+     - no special check for organization and email match
      - allows empty fields for things like country, email, and state
 """
 
@@ -44,7 +44,8 @@ import os
 import time
 
 from mig.shared import returnvalues
-from mig.shared.accountreq import auto_add_user_allowed
+from mig.shared.accountreq import auto_add_user_allowed_direct, \
+    auto_add_user_allowed_with_peer
 from mig.shared.accountstate import default_account_expire
 from mig.shared.bailout import filter_output_objects
 from mig.shared.base import client_id_dir, canonical_user, mask_creds, \
@@ -726,7 +727,13 @@ accepting create matching supplied ID!'''})
             configuration.auto_add_oidc_user:
         fill_user(user_dict)
 
-        if not auto_add_user_allowed(configuration, user_dict):
+        if auto_add_user_allowed_direct(configuration, user_dict):
+            logger.debug('autocreate directly permitted for %s' % client_id)
+        elif auto_add_user_allowed_with_peer(configuration, user_dict):
+            logger.debug('autocreate only permitted with peer for %s' %
+                         client_id)
+            peer_pattern = keyword_auto
+        else:
             logger.warning('autocreate not permitted for %s' % client_id)
             output_objects.append({
                 'object_type': 'error_text', 'text':

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -327,6 +327,7 @@ def generate_confs(
     auto_add_filter_fields='',
     auto_add_filter_method='skip',
     auto_add_user_permit='distinguished_name:.*',
+    auto_add_user_with_peer='distinguished_name:.*',
     cert_valid_days=365,
     oid_valid_days=365,
     oidc_valid_days=365,
@@ -644,6 +645,7 @@ def _generate_confs_prepare(
     auto_add_filter_fields,
     auto_add_filter_method,
     auto_add_user_permit,
+    auto_add_user_with_peer,
     cert_valid_days,
     oid_valid_days,
     oidc_valid_days,
@@ -891,6 +893,7 @@ def _generate_confs_prepare(
     user_dict['__AUTO_ADD_FILTER_FIELDS__'] = auto_add_filter_fields
     user_dict['__AUTO_ADD_FILTER_METHOD__'] = auto_add_filter_method
     user_dict['__AUTO_ADD_USER_PERMIT__'] = auto_add_user_permit
+    user_dict['__AUTO_ADD_USER_WITH_PEER__'] = auto_add_user_with_peer
     user_dict['__CERT_VALID_DAYS__'] = "%s" % cert_valid_days
     user_dict['__OID_VALID_DAYS__'] = "%s" % oid_valid_days
     user_dict['__OIDC_VALID_DAYS__'] = "%s" % oidc_valid_days
@@ -2583,6 +2586,7 @@ def create_user(
     auto_add_filter_fields = ''
     auto_add_filter_method = 'skip'
     auto_add_user_permit = 'distinguished_name:.*'
+    auto_add_user_with_peer = 'distinguished_name:.*'
     cert_valid_days = 365
     oid_valid_days = 365
     oidc_valid_days = 365

--- a/tests/fixture/confs-stdlocal/MiGserver.conf
+++ b/tests/fixture/confs-stdlocal/MiGserver.conf
@@ -30,6 +30,12 @@ auto_add_filter_method = skip
 # auth methods explicitly enabled with auto_add_X_user. Space separated list of
 # user field and regexp-filter pattern pairs separated by colons.
 auto_add_user_permit = distinguished_name:.*
+# Optional limit on users who may sign up through autocreate without operator
+# interaction if a valid peer exists. Defaults to allow ANY distinguished name
+# if unset but only for auth methods explicitly enabled with auto_add_X_user.
+# Space separated list of user field and regexp-filter pattern pairs separated
+# by colons.
+auto_add_user_with_peer = distinguished_name:.*
 # Default account expiry unless set. Renew and web login extends by default.
 cert_valid_days = 365
 oid_valid_days = 365

--- a/tests/fixture/mig_shared_configuration--new.json
+++ b/tests/fixture/mig_shared_configuration--new.json
@@ -17,6 +17,12 @@
       ".*"
     ]
   ],
+  "auto_add_user_with_peer": [
+    [
+      "distinguished_name",
+      ".*"
+    ]
+  ],
   "ca_dir": "",
   "ca_file": "",
   "ca_fqdn": "",

--- a/tests/fixture/mig_shared_configuration--new.json.ini
+++ b/tests/fixture/mig_shared_configuration--new.json.ini
@@ -1,5 +1,6 @@
 [DEFAULT]
 auto_add_user_permit = array_of_tuples
+auto_add_user_with_peer = array_of_tuples
 site_cloud_access = array_of_tuples
 site_peers_permit = array_of_tuples
 site_vgrid_creators = array_of_tuples


### PR DESCRIPTION
Implement another variation of the `auto_add_user_permit` filtering of users who can automatically sign up through `autocreate.py` without site operator interaction. By means of the new `auto_add_user_with_peer` any users failing the initial `auto_add_user_permit` checks can still complete auto sign up if and only if an active peer acceptance exists for them. That is, only when an existing user with permission to designate peers has defined them as a collaboration partner or similar.
The new option is similar in that it supports one or more user field names and regexes that they must match for the new user.
This is particularly useful when an international ID provider like WAYF is configured as OIDC provider and not all the users registered with that IDP should be able to just sign up.
With `auto_add_user_permit` set to cover e.g. a set of whitelisted organizations the `auto_add_user_with_peer` can be left to the default to allow any other user registered at the IDP to also sign up if permitted users already vouched for them. The filtering can also be further restricted to e.g. only allow users from certain countries or organizations to auto sign up with peer acceptance.