### PR TITLE
Fix uninitialized fake variable lint error

### DIFF
--- a/tests/support/wsgisupp.py
+++ b/tests/support/wsgisupp.py
@@ -150,7 +150,7 @@ class WsgiAssertMixin:
         try:
             self.assertTrue(called_once(fake_start_response))
         except AssertionError:
-            if len(fake.calls) == 0:
+            if len(fake_start_response.calls) == 0:
                 raise AssertionError("WSGI handler did not respond")
             else:
                 raise AssertionError("WSGI handler responded more than once")


### PR DESCRIPTION
A simple change to at least make lint happy. Please verify if this is indeed the intended behaviour @albu-diku .