### PR TITLE
Revert "Flexible and dynamic service key/certificate fingerprints in MiGserver.conf"

### DIFF
--- a/mig/install/generateconfs.py
+++ b/mig/install/generateconfs.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # generateconfs - create custom MiG server configuration files
-# Copyright (C) 2003-2025  The MiG Project
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -145,10 +145,7 @@ def main(argv, _generate_confs=generate_confs, _print=print):
         'ext_oidc_rewrite_cookie',
         'dhparams_path',
         'daemon_keycert',
-        'daemon_keycert_sha256',
         'daemon_pubkey',
-        'daemon_pubkey_md5',
-        'daemon_pubkey_sha256',
         'daemon_show_address',
         'alias_field',
         'peers_permit',

--- a/mig/install/migcheckssl-template.sh.cronjob
+++ b/mig/install/migcheckssl-template.sh.cronjob
@@ -40,9 +40,7 @@ server_crt="${domain_cert_path}/server.crt"
 server_crt_ca_pem="${domain_cert_path}/server.crt.ca.pem"
 server_key_crt_ca_pem="${domain_cert_path}/server.key.crt.ca.pem"
 combined_pem="${domain_cert_path}/combined.pem"
-combined_pem_sha256="${combined_pem}.sha256"
 combined_pub="${domain_cert_path}/combined.pub"
-combined_pub_sha256="${combined_pub}.sha256"
 dhparams_pem="${cert_base}/dhparams.pem"
 # use git latest or release version of getssl
 getssl_version="release"
@@ -281,32 +279,10 @@ if [[ ${org_mtime} -ne ${new_mtime} && "${org_chksum}" != "${new_chksum}" ]]; th
         fi
     done
     if [ -n "${migrid_subservices}" ]; then
-        pem_sha256_fp=$(openssl x509 -noout -fingerprint -sha256 -in ${combined_pem})
-        pem_sha256_fp=${pem_sha256_fp/* Fingerprint=/}
-        echo "Please manually update ftps/davs sha256 fingerprint in MiGserver.conf to:"
-        echo "${pem_sha256_fp}"
-        echo "or point those configuration values to the latest fingerprint file with:"
-        echo "FILE::${combined_pem_sha256}"
-        echo "optionally appending '\$\$CACHE_PATH' for memory caching in CACHE_PATH."
-        echo "${pem_sha256_fp}" > ${combined_pem_sha256}
-        pub_md5_fp=$(ssh-keygen -l -E md5 -f ${combined_pub})
-        pub_md5_fp=${pub_md5_fp/* MD5:/}
-        pub_md5_fp=${pub_md5_fp/ */}
-        echo "Please verify that sftp md5 fingerprint in MiGserver.conf is:"
-        echo "${pub_md5_fp}"
-        echo "or point that configuration value to the latest fingerprint file with:"
-        echo "FILE::${combined_pub_md5}"
-        echo "optionally appending '\$\$CACHE_PATH' for memory caching in CACHE_PATH."
-        echo "${pub_md5_fp}" > ${combined_pub_md5}
-        pub_sha256_fp=$(ssh-keygen -l -f ${combined_pub})
-        pub_sha256_fp=${pub_sha256_fp/* SHA256:/}
-        pub_sha256_fp=${pub_sha256_fp/ */}
-        echo "Please verify that sftp sha256 fingerprint in MiGserver.conf is:"
-        echo "${pub_sha256_fp}"
-        echo "or point that configuration value to the latest fingerprint file with:"
-        echo "FILE::${combined_pub_sha256}"
-        echo "optionally appending '\$\$CACHE_PATH' for memory caching in CACHE_PATH."
-        echo "${pub_sha256_fp}" > ${combined_pub_sha256}
+        sha256_fingerprint=$(openssl x509 -noout -fingerprint -sha256 -in ${combined_pem})
+        sha256_fingerprint=${sha256_fingerprint/SHA256 Fingerprint=/}
+        echo "Please update ftps and davs sha256 fingerprint in MiGserver.conf to:"
+        echo "${sha256_fingerprint}"
     fi
 fi
 

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # configuration - configuration wrapper
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
 #
 # This file is part of MiG.
 #
@@ -1134,8 +1134,7 @@ location.""" % self.config_file)
             fingerprint = config.get('GLOBAL', 'user_sftp_key_md5')
             self.user_sftp_key_md5 = fingerprint
         if config.has_option('GLOBAL', 'user_sftp_key_sha256'):
-            fingerprint = expand_external_sources(
-                logger, config.get('GLOBAL', 'user_sftp_key_sha256'))
+            fingerprint = config.get('GLOBAL', 'user_sftp_key_sha256')
             self.user_sftp_key_sha256 = fingerprint
         if config.has_option('GLOBAL', 'user_sftp_key_from_dns'):
             self.user_sftp_key_from_dns = config.getboolean(
@@ -1229,8 +1228,7 @@ location.""" % self.config_file)
             self.user_davs_key = config.get('GLOBAL',
                                             'user_davs_key')
         if config.has_option('GLOBAL', 'user_davs_key_sha256'):
-            fingerprint = expand_external_sources(
-                logger, config.get('GLOBAL', 'user_davs_key_sha256'))
+            fingerprint = config.get('GLOBAL', 'user_davs_key_sha256')
             self.user_davs_key_sha256 = fingerprint
         if config.has_option('GLOBAL', 'user_davs_auth'):
             self.user_davs_auth = config.get('GLOBAL',
@@ -1276,8 +1274,7 @@ location.""" % self.config_file)
             self.user_ftps_key = config.get('GLOBAL',
                                             'user_ftps_key')
         if config.has_option('GLOBAL', 'user_ftps_key_sha256'):
-            fingerprint = expand_external_sources(
-                logger, config.get('GLOBAL', 'user_ftps_key_sha256'))
+            fingerprint = config.get('GLOBAL', 'user_ftps_key_sha256')
             self.user_ftps_key_sha256 = fingerprint
         if config.has_option('GLOBAL', 'user_ftps_auth'):
             self.user_ftps_auth = config.get('GLOBAL',

--- a/tests/fixture/confs-stdlocal/migcheckssl
+++ b/tests/fixture/confs-stdlocal/migcheckssl
@@ -40,9 +40,7 @@ server_crt="${domain_cert_path}/server.crt"
 server_crt_ca_pem="${domain_cert_path}/server.crt.ca.pem"
 server_key_crt_ca_pem="${domain_cert_path}/server.key.crt.ca.pem"
 combined_pem="${domain_cert_path}/combined.pem"
-combined_pem_sha256="${combined_pem}.sha256"
 combined_pub="${domain_cert_path}/combined.pub"
-combined_pub_sha256="${combined_pub}.sha256"
 dhparams_pem="${cert_base}/dhparams.pem"
 # use git latest or release version of getssl
 getssl_version="release"
@@ -281,32 +279,10 @@ if [[ ${org_mtime} -ne ${new_mtime} && "${org_chksum}" != "${new_chksum}" ]]; th
         fi
     done
     if [ -n "${migrid_subservices}" ]; then
-        pem_sha256_fp=$(openssl x509 -noout -fingerprint -sha256 -in ${combined_pem})
-        pem_sha256_fp=${pem_sha256_fp/* Fingerprint=/}
-        echo "Please manually update ftps/davs sha256 fingerprint in MiGserver.conf to:"
-        echo "${pem_sha256_fp}"
-        echo "or point those configuration values to the latest fingerprint file with:"
-        echo "FILE::${combined_pem_sha256}"
-        echo "optionally appending '\$\$CACHE_PATH' for memory caching in CACHE_PATH."
-        echo "${pem_sha256_fp}" > ${combined_pem_sha256}
-        pub_md5_fp=$(ssh-keygen -l -E md5 -f ${combined_pub})
-        pub_md5_fp=${pub_md5_fp/* MD5:/}
-        pub_md5_fp=${pub_md5_fp/ */}
-        echo "Please verify that sftp md5 fingerprint in MiGserver.conf is:"
-        echo "${pub_md5_fp}"
-        echo "or point that configuration value to the latest fingerprint file with:"
-        echo "FILE::${combined_pub_md5}"
-        echo "optionally appending '\$\$CACHE_PATH' for memory caching in CACHE_PATH."
-        echo "${pub_md5_fp}" > ${combined_pub_md5}
-        pub_sha256_fp=$(ssh-keygen -l -f ${combined_pub})
-        pub_sha256_fp=${pub_sha256_fp/* SHA256:/}
-        pub_sha256_fp=${pub_sha256_fp/ */}
-        echo "Please verify that sftp sha256 fingerprint in MiGserver.conf is:"
-        echo "${pub_sha256_fp}"
-        echo "or point that configuration value to the latest fingerprint file with:"
-        echo "FILE::${combined_pub_sha256}"
-        echo "optionally appending '\$\$CACHE_PATH' for memory caching in CACHE_PATH."
-        echo "${pub_sha256_fp}" > ${combined_pub_sha256}
+        sha256_fingerprint=$(openssl x509 -noout -fingerprint -sha256 -in ${combined_pem})
+        sha256_fingerprint=${sha256_fingerprint/SHA256 Fingerprint=/}
+        echo "Please update ftps and davs sha256 fingerprint in MiGserver.conf to:"
+        echo "${sha256_fingerprint}"
     fi
 fi
 


### PR DESCRIPTION
Reverts ucphhpc/migrid-sync#171 merge directly in edge in order to merge through svn as usual.