### PR TITLE
Add account renewal actions to account page

### DIFF
--- a/mig/cgi-bin/accountaction.py
+++ b/mig/cgi-bin/accountaction.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# accountaction - account action page front end
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# -- END_HEADER ---
+#
+
+from __future__ import absolute_import
+import cgi
+
+from mig.shared.functionality.accountaction import main
+from mig.shared.cgiscriptstub import run_cgi_script_possibly_with_cert
+
+run_cgi_script_possibly_with_cert(main)

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -602,6 +602,64 @@ def account_request_template(configuration, password=True, default_values={}):
     return html
 
 
+def account_pw_change_template(configuration, default_values={}):
+    """A general form template used for changing existing local passwords."""
+
+    html = """
+<div id='account-pw-change-grid' class='form_container'>
+"""
+
+    _logger = configuration.logger
+    auth_map = auth_type_description(configuration)
+    show_auth_types = [(key, auth_map[key]) for key in
+                       default_values.get('show', auth_map.keys())]
+    filtered_auth_types = [i for i in show_auth_types if i[0] in
+                           configuration.site_signup_methods]
+    _logger.debug("show_auth_types %s filtered_auth_types %s" %
+                  (show_auth_types, filtered_auth_types))
+    if not filtered_auth_types:
+        html += """<p class='warningtext'>
+No matching local authentication methods enabled on this site, so no passwords
+to change here. In case you rely on a central or external identity provider you
+can probably also change your password with the corresponding ID provider.
+</p>
+"""
+    else:
+        html += """
+<p>
+Please enter your current password for your %(short_title)s account and then your
+new password of choice twice to confirm correctness.
+</p>
+<!-- use post here to avoid field contents in URL -->
+<form method='%(form_method)s' action='%(target_op)s.py'>
+    <input type='hidden' name='%(csrf_field)s' value='%(csrf_token)s' />
+    <input type='hidden' name='action' value='%(account_action)s'/>
+"""
+        html += """
+    <div class='form-row single-entry'>
+    <div class='col-md-12 mb-3 form-cell'>
+      <label for='curpassword'>Current Password</label>
+      <input type='password' name='curpassword' value='' minlength=6 maxlength=%(password_max_len)d pattern='.{6,%(password_max_len)d}' placeholder='The password you chose for your account' required />
+    </div>
+    <div class='col-md-12 mb-3 form-cell'>
+      <label for='password'>New Password</label>
+      <input type='password' name='password' value='' minlength=%(password_min_len)d maxlength=%(password_max_len)d pattern='.{%(password_min_len)d,%(password_max_len)d}' placeholder='A new strong password of your choice' required />
+    </div>
+    <div class='col-md-12 mb-3 form-cell'>
+      <label for='verifypassword'>Repeat New Password</label>
+      <input type='password' name='verifypassword' value='' minlength=%(password_min_len)d maxlength=%(password_max_len)d pattern='.{%(password_min_len)d,%(password_max_len)d}' placeholder='Your new strong password of choice again' required />
+    </div>
+  </div>
+""" % {'password_min_len': password_min_len, 'password_max_len':
+            password_max_len}
+    html += """
+    <input id='submit_button' type=submit value='Change %(auth_label)s Password'/>
+</form>
+</div>
+"""
+    return html
+
+
 def account_pw_reset_template(configuration, default_values={}):
     """A general form template used for various password reset requests."""
 
@@ -649,6 +707,48 @@ and select which authentication method you want to change password for.
         html += """
     </select>
     <input id='submit_button' type=submit value='Request Password Reset'/>
+</form>
+"""
+
+    html += """
+</div>
+"""
+    return html
+
+
+def renew_account_access_template(configuration, default_values={}):
+    """A general form template used for renewing account access."""
+
+    html = """
+<div id='account-renew-access-grid' class='form_container'>
+"""
+
+    _logger = configuration.logger
+    auth_map = auth_type_description(configuration)
+    show_auth_types = [(key, auth_map[key]) for key in
+                       default_values.get('show', auth_map.keys())]
+    filtered_auth_types = [i for i in show_auth_types if i[0] in
+                           configuration.site_signup_methods]
+    _logger.debug("show_auth_types %s filtered_auth_types %s" %
+                  (show_auth_types, filtered_auth_types))
+    if not filtered_auth_types:
+        html += """<p class='warningtext'>
+No matching local authentication methods enabled on this site, so no account
+access to renew here.
+</p>
+"""
+    else:
+        html += """
+<p>
+Account access automatically expires after a while and needs to be actively
+renewed.
+%(peer_acceptance_notice)s
+</p>
+<!-- use post here to avoid field contents in URL -->
+<form method='%(form_method)s' action='%(target_op)s.py'>
+    <input type='hidden' name='%(csrf_field)s' value='%(csrf_token)s' />
+    <input type='hidden' name='action' value='%(account_action)s'/>
+    <input id='submit_button' type=submit value='Renew %(auth_label)s Account Access'/>
 </form>
 """
 

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -26,12 +26,13 @@
 #
 
 """This module contains various helper contents for the certificate and OpenID
-account request handlers"""
+account request handlers.
+"""
 
 from __future__ import absolute_import
 
-import re
 import os
+import re
 import time
 
 # NOTE: the external iso3166 module is optional and only used if available

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -1250,12 +1250,13 @@ def __auto_add_user_allowed(configuration, user_dict, permit_list):
     is empty.
     """
 
-    if not permit_list:
-        return False
+    match = False
+    if permit_list:
+        match = True
     for (key, val) in permit_list:
         if not re.match(val, user_dict.get(key, 'NO SUCH FIELD')):
             return False
-    return True
+    return match
 
 
 def auto_add_user_allowed_direct(configuration, user_dict):

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -602,64 +602,6 @@ def account_request_template(configuration, password=True, default_values={}):
     return html
 
 
-def account_pw_change_template(configuration, default_values={}):
-    """A general form template used for changing existing local passwords."""
-
-    html = """
-<div id='account-pw-change-grid' class='form_container'>
-"""
-
-    _logger = configuration.logger
-    auth_map = auth_type_description(configuration)
-    show_auth_types = [(key, auth_map[key]) for key in
-                       default_values.get('show', auth_map.keys())]
-    filtered_auth_types = [i for i in show_auth_types if i[0] in
-                           configuration.site_signup_methods]
-    _logger.debug("show_auth_types %s filtered_auth_types %s" %
-                  (show_auth_types, filtered_auth_types))
-    if not filtered_auth_types:
-        html += """<p class='warningtext'>
-No matching local authentication methods enabled on this site, so no passwords
-to change here. In case you rely on a central or external identity provider you
-can probably also change your password with the corresponding ID provider.
-</p>
-"""
-    else:
-        html += """
-<p>
-Please enter your current password for your %(short_title)s account and then your
-new password of choice twice to confirm correctness.
-</p>
-<!-- use post here to avoid field contents in URL -->
-<form method='%(form_method)s' action='%(target_op)s.py'>
-    <input type='hidden' name='%(csrf_field)s' value='%(csrf_token)s' />
-    <input type='hidden' name='action' value='%(account_action)s'/>
-"""
-        html += """
-    <div class='form-row single-entry'>
-    <div class='col-md-12 mb-3 form-cell'>
-      <label for='curpassword'>Current Password</label>
-      <input type='password' name='curpassword' value='' minlength=6 maxlength=%(password_max_len)d pattern='.{6,%(password_max_len)d}' placeholder='The password you chose for your account' required />
-    </div>
-    <div class='col-md-12 mb-3 form-cell'>
-      <label for='password'>New Password</label>
-      <input type='password' name='password' value='' minlength=%(password_min_len)d maxlength=%(password_max_len)d pattern='.{%(password_min_len)d,%(password_max_len)d}' placeholder='A new strong password of your choice' required />
-    </div>
-    <div class='col-md-12 mb-3 form-cell'>
-      <label for='verifypassword'>Repeat New Password</label>
-      <input type='password' name='verifypassword' value='' minlength=%(password_min_len)d maxlength=%(password_max_len)d pattern='.{%(password_min_len)d,%(password_max_len)d}' placeholder='Your new strong password of choice again' required />
-    </div>
-  </div>
-""" % {'password_min_len': password_min_len, 'password_max_len':
-            password_max_len}
-    html += """
-    <input id='submit_button' type=submit value='Change %(auth_label)s Password'/>
-</form>
-</div>
-"""
-    return html
-
-
 def account_pw_reset_template(configuration, default_values={}):
     """A general form template used for various password reset requests."""
 

--- a/mig/shared/functionality/account.py
+++ b/mig/shared/functionality/account.py
@@ -164,7 +164,7 @@ def html_tmpl(configuration, client_id, environ, title_entry):
                          form_method, 'csrf_field': csrf_field,
                          'csrf_token': csrf_token})
     # TODO: extend renew to active ext accounts?
-    if show_local and user_dict.get('status', 'active') == 'temporal':
+    if auth_type in show_local and user_dict.get('status', 'active') == 'temporal':
         fill_helpers['account_action'] = "RENEW_ACCESS"
         fill_helpers['peer_acceptance_notice'] = ""
         if configuration.site_peers_mandatory:

--- a/mig/shared/functionality/account.py
+++ b/mig/shared/functionality/account.py
@@ -34,8 +34,7 @@ import datetime
 import os
 
 from mig.shared import returnvalues
-from mig.shared.accountreq import account_pw_change_template, \
-    renew_account_access_template
+from mig.shared.accountreq import renew_account_access_template
 from mig.shared.defaults import csrf_field, user_home_label
 from mig.shared.functional import validate_input_and_cert
 from mig.shared.handlers import get_csrf_limit, make_csrf_token
@@ -134,8 +133,8 @@ def html_tmpl(configuration, client_id, environ, title_entry):
         </div>
     '''
 
-    # Account management like renew account access and change password for local users
-    # TODO: add delete account support for all accounts?
+    # Account management like renew account access for local users
+    # TODO: add change password and delete account support for all accounts?
     (auth_type_name, auth_flavor) = detect_client_auth(configuration, environ)
     (auth_type, auth_label) = find_auth_type_and_label(configuration,
                                                        auth_type_name,
@@ -164,20 +163,6 @@ def html_tmpl(configuration, client_id, environ, title_entry):
     fill_helpers.update({'target_op': target_op, 'form_method':
                          form_method, 'csrf_field': csrf_field,
                          'csrf_token': csrf_token})
-    if auth_type in show_local and (user_dict.get('password', False) or
-                                    user_dict.get('password_hash', False)):
-        fill_helpers['account_action'] = "CHANGE_PASSWORD"
-        fill_helpers['pwchange_helper'] = account_pw_change_template(
-            configuration, default_values=fill_helpers) % fill_helpers
-
-        # TODO: display when ready
-        html += '''
-            <div class="change-account-pw__header col-12 hidden">
-                <h3>Change Account Password</h3>
-                %(pwchange_helper)s
-            </div>
-        ''' % fill_helpers
-
     # TODO: extend renew to active ext accounts?
     if show_local and user_dict.get('status', 'active') == 'temporal':
         fill_helpers['account_action'] = "RENEW_ACCESS"

--- a/mig/shared/functionality/account.py
+++ b/mig/shared/functionality/account.py
@@ -36,13 +36,13 @@ import os
 from mig.shared import returnvalues
 from mig.shared.accountreq import account_pw_reset_template
 from mig.shared.base import requested_page
-from mig.shared.defaults import csrf_field, user_home_label, AUTH_MIG_OID, \
-    AUTH_MIG_OIDC, AUTH_MIG_CERT, AUTH_EXT_CERT
+from mig.shared.defaults import AUTH_EXT_CERT, AUTH_MIG_CERT, AUTH_MIG_OID, \
+    AUTH_MIG_OIDC, csrf_field, user_home_label
 from mig.shared.functional import validate_input_and_cert
-from mig.shared.init import initialize_main_variables, find_entry
 from mig.shared.handlers import get_csrf_limit, make_csrf_token
 from mig.shared.htmlgen import html_user_messages, man_base_js
 from mig.shared.httpsclient import detect_client_auth
+from mig.shared.init import find_entry, initialize_main_variables
 from mig.shared.output import html_link
 from mig.shared.useradm import get_full_user_map
 

--- a/mig/shared/functionality/account.py
+++ b/mig/shared/functionality/account.py
@@ -36,12 +36,12 @@ import os
 from mig.shared import returnvalues
 from mig.shared.accountreq import account_pw_reset_template
 from mig.shared.base import requested_page
-from mig.shared.defaults import csrf_field, user_home_label, cert_field_order, \
-    AUTH_MIG_OID, AUTH_MIG_OIDC, AUTH_MIG_CERT, AUTH_EXT_CERT
+from mig.shared.defaults import csrf_field, user_home_label, AUTH_MIG_OID, \
+    AUTH_MIG_OIDC, AUTH_MIG_CERT, AUTH_EXT_CERT
 from mig.shared.functional import validate_input_and_cert
 from mig.shared.init import initialize_main_variables, find_entry
 from mig.shared.handlers import get_csrf_limit, make_csrf_token
-from mig.shared.htmlgen import html_user_messages, man_base_html, man_base_js
+from mig.shared.htmlgen import html_user_messages, man_base_js
 from mig.shared.httpsclient import detect_client_auth
 from mig.shared.output import html_link
 from mig.shared.useradm import get_full_user_map

--- a/mig/shared/functionality/account.py
+++ b/mig/shared/functionality/account.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # account - account page with info and account management options
-# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -34,9 +34,16 @@ import datetime
 import os
 
 from mig.shared import returnvalues
+from mig.shared.accountreq import account_pw_reset_template
+from mig.shared.base import requested_page
+from mig.shared.defaults import csrf_field, user_home_label, cert_field_order, \
+    AUTH_MIG_OID, AUTH_MIG_OIDC, AUTH_MIG_CERT, AUTH_EXT_CERT
 from mig.shared.functional import validate_input_and_cert
 from mig.shared.init import initialize_main_variables, find_entry
+from mig.shared.handlers import get_csrf_limit, make_csrf_token
 from mig.shared.htmlgen import html_user_messages, man_base_html, man_base_js
+from mig.shared.httpsclient import detect_client_auth
+from mig.shared.output import html_link
 from mig.shared.useradm import get_full_user_map
 
 _account_field_order = [('full_name', 'Full Name'),
@@ -93,7 +100,7 @@ def html_tmpl(configuration, client_id, environ, title_entry):
         user_token += claim_dump
     fill_helpers = {'short_title': configuration.short_title,
                     'user_msg': user_msg, 'show_user_msg': show_user_msg,
-                    'user_account': user_account,
+                    'home_label': user_home_label, 'user_account': user_account,
                     'user_token': user_token}
 
     html = '''
@@ -129,7 +136,128 @@ def html_tmpl(configuration, client_id, environ, title_entry):
         </div>
     '''
 
-    # TODO: add account management actions
+    # Account management like renew user and change password for local users
+    # TODO: add delete account support for all accounts?
+    (auth_type, auth_flavor) = detect_client_auth(configuration, environ)
+    show_local = [i for i in configuration.site_login_methods
+                  if i.startswith('mig')]
+    html += '''
+        <div id="manage-container" class="row">
+            <div class="manage-page__header col-12">
+                <h2>Manage Account</h2>
+                <p class="sub-title">Depending on your %(short_title)s account
+                type you have access to one or more account management actions
+                below.
+                </p>
+            </div>
+            ''' % fill_helpers
+    if show_local and (user_dict.get('password', False) or
+                       user_dict.get('password_hash', False)):
+        bin_url = requested_page(os.environ).replace('-sid', '-bin')
+        if auth_flavor == AUTH_MIG_OID:
+            migoid_url = os.path.join(os.path.dirname(bin_url), 'reqoid.py')
+            migoid_link = {'object_type': 'link', 'destination': migoid_url,
+                           'text': 'Change %s %s password' %
+                           (configuration.user_mig_oid_title, auth_type)}
+            fill_helpers['pwreset_helper'] = html_link(migoid_link)
+        elif auth_flavor == AUTH_MIG_OIDC:
+            migoidc_url = os.path.join(os.path.dirname(bin_url), 'reqoidc.py')
+            migoidc_link = {'object_type': 'link', 'destination': migoidc_url,
+                            'text': 'Change %s %s password' %
+                            (configuration.user_mig_oidc_title, auth_type)}
+            fill_helpers['pwreset_helper'] = html_link(migoidc_link)
+        elif auth_flavor == AUTH_MIG_CERT:
+            migcert_url = os.path.join(os.path.dirname(bin_url), 'migcert.py')
+            migcert_link = {'object_type': 'link', 'destination': migcert_url,
+                            'text': 'Change %s %s password' %
+                            (configuration.user_mig_cert_title, auth_type)}
+            fill_helpers['pwreset_helper'] = html_link(migcert_link)
+        else:
+            form_method = 'post'
+            csrf_limit = get_csrf_limit(configuration)
+            target_op = 'reqpwresetaction'
+            csrf_token = make_csrf_token(configuration, form_method, target_op,
+                                         client_id, csrf_limit)
+            fill_helpers.update({'target_op': target_op, 'form_method':
+                                 form_method, 'csrf_field': csrf_field,
+                                 'csrf_token': csrf_token, 'cert_id': client_id,
+                                 'show': show_local})
+            fill_helpers['pwreset_helper'] = '''
+            <p>You can reset your password with a reset link sent to your
+                email address above for proof of ownership</p>
+            '''
+            fill_helpers['pwreset_helper'] += account_pw_reset_template(
+                configuration, default_values=fill_helpers) % fill_helpers
+
+        html += '''
+            <div class="resetpw__header col-12">
+                <h3>Password Reset</h3>
+                %(pwreset_helper)s
+            </div>
+    ''' % fill_helpers
+
+    if user_dict.get('status', 'active') == 'temporal':
+        bin_url = requested_page(os.environ).replace('-sid', '-bin')
+        if auth_flavor == AUTH_MIG_OID:
+            migoid_url = os.path.join(os.path.dirname(bin_url), 'reqoid.py')
+            migoid_link = {'object_type': 'link', 'destination': migoid_url,
+                           'text': 'Change %s %s password' %
+                           (configuration.user_mig_oid_title, auth_type)}
+            fill_helpers['pwreset_helper'] = html_link(migoid_link)
+        elif auth_flavor == AUTH_MIG_OIDC:
+            migoidc_url = os.path.join(os.path.dirname(bin_url), 'reqoidc.py')
+            migoidc_link = {'object_type': 'link', 'destination': migoidc_url,
+                            'text': 'Change %s %s password' %
+                            (configuration.user_mig_oidc_title, auth_type)}
+            fill_helpers['pwreset_helper'] = html_link(migoidc_link)
+        elif auth_flavor == AUTH_MIG_CERT:
+            migcert_url = os.path.join(os.path.dirname(bin_url), 'migcert.py')
+            migcert_link = {'object_type': 'link', 'destination': migcert_url,
+                            'text': 'Change %s %s password' %
+                            (configuration.user_mig_cert_title, auth_type)}
+            fill_helpers['pwreset_helper'] = html_link(migcert_link)
+        else:
+            form_method = 'post'
+            csrf_limit = get_csrf_limit(configuration)
+            target_op = 'autocreate'
+            csrf_token = make_csrf_token(configuration, form_method, target_op,
+                                         client_id, csrf_limit)
+            fill_helpers['autorenew_form_prefix'] = '''
+        <form class="autorenew" action="%s.py" method="%s">
+            <input type="hidden" name="%s" value="%s">
+            <input type="hidden" name="accept_terms" value="yes">
+            <input type="hidden" name="peers_full_name" value="%s">
+            <input type="hidden" name="peers_email" value="%s">
+        ''' % (target_op, form_method, csrf_field, csrf_token,
+               user_dict.get('peers_full_name', ''),
+               user_dict.get('peers_email', ''))
+        if auth_flavor == AUTH_EXT_CERT:
+            fill_helpers['autorenew_form_prefix'] += '''
+            <input type="hidden" name="cert_id" value="%s">
+            <input type="hidden" name="email" value="%s">
+            ''' % (client_id, user_dict['email'])
+        fill_helpers['autorenew_form_suffix'] = '''
+            <input type="submit" value="Renew Account Access">
+        </form>
+        '''
+        html += '''
+        <div class="autorenew__header col-12">
+            <h3>Renew Access</h3>
+            <p>
+            Account access automatically expires after a while and needs to be
+            actively renewed. If you had someone appoint you as their peer and
+            that appointment has not yet expired you can renew your access here
+            without further operator or peer contact involvement.
+            </p>
+            %(autorenew_form_prefix)s
+            %(autorenew_form_suffix)s
+        </div>
+        ''' % fill_helpers
+
+    html += '''
+            <div class="col-lg-12 vertical-spacer"></div>
+        </div>
+    '''
 
     return html
 

--- a/mig/shared/functionality/accountaction.py
+++ b/mig/shared/functionality/accountaction.py
@@ -1,0 +1,428 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# accountaction - handle account actions like change pw and renew access
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# -- END_HEADER ---
+#
+
+"""Account actions backend for password change and account renewal."""
+
+from __future__ import absolute_import
+
+import os
+import time
+
+from mig.shared import returnvalues
+from mig.shared.base import is_gdp_user
+from mig.shared.defaults import keyword_auto, AUTH_MIG_CERT, AUTH_MIG_OID, \
+     AUTH_MIG_OIDC #, AUTH_EXT_CERT, AUTH_EXT_OID, AUTH_EXT_OIDC
+from mig.shared.functional import validate_input, REJECT_UNSET
+from mig.shared.gdp.all import ensure_gdp_user
+from mig.shared.griddaemons.https import default_user_abuse_hits, \
+     default_proto_abuse_hits, hit_rate_limit, expire_rate_limit, \
+     validate_auth_attempt
+from mig.shared.handlers import safe_handler, get_csrf_limit
+from mig.shared.htmlgen import themed_styles, themed_scripts
+from mig.shared.httpsclient import detect_client_auth, find_auth_type_and_label
+from mig.shared.init import initialize_main_variables #, find_entry
+#from mig.shared.notification import send_email
+from mig.shared.pwcrypto import make_hash
+from mig.shared.userdb import default_db_path
+from mig.shared.useradm import default_search, search_users, create_user
+
+SUPPORTED_ACTIONS = ["RENEW_ACCESS",
+                     #"CHANGE_PASSWORD"
+                     ]
+
+def allow_renew_access(configuration, client_id, user_dict, auth_flavor):
+    """Helper to check prerequisites for the RENEW_ACCESS requests."""
+    _logger = configuration.logger
+    allow_renew, renew_err = False, 'Not fully implemented, yet'
+    if auth_flavor in (AUTH_MIG_CERT, AUTH_MIG_OID, AUTH_MIG_OIDC):
+        _logger.debug("Account renew for %r is allowed to proceed" % client_id)
+        allow_renew, renew_err = True, ""
+    else:
+        _logger.warning("Account renew for %r with %s auth unsupported" % \
+                       (client_id, auth_flavor))
+        renew_err = "Account access renew refused - invalid auth flavor!"
+    return (allow_renew, renew_err)
+
+
+def renew_access(configuration, client_id, user_dict, auth_flavor):
+    """Helper to actually renew access for the RENEW_ACCESS requests."""
+    _logger = configuration.logger
+    renew_status, renew_err = False, 'Not fully implemented yet'
+    peer_pattern = keyword_auto
+    db_path = default_db_path(configuration)
+    old_expire = user_dict.get('expire', -1)
+    if auth_flavor == AUTH_MIG_CERT:
+        extend_days = configuration.cert_valid_days
+    elif auth_flavor == AUTH_MIG_OID:
+        extend_days = configuration.oid_valid_days
+    elif auth_flavor == AUTH_MIG_OIDC:
+        extend_days = configuration.oidc_valid_days
+    else:
+        extend_days = configuration.generic_valid_days
+    max_extend_secs = extend_days * 24 * 3600
+    new_expire = max(old_expire, time.time() + max_extend_secs)
+    user_dict['expire'] = new_expire
+    try:
+        _logger.info("Renew %(distinguished_name)r with expire at %(expire)d" \
+                     % user_dict)
+        updated = create_user(user_dict, configuration, db_path,
+                              ask_renew=False, default_renew=True,
+                              verify_peer=peer_pattern, auto_create_db=False)
+        if configuration.site_enable_gdp:
+            (gdp_success, msg) = ensure_gdp_user(configuration,
+                                                  "127.0.0.1",
+                                                  user_dict['distinguished_name'])
+            if not gdp_success:
+                raise Exception("Failed to renew GDP user: %s" % msg)
+        renewed_expire = updated.get('expire', -1)
+        _logger.info("Renewed %(distinguished_name)r to expire at %(expire)d" % \
+                    updated)
+        if renewed_expire > old_expire:
+            renew_status, renew_err = True, ""
+        else:
+            renew_err = "Renew could not extend account expire value (no peer?)"
+    except Exception as exc:
+        _logger.warning("Error renewing user %r: %s" % (client_id, exc))
+    
+    # TODO: send email on renew?
+    return (renew_status, renew_err)
+
+
+def allow_change_password(configuration, client_id, user_dict, auth_flavor,
+                    curpassword, password, verifypassword):
+    """Helper to check prerequisites for the CHANGE_PASSWORD requests."""
+    _logger = configuration.logger
+    allow_change, change_err = False, 'Not allowed'
+    saved_password = user_dict['password']
+    saved_password_hash = user_dict.get('password_hash', '')
+    # MiG OpenID users without password recovery have empty
+    # password value and on renew we then leave any saved cert
+    # password alone.
+    # External OpenID users do not provide a password so again any
+    # existing password should be left alone on renewal.
+    # The password_hash field is not guaranteed to exist.
+    if auth_flavor == AUTH_MIG_CERT:
+        if saved_password != curpassword:
+            _logger.warning("reject %r password change - wrong password" % \
+                           client_id)
+            change_err = "Password change refused - password mismatch!"
+            return (allow_change, change_err)
+    elif auth_flavor in (AUTH_MIG_OID, AUTH_MIG_OIDC):
+        if not saved_password_hash:
+            _logger.warning("reject %r password change - no saved hash" % \
+                           client_id)
+            change_err = "Password change refused - password auth disabled!"
+            return (allow_change, change_err)
+
+        curpassword_hash = make_hash(configuration, curpassword)
+        if saved_password_hash != curpassword_hash:
+            _logger.warning("reject %r password change - wrong password" % \
+                           client_id)
+            change_err = "Password change refused - password mismatch!"
+            return (allow_change, change_err)
+    else:
+        _logger.warning("Invalid password change for %r with %s auth" % \
+                       (client_id, auth_flavor))
+        change_err = "Password change refused - invalid auth flavor!"
+        return (allow_change, change_err)
+
+    if password != verifypassword:
+        _logger.warning("Password change for %r rejected with verify diff" % \
+                       client_id)
+        change_err = "Password change refused - password and verify differ!"
+        return (allow_change, change_err)
+
+    _logger.debug("Password change for %r is allowed to proceed" % client_id)
+    allow_change, change_err = True, ""
+    return (allow_change, change_err)
+
+
+def change_password(configuration, client_id, user_dict, auth_flavor,
+                    curpassword, password, verifypassword):
+    """Helper to actually change password for the RENEW_ACCESS requests."""
+    _logger = configuration.logger
+    # TODO: implement
+    change_status, change_err = False, 'Not implemented'
+    # TODO: send email on renew
+    return (change_status, change_err)
+
+
+def signature(configuration):
+    """Signature of the main function"""
+
+    defaults = {
+        'action': REJECT_UNSET,
+        'curpassword': [''],
+        'password': [''],
+        'verifypassword': [''],
+    }
+    return ['text', defaults]
+
+
+def main(client_id, user_arguments_dict, environ=None):
+    """Main function used by front end"""
+
+    if environ is None:
+        environ = os.environ
+    (configuration, logger, output_objects, op_name) = \
+        initialize_main_variables(client_id, op_header=False, op_title=False,
+                                  op_menu=False)
+    # IMPORTANT: no title in init above so we MUST call it immediately here
+    #            or basic styling will break on e.g. the check user result.
+    styles = themed_styles(configuration)
+    scripts = themed_scripts(configuration, logged_in=False)
+    title_entry = {'object_type': 'title',
+                   'text': '%s account action' %
+                   configuration.short_title,
+                   'skipmenu': True, 'style': styles, 'script': scripts}
+    output_objects.append(title_entry)
+    output_objects.append({'object_type': 'header', 'text':
+                           '%s account action' %
+                           configuration.short_title
+                           })
+
+    defaults = signature(configuration)[1]
+    (validate_status, accepted) = validate_input(user_arguments_dict,
+                                                 defaults, output_objects,
+                                                 allow_rejects=False)
+    if not validate_status:
+        # NOTE: 'accepted' is a non-sensitive error string here
+        logger.warning('%s invalid input: %s' % (op_name, accepted))
+        return (accepted, returnvalues.CLIENT_ERROR)
+
+    action = accepted['action'][-1].strip()    
+    curpassword = accepted['curpassword'][-1].strip()
+    password = accepted['password'][-1].strip()
+    verifypassword = accepted['verifypassword'][-1].strip()
+
+    # Seconds to delay next attempt after hitting rate limit
+    if action == "RENEW_ACCESS":
+        delay_retry = 3600
+    elif action == "CHANGE_PASSWORD":
+        delay_retry = 900
+    else:
+        delay_retry = 300
+    scripts['init'] += '''
+function update_reload_counter(cnt, delay) {
+    var remain = (delay - cnt);
+    $("#reload_counter").html(remain.toString());
+    if (cnt >= delay) {
+        /* Load previous page again without re-posting last attempt */
+        location = history.back();
+    } else {
+        setTimeout(function() { update_reload_counter(cnt+1, delay); }, 1000);
+    }
+}
+    '''
+
+    if not safe_handler(configuration, 'post', op_name, client_id,
+                        get_csrf_limit(configuration), accepted):
+        output_objects.append(
+            {'object_type': 'error_text', 'text': '''Only accepting
+CSRF-filtered POST requests to prevent unintended updates'''
+             })
+        return (output_objects, returnvalues.CLIENT_ERROR)
+
+    if action not in SUPPORTED_ACTIONS:
+        output_objects.append({'object_type': 'error_text', 'text':
+                               'Unsupported account action: %r' % action})
+        output_objects.append(
+            {'object_type': 'link', 'destination': 'javascript:history.back();',
+             'class': 'genericbutton', 'text': "Try again"})
+        return (output_objects, returnvalues.CLIENT_ERROR)
+
+    (auth_type_name, auth_flavor) = detect_client_auth(configuration, environ)
+    (auth_type, auth_label) = find_auth_type_and_label(configuration,
+                                                       auth_type_name,
+                                                       auth_flavor)
+    if auth_type not in configuration.site_login_methods:
+        output_objects.append({'object_type': 'error_text', 'text':
+                               'Site does not support %r authentication' %
+                               auth_type_name})
+        output_objects.append(
+            {'object_type': 'link', 'destination': 'javascript:history.back();',
+             'class': 'genericbutton', 'text': "Try again"})
+        return (output_objects, returnvalues.CLIENT_ERROR)
+
+    logger.info('got %s account %s request from %r' % (auth_type_name, action,
+                                                       client_id))
+
+    client_addr = os.environ.get('REMOTE_ADDR', None)
+    tcp_port = int(os.environ.get('REMOTE_PORT', '0'))
+
+    status = returnvalues.OK
+
+    # Rate account action attempts for any client_id from source addr to prevent
+    # excessive requests spamming users or overloading server.
+    # We do so no matter if client_id matches a valid user to prevent disclosure.
+    # Rate limit does not affect action for another ID from same address as
+    # that may be perfectly valid e.g. if behind a shared NAT-gateway.
+    proto = 'https'
+    disconnect, exceeded_rate_limit = False, False
+    # Clean up expired entries in persistent rate limit cache
+    expire_rate_limit(configuration, proto, fail_cache=delay_retry,
+                      expire_delay=delay_retry)
+    if hit_rate_limit(configuration, proto, client_addr, client_id,
+                      max_user_hits=1):
+        exceeded_rate_limit = True
+    # Update rate limits and write to auth log
+    (authorized, disconnect) = validate_auth_attempt(
+        configuration,
+        proto,
+        "accountupdate",
+        client_id,
+        client_addr,
+        tcp_port,
+        secret=curpassword,
+        authtype_enabled=True,
+        modify_account=True,
+        exceeded_rate_limit=exceeded_rate_limit,
+        user_abuse_hits=default_user_abuse_hits,
+        proto_abuse_hits=default_proto_abuse_hits,
+        max_secret_hits=1,
+        skip_notify=True,
+    )
+
+    if exceeded_rate_limit or disconnect:
+        logger.warning('Throttle %s for %s from %s - past rate limit' %
+                       (op_name, client_id, client_addr))
+        # NOTE: we keep actual result in plain text for json extract
+        output_objects.append({'object_type': 'html_form', 'text': '''
+<div class="vertical-spacer"></div>
+<div class="error leftpad errortext">
+'''})
+        output_objects.append({'object_type': 'text', 'text': """
+Invalid input or rate limit exceeded - please wait %d seconds before retrying.
+""" % delay_retry
+                               })
+        output_objects.append({'object_type': 'html_form', 'text': '''
+</div>
+<div class="vertical-spacer"></div>
+<div class="info leftpad">
+Origin will reload automatically in <span id="reload_counter">%d</span> seconds.
+</div>
+</div>
+''' % delay_retry})
+        scripts['ready'] += '''
+    setTimeout(function() { update_reload_counter(1, %d); }, 1000);
+''' % delay_retry
+        return (output_objects, status)
+
+    search_filter = default_search()
+    search_filter['distinguished_name'] = client_id
+    (_, hits) = search_users(search_filter, configuration, keyword_auto, False)
+    # Filter out any gdp project users
+    hits = [i for i in hits if not is_gdp_user(configuration, i[0])]
+    if len(hits) != 1:
+        logger.warning("%d local users unexpectedly matched %r" % (len(hits),
+                                                                   client_id))
+        output_objects.append({
+            'object_type': 'error_text', 'text':
+            """Account action failed with internal error. Please report to
+support if the problem persists.
+            """})
+        status = returnvalues.SYSTEM_ERROR
+        return (output_objects, status)
+
+    logger.debug('handle %s account %s request from %r' % (auth_type_name,
+                                                           action, client_id))
+    (uid, user_dict) = hits[0]
+    if action == "CHANGE_PASSWORD":
+       allowed, err = allow_change_password(configuration, client_id,
+                                            user_dict, auth_flavor,
+                                            curpassword, password,
+                                            verifypassword)
+       if not allowed:
+           output_objects.append(
+               {'object_type': 'error_text', 'text':
+                'Refused account password change: %s' % err})
+           output_objects.append(
+               {'object_type': 'link', 'destination':
+                'javascript:history.back();',
+                'class': 'genericbutton', 'text': "Try again"})
+           return (output_objects, returnvalues.CLIENT_ERROR)
+
+       changed, err = change_password(configuration, client_id, user_dict,
+                                      auth_flavor, curpassword, password,
+                                      verifypassword)
+       if not changed:
+           output_objects.append(
+               {'object_type': 'error_text', 'text':
+                'Failed account password change: %s' % err})
+           output_objects.append(
+               {'object_type': 'link', 'destination':
+                'javascript:history.back();',
+                'class': 'genericbutton', 'text': "Try again"})
+           return (output_objects, returnvalues.CLIENT_ERROR)            
+
+       output_objects.append(
+           {'object_type': 'text', 'text':
+            'Your account password was successfully changed'})
+
+    elif action == "RENEW_ACCESS":
+        allowed, err = allow_renew_access(configuration, client_id,
+                                          user_dict, auth_flavor)
+        if not allowed:
+            output_objects.append(
+                {'object_type': 'error_text', 'text':
+                 'Refused account access renew: %s' % err})
+            output_objects.append(
+                {'object_type': 'link', 'destination':
+                 'javascript:history.back();',
+                 'class': 'genericbutton', 'text': "Try again"})
+            return (output_objects, returnvalues.CLIENT_ERROR)
+
+        renewed, err = renew_access(configuration, client_id, user_dict,
+                                    auth_flavor)
+        if not renewed:
+            output_objects.append(
+                {'object_type': 'error_text', 'text':
+                 'Failed to renew account access: %s' % err})
+            output_objects.append(
+                {'object_type': 'link', 'destination':
+                 'javascript:history.back();',
+                 'class': 'genericbutton', 'text': "Try again"})
+            return (output_objects, returnvalues.CLIENT_ERROR)
+
+        output_objects.append(
+            {'object_type': 'text', 'text':
+                 'Your account access was successfully renewed.'})
+    else:
+            output_objects.append(
+                {'object_type': 'error_text', 'text':
+                 'Unsupported account action: %s' % action})
+            output_objects.append(
+                {'object_type': 'link', 'destination':
+                 'javascript:history.back();',
+                 'class': 'genericbutton', 'text': "Try again"})
+            return (output_objects, returnvalues.CLIENT_ERROR)
+    
+    logger.debug("Account %s %s completed" % (auth_type_name, action))
+    output_objects.append(
+        {'object_type': 'link', 'destination': 'account.py',
+         'class': 'genericbutton', 'text': "Show Account Info"})
+    return (output_objects, status)

--- a/mig/shared/httpsclient.py
+++ b/mig/shared/httpsclient.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # httpsclient - Shared functions for all HTTPS clients
-# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -33,12 +33,12 @@ from __future__ import absolute_import
 import os
 import socket
 
+from mig.shared.base import is_gdp_user, get_xgi_bin, auth_type_description
 from mig.shared.defaults import AUTH_CERTIFICATE, AUTH_OPENID_V2, \
     AUTH_OPENID_CONNECT, AUTH_GENERIC, AUTH_NONE, AUTH_MIG_OID, AUTH_EXT_OID, \
     AUTH_MIG_OIDC, AUTH_EXT_OIDC, AUTH_MIG_CERT, AUTH_EXT_CERT, \
     AUTH_SID_GENERIC, AUTH_UNKNOWN, auth_openid_mig_db, auth_openid_ext_db, \
     keyword_all, csrf_field
-from mig.shared.base import is_gdp_user, get_xgi_bin
 from mig.shared.gdp.all import get_project_user_dn
 from mig.shared.handlers import get_csrf_limit
 from mig.shared.pwcrypto import make_csrf_token, make_csrf_trust_token
@@ -418,6 +418,21 @@ def extract_client_id(configuration, environ, lookup_dn=True):
         # Fall back to use certificate value in any case
         distinguished_name = extract_client_cert(configuration, environ)
     return distinguished_name
+
+
+def find_auth_type_and_label(configuration, auth_type_name, auth_flavor):
+    """Use contents of auth_type_description and auth_flavor to lookup actual
+    simple auth_type (migoid, extcert, ...) and corresponding descritpive label
+    for that auth_type.
+    """
+    rev_auth_flavor_map = {AUTH_EXT_OID: 'extoid', AUTH_EXT_OIDC: 'extoidc',
+                           AUTH_MIG_OID: 'migoid', AUTH_MIG_OIDC: 'migoidc',
+                           AUTH_EXT_CERT: 'extcert', AUTH_MIG_CERT: 'migcert',
+                           AUTH_UNKNOWN: 'unknown'}
+    auth_type = rev_auth_flavor_map[auth_flavor]
+    auth_map = auth_type_description(configuration)
+    auth_label = auth_map[auth_type]
+    return (auth_type, auth_label)
 
 
 def require_twofactor_setup(configuration, script_name, client_id, environ):


### PR DESCRIPTION
Add account renewal actions to account page as originally attempted in PR #168.
Postpone the password change and account delete action which although nice has less imminent value compared to the development effort.