### PR TITLE
Hyphens in test names result in them not being discovered; rename to avoid.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
 # migrid core dependencies on a format suitable for pip install as described on
 # https://pip.pypa.io/en/stable/reference/requirement-specifiers/
 future
+
+# cgi was removed from the standard library in Python 3.13
+legacy-cgi;python_version >= "3.13"
+
 # NOTE: python-3.6 and earlier versions require older pyotp, whereas 3.7+
 #       should work with any modern version. We tested 2.9.0 to work.
 pyotp;python_version >= "3.7"

--- a/tests/support/snapshotsupp.py
+++ b/tests/support/snapshotsupp.py
@@ -27,6 +27,7 @@
 """Test support code for the use of snapshots in tests."""
 
 import difflib
+import errno
 import re
 import os
 
@@ -36,8 +37,9 @@ TEST_SNAPSHOTS_DIR = os.path.join(TEST_BASE, "snapshots")
 
 try:
     os.mkdir(TEST_SNAPSHOTS_DIR)
-except FileExistsError:
-    pass
+except OSError as direxc:
+    if direxc.errno != errno.EEXIST:  # FileExistsError
+        raise
 
 
 def _delimited_lines(value):

--- a/tests/test_mig_wsgibin.py
+++ b/tests/test_mig_wsgibin.py
@@ -109,13 +109,13 @@ class TitleExtractingHtmlParser(DocumentBasicsHtmlParser):
             self._title = args[0]
 
     def handle_starttag(self, tag, attrs):
-        super().handle_starttag(tag, attrs)
+        DocumentBasicsHtmlParser.handle_starttag(self, tag, attrs)
 
         if tag == 'title':
             self._within_title = True
 
     def handle_endtag(self, tag):
-        super().handle_endtag(tag)
+        DocumentBasicsHtmlParser.handle_endtag(self, tag)
 
         if tag == 'title':
             self._within_title = False


### PR DESCRIPTION
Due to this test having been disabled a couple of things that it would have
brought to our attention were missed and are additionally fixed here:
* cgi has been removed from Python 3.13+

To remain compatible with PY2:
* phrase the super calls in a way that appeasaes the old version
* late FileNotExistsError addition that needs to be errno on OSError