### PR TITLE
Remove the now unused imports after PR185

### DIFF
--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -39,14 +39,10 @@ from past.builtins import basestring
 
 import ast
 import base64
-import crypt
-import datetime
 import grp
 import os
 import pwd
-import random
 import re
-import socket
 import subprocess
 import sys
 


### PR DESCRIPTION
Remove the now unused imports from PR #185 , where the crypt import in particular still causes CI failure on python-3.13 in the `python3-latest` runner.