### PR TITLE
Fix invalid HTML document being generated for certain error cases.

### DIFF
--- a/mig/shared/output.py
+++ b/mig/shared/output.py
@@ -2820,10 +2820,11 @@ def format_output(
 
         # hide previous output
 
-        out_obj = []
-        out_obj.extend([{'object_type': 'error_text', 'text':
-                         'Validation error! %s' % val_msg},
-                        {'object_type': 'title', 'text': 'Validation error!'}])
+        out_obj = [
+            {'object_type': 'start'},
+            {'object_type': 'title', 'text': 'Validation error!'},
+            {'object_type': 'error_text', 'text': 'Validation error! %s' % val_msg},
+        ]
 
     start = None
     title = None


### PR DESCRIPTION
Any execution that results in ret_val (https://github.com/ucphhpc/migrid-sync/blob/6ae253846fd67d0e60af6668a9f9947be70243f4/mig/shared/output.py#L2813) returning false is currently producing an invalid HTML document due the to the subsequent overridden output objects array (https://github.com/ucphhpc/migrid-sync/blob/6ae253846fd67d0e60af6668a9f9947be70243f4/mig/shared/output.py#L2824) not being correctly processed by the object type renderer.