### PR TITLE
Integrate site status page

### DIFF
--- a/mig/install/apache-MiG-template.conf
+++ b/mig/install/apache-MiG-template.conf
@@ -114,6 +114,11 @@ Alias /assets/ "__MIG_CODE__/assets/"
 Alias /public/ "__MIG_STATE__/wwwpublic/"
 # Bind security.txt (https://securitytxt.org/) once and for all
 Alias /.well-known/security.txt "__MIG_STATE__/wwwpublic/.well-known/security.txt"
+<IfDefine STATUS_ALIAS_FQDN>
+# Status page helpers
+Alias /status.html "__MIG_STATE__/wwwpublic/status.html"
+Alias /status-events.json "__MIG_STATE__/wwwpublic/status-events.json"
+</IfDefine>
 <Directory "__MIG_STATE__/wwwpublic">
     AuthType none
     <IfVersion > 2.2>
@@ -432,6 +437,9 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
     <IfDefine PUBLIC_ALIAS_FQDN>
     ServerAlias ${PUBLIC_ALIAS_FQDN}
     </IfDefine>
+    <IfDefine STATUS_ALIAS_FQDN>
+    ServerAlias ${STATUS_ALIAS_FQDN}
+    </IfDefine>
     # Optionally add extra server aliases for current and future use here
     #ServerAlias something.__BASE_FQDN__ somethingelse.__BASE_FQDN__
 
@@ -474,6 +482,11 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
     __PREFER_HTTPS_COMMENTED__        RewriteCond %{HTTPS} off
     __PREFER_HTTPS_COMMENTED__        RewriteCond %{HTTP_HOST} ^${PUBLIC_ALIAS_FQDN}$
     __PREFER_HTTPS_COMMENTED__        RewriteRule ^/?(.*) https://${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}/$1 [R,L]
+    __PREFER_HTTPS_COMMENTED__    </IfDefine>
+    __PREFER_HTTPS_COMMENTED__    <IfDefine STATUS_ALIAS_FQDN>
+    __PREFER_HTTPS_COMMENTED__        RewriteCond %{HTTPS} off
+    __PREFER_HTTPS_COMMENTED__        RewriteCond %{HTTP_HOST} ^${STATUS_ALIAS_FQDN}$
+    __PREFER_HTTPS_COMMENTED__        RewriteRule ^/?(.*) https://${STATUS_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}/$1 [R,L]
     __PREFER_HTTPS_COMMENTED__    </IfDefine>
     __PREFER_HTTPS_COMMENTED__</IfDefine>
 
@@ -609,6 +622,9 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
 <VirtualHost ${PUBLIC_FQDN}:${PUBLIC_HTTPS_PORT}>
     ServerName ${PUBLIC_FQDN}
     ServerAlias __BASE_FQDN__
+    <IfDefine STATUS_ALIAS_FQDN>
+    ServerAlias ${STATUS_ALIAS_FQDN}
+    </IfDefine>
     # Optionally add extra server aliases for current and future use here
     #ServerAlias something.__BASE_FQDN__ somethingelse.__BASE_FQDN__
 
@@ -659,6 +675,12 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
         RewriteLog __APACHE_LOG__/rewrite.log
         RewriteLogLevel 0
     </IfVersion>
+
+    <IfDefine STATUS_ALIAS_FQDN>
+    # Redirect implict target to status page
+    RewriteCond %{SERVER_NAME} ^${STATUS_ALIAS_FQDN}$
+    RewriteRule ^(/*)$ /status.html [L,R]
+    </IfDefine>
 
     # Break rewriting chain for commonly-requested final destinations
     # * Direct files (including subrequest for /X.py from /wsgi-bin/X.py)
@@ -734,6 +756,9 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
 <IfDefine PUBLIC_ALIAS_FQDN>
 <VirtualHost ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}>
     ServerName ${PUBLIC_ALIAS_FQDN}
+    <IfDefine STATUS_ALIAS_FQDN>
+    ServerAlias ${STATUS_ALIAS_FQDN}
+    </IfDefine>
     # General setup for the virtual host
     DocumentRoot "__MIG_STATE__/wwwpublic"
     ErrorLog __APACHE_LOG__/ssl-error.log
@@ -773,6 +798,12 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
         RewriteLog __APACHE_LOG__/rewrite.log
         RewriteLogLevel 0
     </IfVersion>
+
+    <IfDefine STATUS_ALIAS_FQDN>
+    # Redirect implict target to status page
+    RewriteCond %{SERVER_NAME} ^${STATUS_ALIAS_FQDN}$
+    RewriteRule ^(/*)$ /status.html [L,R]
+    </IfDefine>
 
     # Break rewriting chain for commonly-requested final destinations
     # * Internal Aliased helper locations

--- a/mig/install/apache-apache2-template.conf
+++ b/mig/install/apache-apache2-template.conf
@@ -48,6 +48,7 @@ IncludeOptional __APACHE_ETC__/production-mode*.conf
 # Always-on vhosts both for emergency and production mode
 __IFDEF_PUBLIC_FQDN__ PUBLIC_FQDN __PUBLIC_FQDN__
 __IFDEF_PUBLIC_ALIAS_FQDN__ PUBLIC_ALIAS_FQDN __PUBLIC_ALIAS_FQDN__
+__IFDEF_STATUS_ALIAS_FQDN__ STATUS_ALIAS_FQDN __STATUS_ALIAS_FQDN__
 # User vhosts are ONLY enabled in actual production mode
 <IfDefine PRODUCTION_MODE>
 __IFDEF_BASE_FQDN__ BASE_FQDN __BASE_FQDN__

--- a/mig/install/apache-ports-template.conf
+++ b/mig/install/apache-ports-template.conf
@@ -33,14 +33,14 @@ Listen ${PUBLIC_HTTP_PORT}
     </IfDefine>
     <IfDefine PUBLIC_ALIAS_FQDN>
     <IfDefine PUBLIC_HTTPS_PORT>
-    <IfDefine PRODUCTION_MODE>
-    #NameVirtualHost ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
+    __APACHE_PRE2.4__ NameVirtualHost ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
     __PUBLIC_ALIAS_HTTPS_LISTEN__ ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
     </IfDefine>
-    <IfDefine !PRODUCTION_MODE>
-    # Also force listen on PUBLIC_ALIAS_FQDN here if not in PRODUCTION_MODE
-    Listen ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
     </IfDefine>
+    <IfDefine STATUS_ALIAS_FQDN>
+    <IfDefine PUBLIC_HTTPS_PORT>
+    __APACHE_PRE2.4__ NameVirtualHost ${STATUS_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
+    __STATUS_ALIAS_HTTPS_LISTEN__ ${STATUS_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
     </IfDefine>
     </IfDefine>
     <IfDefine MIG_CERT_FQDN>
@@ -66,8 +66,14 @@ Listen ${PUBLIC_HTTP_PORT}
 <IfModule mod_gnutls.c>
     <IfDefine PUBLIC_ALIAS_FQDN>
     <IfDefine PUBLIC_HTTPS_PORT>
-    #NameVirtualHost ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
+    __APACHE_PRE2.4__ NameVirtualHost ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
     __PUBLIC_ALIAS_HTTPS_LISTEN__ ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
+    </IfDefine>
+    </IfDefine>
+    <IfDefine STATUS_ALIAS_FQDN>
+    <IfDefine PUBLIC_HTTPS_PORT>
+    __APACHE_PRE2.4__ NameVirtualHost ${STATUS_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
+    __STATUS_ALIAS_HTTPS_LISTEN__ ${STATUS_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
     </IfDefine>
     </IfDefine>
     <IfDefine MIG_CERT_FQDN>

--- a/mig/install/generateconfs.py
+++ b/mig/install/generateconfs.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # generateconfs - create custom MiG server configuration files
-# Copyright (C) 2003-2025  The MiG Project
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -76,6 +76,7 @@ def main(argv, _generate_confs=generate_confs, _print=print):
         'base_fqdn',
         'public_fqdn',
         'public_alias_fqdn',
+        'status_alias_fqdn',
         'public_sec_fqdn',
         'mig_cert_fqdn',
         'ext_cert_fqdn',

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -292,6 +292,7 @@ def generate_confs(
     base_fqdn='',
     public_fqdn='',
     public_alias_fqdn='',
+    status_alias_fqdn='',
     public_sec_fqdn='',
     mig_cert_fqdn='',
     ext_cert_fqdn='',
@@ -613,6 +614,7 @@ def _generate_confs_prepare(
     base_fqdn,
     public_fqdn,
     public_alias_fqdn,
+    status_alias_fqdn,
     public_sec_fqdn,
     mig_cert_fqdn,
     ext_cert_fqdn,
@@ -843,6 +845,7 @@ def _generate_confs_prepare(
     user_dict['__BASE_FQDN__'] = base_fqdn
     user_dict['__PUBLIC_FQDN__'] = public_fqdn
     user_dict['__PUBLIC_ALIAS_FQDN__'] = public_alias_fqdn
+    user_dict['__STATUS_ALIAS_FQDN__'] = status_alias_fqdn
     if public_use_https:
         if public_sec_fqdn:
             user_dict['__PUBLIC_SEC_FQDN__'] = public_sec_fqdn
@@ -1081,6 +1084,7 @@ def _generate_confs_prepare(
     user_dict['__GDP_PATH_SCRAMBLE__'] = gdp_path_scramble
     user_dict['__PUBLIC_HTTPS_LISTEN__'] = listen_clause
     user_dict['__PUBLIC_ALIAS_HTTPS_LISTEN__'] = listen_clause
+    user_dict['__STATUS_ALIAS_HTTPS_LISTEN__'] = listen_clause
     user_dict['__QUOTA_BACKEND__'] = quota_backend
     user_dict['__QUOTA_USER_LIMIT__'] = "%s" % quota_user_limit
     user_dict['__QUOTA_VGRID_LIMIT__'] = "%s" % quota_vgrid_limit
@@ -1220,6 +1224,9 @@ cert, oid and sid based https!
     user_dict['__IFDEF_PUBLIC_ALIAS_FQDN__'] = 'UnDefine'
     if user_dict['__PUBLIC_ALIAS_FQDN__']:
         user_dict['__IFDEF_PUBLIC_ALIAS_FQDN__'] = 'Define'
+    user_dict['__IFDEF_STATUS_ALIAS_FQDN__'] = 'UnDefine'
+    if user_dict['__STATUS_ALIAS_FQDN__']:
+        user_dict['__IFDEF_STATUS_ALIAS_FQDN__'] = 'Define'
 
     user_dict['__IFDEF_MIG_CERT_FQDN__'] = 'UnDefine'
     if user_dict['__MIG_CERT_FQDN__']:
@@ -2092,6 +2099,11 @@ ssh-keygen -f %(__DAEMON_KEYCERT__)s -y > %(__DAEMON_PUBKEY__)s""" % user_dict)
         # Apache fails on duplicate listen clauses
         if public_use_https and public_alias_fqdn == public_fqdn:
             user_dict['__PUBLIC_ALIAS_HTTPS_LISTEN__'] = "# %s" % listen_clause
+    if status_alias_fqdn:
+        # Apache fails on duplicate listen clauses
+        if public_use_https and status_alias_fqdn in (public_fqdn,
+                                                      public_alias_fqdn):
+            user_dict['__STATUS_ALIAS_HTTPS_LISTEN__'] = "# %s" % listen_clause
 
     if mig_cert_fqdn:
         user_dict['__MIG_CERT_URL__'] = 'https://%(__MIG_CERT_FQDN__)s' % \

--- a/tests/fixture/confs-stdlocal/MiG.conf
+++ b/tests/fixture/confs-stdlocal/MiG.conf
@@ -114,6 +114,11 @@ Alias /assets/ "/home/mig/mig/assets/"
 Alias /public/ "/home/mig/state/wwwpublic/"
 # Bind security.txt (https://securitytxt.org/) once and for all
 Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.txt"
+<IfDefine STATUS_ALIAS_FQDN>
+# Status page helpers
+Alias /status.html "/home/mig/state/wwwpublic/status.html"
+Alias /status-events.json "/home/mig/state/wwwpublic/status-events.json"
+</IfDefine>
 <Directory "/home/mig/state/wwwpublic">
     AuthType none
     <IfVersion > 2.2>
@@ -432,6 +437,9 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
     <IfDefine PUBLIC_ALIAS_FQDN>
     ServerAlias ${PUBLIC_ALIAS_FQDN}
     </IfDefine>
+    <IfDefine STATUS_ALIAS_FQDN>
+    ServerAlias ${STATUS_ALIAS_FQDN}
+    </IfDefine>
     # Optionally add extra server aliases for current and future use here
     #ServerAlias something. somethingelse.
 
@@ -474,6 +482,11 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
            RewriteCond %{HTTPS} off
            RewriteCond %{HTTP_HOST} ^${PUBLIC_ALIAS_FQDN}$
            RewriteRule ^/?(.*) https://${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}/$1 [R,L]
+       </IfDefine>
+       <IfDefine STATUS_ALIAS_FQDN>
+           RewriteCond %{HTTPS} off
+           RewriteCond %{HTTP_HOST} ^${STATUS_ALIAS_FQDN}$
+           RewriteRule ^/?(.*) https://${STATUS_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}/$1 [R,L]
        </IfDefine>
     </IfDefine>
 
@@ -609,6 +622,9 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
 <VirtualHost ${PUBLIC_FQDN}:${PUBLIC_HTTPS_PORT}>
     ServerName ${PUBLIC_FQDN}
     ServerAlias 
+    <IfDefine STATUS_ALIAS_FQDN>
+    ServerAlias ${STATUS_ALIAS_FQDN}
+    </IfDefine>
     # Optionally add extra server aliases for current and future use here
     #ServerAlias something. somethingelse.
 
@@ -659,6 +675,12 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
         RewriteLog /var/log/apache2/rewrite.log
         RewriteLogLevel 0
     </IfVersion>
+
+    <IfDefine STATUS_ALIAS_FQDN>
+    # Redirect implict target to status page
+    RewriteCond %{SERVER_NAME} ^${STATUS_ALIAS_FQDN}$
+    RewriteRule ^(/*)$ /status.html [L,R]
+    </IfDefine>
 
     # Break rewriting chain for commonly-requested final destinations
     # * Direct files (including subrequest for /X.py from /wsgi-bin/X.py)
@@ -734,6 +756,9 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
 <IfDefine PUBLIC_ALIAS_FQDN>
 <VirtualHost ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}>
     ServerName ${PUBLIC_ALIAS_FQDN}
+    <IfDefine STATUS_ALIAS_FQDN>
+    ServerAlias ${STATUS_ALIAS_FQDN}
+    </IfDefine>
     # General setup for the virtual host
     DocumentRoot "/home/mig/state/wwwpublic"
     ErrorLog /var/log/apache2/ssl-error.log
@@ -773,6 +798,12 @@ Alias /.well-known/security.txt "/home/mig/state/wwwpublic/.well-known/security.
         RewriteLog /var/log/apache2/rewrite.log
         RewriteLogLevel 0
     </IfVersion>
+
+    <IfDefine STATUS_ALIAS_FQDN>
+    # Redirect implict target to status page
+    RewriteCond %{SERVER_NAME} ^${STATUS_ALIAS_FQDN}$
+    RewriteRule ^(/*)$ /status.html [L,R]
+    </IfDefine>
 
     # Break rewriting chain for commonly-requested final destinations
     # * Internal Aliased helper locations

--- a/tests/fixture/confs-stdlocal/apache2.conf
+++ b/tests/fixture/confs-stdlocal/apache2.conf
@@ -48,6 +48,7 @@ IncludeOptional /etc/apache2/production-mode*.conf
 # Always-on vhosts both for emergency and production mode
 UnDefine PUBLIC_FQDN 
 UnDefine PUBLIC_ALIAS_FQDN 
+UnDefine STATUS_ALIAS_FQDN 
 # User vhosts are ONLY enabled in actual production mode
 <IfDefine PRODUCTION_MODE>
 UnDefine BASE_FQDN 

--- a/tests/fixture/confs-stdlocal/ports.conf
+++ b/tests/fixture/confs-stdlocal/ports.conf
@@ -33,14 +33,14 @@ Listen ${PUBLIC_HTTP_PORT}
     </IfDefine>
     <IfDefine PUBLIC_ALIAS_FQDN>
     <IfDefine PUBLIC_HTTPS_PORT>
-    <IfDefine PRODUCTION_MODE>
     #NameVirtualHost ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
     #Listen ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
     </IfDefine>
-    <IfDefine !PRODUCTION_MODE>
-    # Also force listen on PUBLIC_ALIAS_FQDN here if not in PRODUCTION_MODE
-    Listen ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
     </IfDefine>
+    <IfDefine STATUS_ALIAS_FQDN>
+    <IfDefine PUBLIC_HTTPS_PORT>
+    #NameVirtualHost ${STATUS_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
+    #Listen ${STATUS_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
     </IfDefine>
     </IfDefine>
     <IfDefine MIG_CERT_FQDN>
@@ -68,6 +68,12 @@ Listen ${PUBLIC_HTTP_PORT}
     <IfDefine PUBLIC_HTTPS_PORT>
     #NameVirtualHost ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
     #Listen ${PUBLIC_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
+    </IfDefine>
+    </IfDefine>
+    <IfDefine STATUS_ALIAS_FQDN>
+    <IfDefine PUBLIC_HTTPS_PORT>
+    #NameVirtualHost ${STATUS_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
+    #Listen ${STATUS_ALIAS_FQDN}:${PUBLIC_HTTPS_PORT}
     </IfDefine>
     </IfDefine>
     <IfDefine MIG_CERT_FQDN>


### PR DESCRIPTION
Integrate site status page through a vhost alias like `status.BASE_FQDN` on either `PUBLIC_FQDN` or `PUBLIC_ALIAS_FQDN`.
If set and users request http(s)?://status.BASE_FQDN they will be presented with the contents of `state/wwwpublic/status.html` which if linked to the default `status-dynamic.html` delivers dynamic contents based on the the json status events entries in
`state/wwwpublic/status-events.json`
A basic example and a complete set of actual events are included in the corresponding `state/wwwpublic` folder of the migrid-ucph-sites repo at https://github.com/ucphhpc/migrid-ucph-sites
with an actual deployment visible on
https://status.erda.dk

Includes basic unit test updates to make sure the existing tests complete without errors but no specific tests to further test variations in configuration values, which would of course be nice to have.

Includes minor consistency fixes in the apache ports template.