### PR TITLE
Extend snapshotting support to allow capturing the content only output.

### DIFF
--- a/tests/snapshots/test_objects_with_type_text.html
+++ b/tests/snapshots/test_objects_with_type_text.html
@@ -1,0 +1,1 @@
+<p>some text</p>

--- a/tests/test_mig_wsgibin.py
+++ b/tests/test_mig_wsgibin.py
@@ -241,7 +241,7 @@ class MigWsgibin(MigTestCase, SnapshotAssertMixin, WsgiAssertMixin):
         self.assertSnapshot(output, extension='html')
 
 
-class MigWsgibin_output_objects(MigTestCase, WsgiAssertMixin):
+class MigWsgibin_output_objects(MigTestCase, WsgiAssertMixin, SnapshotAssertMixin):
 
     def _provide_configuration(self):
         return 'testconfig'
@@ -280,6 +280,28 @@ class MigWsgibin_output_objects(MigTestCase, WsgiAssertMixin):
 
         output, _ = self.assertWsgiResponse(wsgi_result, self.fake_wsgi, 200)
         self.assertIsValidHtmlDocument(output)
+
+    def test_objects_with_type_text(self):
+        output_objects = [
+            # workaround invalid HTML being generated with no title object
+            {
+                'object_type': 'title',
+                'text': 'TEST'
+            },
+            {
+                'object_type': 'text',
+                'text': 'some text',
+            }
+        ]
+        self.fake_backend.set_response(output_objects, returnvalues.OK)
+
+        wsgi_result = migwsgi.application(
+            *self.application_args,
+            **self.application_kwargs
+        )
+
+        output, _ = self.assertWsgiResponse(wsgi_result, self.fake_wsgi, 200)
+        self.assertSnapshotOfHtmlContent(output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Ever so slightly move the already existing comment markers that surround the content so they surround _only_ pure content - then add a new assertion to the snapshot support code that reads these and captures only what is between them.

In this way we allow excluding the boilerplate header/footer for a given test and capture output object specific content.

cc @rasmunk 