### PR TITLE
Write-protect ID fields in sign up forms when user is already authenticated

### DIFF
--- a/mig/shared/functionality/extcert.py
+++ b/mig/shared/functionality/extcert.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # extcert - External certificate account sign up backend
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -25,7 +25,7 @@
 # -- END_HEADER ---
 #
 
-"""Request account sign up with external certificate back end"""
+"""Request account access through externally signed X509 certificate auth"""
 
 from __future__ import absolute_import
 
@@ -159,11 +159,9 @@ def main(client_id, user_arguments_dict):
         fill_helpers['readonly_%s' % field] = ''
     ro_fields = [i for i in accepted['ro_fields'] if i in
                  list(cert_field_map) + given_peers]
-    # Only write-protect ID fields in auto-mode
-    if keyword_auto in accepted['ro_fields']:
+    # Write-protect ID fields in auto-mode or if already logged in
+    if keyword_auto in accepted['ro_fields'] or client_id:
         ro_fields += [i for i in list(cert_field_map) if not i in ro_fields]
-    # NOTE: lock all ID fields to current certificate here
-    ro_fields += [i for i in id_fields if not i in ro_fields]
     for field in ro_fields:
         fill_helpers['readonly_%s' % field] = 'readonly'
     fill_helpers.update(user_fields)

--- a/mig/shared/functionality/reqcert.py
+++ b/mig/shared/functionality/reqcert.py
@@ -3,8 +3,8 @@
 #
 # --- BEGIN_HEADER ---
 #
-# reqcert - Certificate account request backend
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# reqcert - Local certificate request and account sign up backend
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -25,7 +25,7 @@
 # -- END_HEADER ---
 #
 
-"""Request certificate account back end"""
+"""Request account access through locally signed X509 certificate auth"""
 
 from __future__ import absolute_import
 
@@ -196,8 +196,8 @@ jobs and privileges.</p>''' % configuration.short_title})
         fill_helpers['readonly_%s' % field] = ''
     ro_fields = [i for i in accepted['ro_fields'] if i in
                  list(cert_field_map) + given_peers]
-    # Only write-protect ID fields in auto-mode
-    if keyword_auto in accepted['ro_fields']:
+    # Write-protect ID fields in auto-mode or if already logged in
+    if keyword_auto in accepted['ro_fields'] or client_id:
         ro_fields += [i for i in list(cert_field_map) if not i in ro_fields]
     if reset_token:
         user_fields['reset_token'] = reset_token

--- a/mig/shared/functionality/reqoid.py
+++ b/mig/shared/functionality/reqoid.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # reqoid - OpenID account request backend
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -25,7 +25,7 @@
 # -- END_HEADER ---
 #
 
-"""Request OpenID account back end"""
+"""Request account access through built-in OpenID 2.0 service auth"""
 
 from __future__ import absolute_import
 
@@ -198,8 +198,8 @@ to your old files, jobs and privileges. </p>''' %
         fill_helpers['readonly_%s' % field] = ''
     ro_fields = [i for i in accepted['ro_fields'] if i in
                  list(cert_field_map) + given_peers]
-    # Only write-protect ID fields in auto-mode
-    if keyword_auto in accepted['ro_fields']:
+    # Write-protect ID fields in auto-mode or if already logged in
+    if keyword_auto in accepted['ro_fields'] or client_id:
         ro_fields += [i for i in list(cert_field_map) if not i in ro_fields]
     if reset_token:
         user_fields['reset_token'] = reset_token


### PR DESCRIPTION
Write-protect ID fields in sign up forms when user is already authenticated. We don't want account ID changes in that relation, since it will only cause frustrations and headaches both for users and operators.