### PR TITLE
Fix/missing md5 fingerprint variable init in migcheckssl

### DIFF
--- a/README
+++ b/README
@@ -711,7 +711,10 @@ additional web apps and OpenID on CentOS:
                    --serveralias_clause='ServerAlias' --alias_field=email \
                    --dhparams_path=~/certs/dhparams.pem \
                    --daemon_keycert=~/certs/combined.pem \
+                   --daemon_keycert_sha256='FILE::/home/mig/certs/combined.pem.sha256' \
                    --daemon_pubkey=~/certs/combined.pub \
+                   --daemon_pubkey_md5='FILE::/home/mig/certs/combined.pub.md5' \
+                   --daemon_pubkey_sha256='FILE::/home/mig/certs/combined.pub.sha256' \
                    --daemon_pubkey_from_dns=True \
                    --signup_methods="extoid migoid migcert extoidc" \
                    --login_methods="extoid migoid migcert extoidc" \
@@ -811,7 +814,10 @@ local OpenID login and added Jupyter+cloud integration for data analysis:
                    --serveralias_clause='#ServerAlias' --alias_field=email \
                    --dhparams_path=~/certs/dhparams.pem \
                    --daemon_keycert=~/certs/combined.pem \
+                   --daemon_keycert_sha256='FILE::/home/mig/certs/combined.pem.sha256' \
                    --daemon_pubkey=~/certs/combined.pub \
+                   --daemon_pubkey_md5='FILE::/home/mig/certs/combined.pub.md5' \
+                   --daemon_pubkey_sha256='FILE::/home/mig/certs/combined.pub.sha256' \
                    --daemon_pubkey_from_dns=True \
                    --signup_methods="extoid migoid extcert extoidc" \
                    --login_methods="extoid migoid extcert extoidc" \
@@ -997,7 +1003,10 @@ https://en.wikipedia.org/wiki/General_Data_Protection_Regulation
                    --serveralias_clause='#ServerAlias' --alias_field=email \
                    --dhparams_path=~/certs/dhparams.pem \
                    --daemon_keycert=~/certs/combined.pem \
+                   --daemon_keycert_sha256='FILE::/home/mig/certs/combined.pem.sha256' \
                    --daemon_pubkey=~/certs/combined.pub \
+                   --daemon_pubkey_md5='FILE::/home/mig/certs/combined.pub.md5' \
+                   --daemon_pubkey_sha256='FILE::/home/mig/certs/combined.pub.sha256' \
                    --daemon_pubkey_from_dns=True \
                    --daemon_show_address=sif-io.erda.dk \
                    --signup_methods="extoid migoid" \

--- a/README
+++ b/README
@@ -711,10 +711,10 @@ additional web apps and OpenID on CentOS:
                    --serveralias_clause='ServerAlias' --alias_field=email \
                    --dhparams_path=~/certs/dhparams.pem \
                    --daemon_keycert=~/certs/combined.pem \
-                   --daemon_keycert_sha256='FILE::/home/mig/certs/combined.pem.sha256' \
+                   --daemon_keycert_sha256='FILE::/etc/httpd/MiG-certificates/combined.pem.sha256' \
                    --daemon_pubkey=~/certs/combined.pub \
-                   --daemon_pubkey_md5='FILE::/home/mig/certs/combined.pub.md5' \
-                   --daemon_pubkey_sha256='FILE::/home/mig/certs/combined.pub.sha256' \
+                   --daemon_pubkey_md5='FILE::/etc/httpd/MiG-certificates/combined.pub.md5' \
+                   --daemon_pubkey_sha256='FILE::/etc/httpd/MiG-certificates/combined.pub.sha256' \
                    --daemon_pubkey_from_dns=True \
                    --signup_methods="extoid migoid migcert extoidc" \
                    --login_methods="extoid migoid migcert extoidc" \
@@ -814,10 +814,10 @@ local OpenID login and added Jupyter+cloud integration for data analysis:
                    --serveralias_clause='#ServerAlias' --alias_field=email \
                    --dhparams_path=~/certs/dhparams.pem \
                    --daemon_keycert=~/certs/combined.pem \
-                   --daemon_keycert_sha256='FILE::/home/mig/certs/combined.pem.sha256' \
+                   --daemon_keycert_sha256='FILE::/etc/httpd/MiG-certificates/combined.pem.sha256' \
                    --daemon_pubkey=~/certs/combined.pub \
-                   --daemon_pubkey_md5='FILE::/home/mig/certs/combined.pub.md5' \
-                   --daemon_pubkey_sha256='FILE::/home/mig/certs/combined.pub.sha256' \
+                   --daemon_pubkey_md5='FILE::/etc/httpd/MiG-certificates/combined.pub.md5' \
+                   --daemon_pubkey_sha256='FILE::/etc/httpd/MiG-certificates/combined.pub.sha256' \
                    --daemon_pubkey_from_dns=True \
                    --signup_methods="extoid migoid extcert extoidc" \
                    --login_methods="extoid migoid extcert extoidc" \
@@ -1003,10 +1003,10 @@ https://en.wikipedia.org/wiki/General_Data_Protection_Regulation
                    --serveralias_clause='#ServerAlias' --alias_field=email \
                    --dhparams_path=~/certs/dhparams.pem \
                    --daemon_keycert=~/certs/combined.pem \
-                   --daemon_keycert_sha256='FILE::/home/mig/certs/combined.pem.sha256' \
+                   --daemon_keycert_sha256='FILE::/etc/httpd/MiG-certificates/combined.pem.sha256' \
                    --daemon_pubkey=~/certs/combined.pub \
-                   --daemon_pubkey_md5='FILE::/home/mig/certs/combined.pub.md5' \
-                   --daemon_pubkey_sha256='FILE::/home/mig/certs/combined.pub.sha256' \
+                   --daemon_pubkey_md5='FILE::/etc/httpd/MiG-certificates/combined.pub.md5' \
+                   --daemon_pubkey_sha256='FILE::/etc/httpd/MiG-certificates/combined.pub.sha256' \
                    --daemon_pubkey_from_dns=True \
                    --daemon_show_address=sif-io.erda.dk \
                    --signup_methods="extoid migoid" \

--- a/mig/install/migcheckssl-template.sh.cronjob
+++ b/mig/install/migcheckssl-template.sh.cronjob
@@ -42,6 +42,7 @@ server_key_crt_ca_pem="${domain_cert_path}/server.key.crt.ca.pem"
 combined_pem="${domain_cert_path}/combined.pem"
 combined_pem_sha256="${combined_pem}.sha256"
 combined_pub="${domain_cert_path}/combined.pub"
+combined_pub_md5="${combined_pub}.md5"
 combined_pub_sha256="${combined_pub}.sha256"
 dhparams_pem="${cert_base}/dhparams.pem"
 # use git latest or release version of getssl
@@ -122,7 +123,10 @@ if [[ ${verbose} -eq 1 ]]; then
     echo "server_key_crt_ca_pem: ${server_key_crt_ca_pem}"
     echo "dhparams_pem: ${dhparams_pem}" 
     echo "combined_pem: ${combined_pem}"
+    echo "combined_pem_sha256: ${combined_pem_sha256}"
     echo "combined_pub: ${combined_pub}"
+    echo "combined_pub_md5: ${combined_pub_md5}"
+    echo "combined_pub_sha256: ${combined_pub_sha256}"
 fi
 
 # Ensure domain certificate path

--- a/tests/fixture/confs-stdlocal/migcheckssl
+++ b/tests/fixture/confs-stdlocal/migcheckssl
@@ -42,6 +42,7 @@ server_key_crt_ca_pem="${domain_cert_path}/server.key.crt.ca.pem"
 combined_pem="${domain_cert_path}/combined.pem"
 combined_pem_sha256="${combined_pem}.sha256"
 combined_pub="${domain_cert_path}/combined.pub"
+combined_pub_md5="${combined_pub}.md5"
 combined_pub_sha256="${combined_pub}.sha256"
 dhparams_pem="${cert_base}/dhparams.pem"
 # use git latest or release version of getssl
@@ -122,7 +123,10 @@ if [[ ${verbose} -eq 1 ]]; then
     echo "server_key_crt_ca_pem: ${server_key_crt_ca_pem}"
     echo "dhparams_pem: ${dhparams_pem}" 
     echo "combined_pem: ${combined_pem}"
+    echo "combined_pem_sha256: ${combined_pem_sha256}"
     echo "combined_pub: ${combined_pub}"
+    echo "combined_pub_md5: ${combined_pub_md5}"
+    echo "combined_pub_sha256: ${combined_pub_sha256}"
 fi
 
 # Ensure domain certificate path


### PR DESCRIPTION
Apparently this bit got lost in PR171 but added here now along with a minor update to the README to actually use the new fingerprint files on sites to avoid manual updates on every LetsEncrypt certificate renewal.