### PR TITLE
Generalize the `validate_auth_attempt` helper signature and call slightly

### DIFF
--- a/mig/shared/functionality/reqpwresetaction.py
+++ b/mig/shared/functionality/reqpwresetaction.py
@@ -138,7 +138,6 @@ Please contact the %s providers if you want to reset your associated password.
              'class': 'genericbutton', 'text': "Back"})
         return (output_objects, returnvalues.CLIENT_ERROR)
 
-    os.environ.get('USER', 'mig')
     client_addr = os.environ.get('REMOTE_ADDR', None)
     tcp_port = int(os.environ.get('REMOTE_PORT', '0'))
     anon_migoid_url = configuration.migserver_https_sid_url
@@ -208,7 +207,7 @@ Origin will reload automatically in <span id="reload_counter">%d</span> seconds.
         # Registered emails are automatically lowercased
         search_filter['email'] = cert_id.lower()
     (_, hits) = search_users(search_filter, configuration, keyword_auto, False)
-    user_dict, _password_hash = None, None
+    user_dict = None
     for (uid, user_dict) in hits:
         if is_gdp_user(configuration, uid):
             logger.debug("skip password reset for gdp sub-user %r" % cert_id)

--- a/mig/shared/functionality/reqpwresetaction.py
+++ b/mig/shared/functionality/reqpwresetaction.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # reqpwresetaction - handle account password reset requests and send email to user
-# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -165,13 +165,13 @@ Please contact the %s providers if you want to reset your associated password.
     (authorized, disconnect) = validate_auth_attempt(
         configuration,
         proto,
-        op_name,
+        "passwordreset",
         cert_id,
         client_addr,
         tcp_port,
         secret=None,
         authtype_enabled=True,
-        auth_reset=True,
+        modify_account=True,
         exceeded_rate_limit=exceeded_rate_limit,
         user_abuse_hits=default_user_abuse_hits,
         proto_abuse_hits=default_proto_abuse_hits,

--- a/mig/shared/functionality/reqpwresetaction.py
+++ b/mig/shared/functionality/reqpwresetaction.py
@@ -30,21 +30,18 @@
 from __future__ import absolute_import
 
 import os
-import tempfile
-import time
 
 from mig.shared import returnvalues
-from mig.shared.base import canonical_user_with_peers, generate_https_urls, \
-    fill_distinguished_name, cert_field_map, auth_type_description, \
-    mask_creds, is_gdp_user
-from mig.shared.defaults import keyword_auto, RESET_TOKEN_TTL
-from mig.shared.functional import validate_input, REJECT_UNSET
-from mig.shared.griddaemons.https import default_max_user_hits, \
-    default_user_abuse_hits, default_proto_abuse_hits, hit_rate_limit, \
-    expire_rate_limit, validate_auth_attempt
-from mig.shared.handlers import safe_handler, get_csrf_limit
-from mig.shared.htmlgen import themed_styles, themed_scripts
-from mig.shared.init import initialize_main_variables, find_entry
+from mig.shared.base import auth_type_description, canonical_user_with_peers, \
+    cert_field_map, is_gdp_user, mask_creds
+from mig.shared.defaults import RESET_TOKEN_TTL, keyword_auto
+from mig.shared.functional import REJECT_UNSET, validate_input
+from mig.shared.griddaemons.https import default_proto_abuse_hits, \
+    default_user_abuse_hits, expire_rate_limit, hit_rate_limit, \
+    validate_auth_attempt
+from mig.shared.handlers import get_csrf_limit, safe_handler
+from mig.shared.htmlgen import themed_scripts, themed_styles
+from mig.shared.init import initialize_main_variables
 from mig.shared.notification import send_email
 from mig.shared.pwcrypto import generate_reset_token
 from mig.shared.url import urlencode
@@ -125,7 +122,7 @@ CSRF-filtered POST requests to prevent unintended updates'''
              'class': 'genericbutton', 'text': "Try again"})
         return (output_objects, returnvalues.CLIENT_ERROR)
 
-    if not auth_type in configuration.site_login_methods:
+    if auth_type not in configuration.site_login_methods:
         output_objects.append({'object_type': 'error_text', 'text':
                                'You must provide a supported auth_type!'})
         output_objects.append(
@@ -141,7 +138,7 @@ Please contact the %s providers if you want to reset your associated password.
              'class': 'genericbutton', 'text': "Back"})
         return (output_objects, returnvalues.CLIENT_ERROR)
 
-    mig_user = os.environ.get('USER', 'mig')
+    os.environ.get('USER', 'mig')
     client_addr = os.environ.get('REMOTE_ADDR', None)
     tcp_port = int(os.environ.get('REMOTE_PORT', '0'))
     anon_migoid_url = configuration.migserver_https_sid_url
@@ -211,7 +208,7 @@ Origin will reload automatically in <span id="reload_counter">%d</span> seconds.
         # Registered emails are automatically lowercased
         search_filter['email'] = cert_id.lower()
     (_, hits) = search_users(search_filter, configuration, keyword_auto, False)
-    user_dict, password_hash = None, None
+    user_dict, _password_hash = None, None
     for (uid, user_dict) in hits:
         if is_gdp_user(configuration, uid):
             logger.debug("skip password reset for gdp sub-user %r" % cert_id)
@@ -227,7 +224,7 @@ Origin will reload automatically in <span id="reload_counter">%d</span> seconds.
         try:
             reset_token = generate_reset_token(configuration, user_dict,
                                                auth_type)
-        except ValueError as vae:
+        except ValueError:
             logger.info("skip password reset for %r without matching auth" %
                         cert_id)
             continue

--- a/mig/shared/griddaemons/auth.py
+++ b/mig/shared/griddaemons/auth.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # auth - grid daemon auth helper functions
-# Copyright (C) 2010-2024  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -187,7 +187,7 @@ def validate_auth_attempt(configuration,
                           valid_twofa=False,
                           authtype_enabled=False,
                           valid_auth=False,
-                          auth_reset=False,
+                          modify_account=False,
                           exceeded_rate_limit=False,
                           exceeded_max_sessions=False,
                           user_abuse_hits=default_user_abuse_hits,
@@ -229,8 +229,8 @@ def validate_auth_attempt(configuration,
                  % valid_twofa
                  + "authtype_enabled: %s, valid_auth: %s\n"
                  % (authtype_enabled, valid_auth)
-                 + "auth_reset: %s\n"
-                 % auth_reset
+                 + "modify_account: %s\n"
+                 % modify_account
                  + "exceeded_rate_limit: %s\n"
                  % exceeded_rate_limit
                  + "exceeded_max_sessions: %s\n"
@@ -268,7 +268,7 @@ def validate_auth_attempt(configuration,
                  or authtype in ["session"]):
         pass
     elif protocol == 'https' \
-            and authtype in ["twofactor", "reqpwresetaction"]:
+            and authtype in ["twofactor", "passwordreset", "accountupdate"]:
         pass
     elif protocol == 'openid' \
             and authtype in configuration.user_openid_auth:
@@ -395,8 +395,8 @@ mandatory two factor session was closed or expired.
         authlog(configuration, 'WARNING', protocol, authtype,
                 username, ip_addr, auth_msg,
                 notify=notify, hint=mount_hint)
-    elif authtype_enabled and auth_reset:
-        # IMPORTANT: leave unauthorized here to enforce rate limit on resets
+    elif authtype_enabled and modify_account:
+        # IMPORTANT: leave unauthorized here for rate limit on resets and renew
         authorized = False
         auth_msg = "Allow %s" % authtype
         log_msg = auth_msg + " for %s from %s" % (username, ip_addr)

--- a/mig/shared/griddaemons/auth.py
+++ b/mig/shared/griddaemons/auth.py
@@ -27,15 +27,15 @@
 
 """ MiG daemon auth functions"""
 
-import time
 import re
+import time
 
 from mig.shared.auth import active_twofactor_session
-from mig.shared.base import extract_field, expand_openid_alias
+from mig.shared.base import expand_openid_alias, extract_field
 from mig.shared.defaults import CRACK_USERNAME_REGEX, protocol_aliases
 from mig.shared.gdp.all import get_client_id_from_project_client_id
-from mig.shared.griddaemons.ratelimits import default_user_abuse_hits, \
-    default_proto_abuse_hits, default_max_secret_hits, update_rate_limit
+from mig.shared.griddaemons.ratelimits import default_max_secret_hits, \
+    default_proto_abuse_hits, default_user_abuse_hits, update_rate_limit
 from mig.shared.griddaemons.sessions import active_sessions
 from mig.shared.notification import send_system_notification
 from mig.shared.settings import load_twofactor
@@ -273,7 +273,7 @@ def validate_auth_attempt(configuration,
     elif protocol == 'openid' \
             and authtype in configuration.user_openid_auth:
         pass
-    elif not protocol in ['davs', 'ftps', 'sftp', 'sftp-subsys', 'https',
+    elif protocol not in ['davs', 'ftps', 'sftp', 'sftp-subsys', 'https',
                           'openid']:
         logger.error("Invalid protocol: %r" % protocol)
         return (authorized, disconnect)


### PR DESCRIPTION
Adjust the `validate_auth_attempt` helper signature and call slightly in preparation for reuse in the new account action backend. Namely pass a telling value for `authtype` in reset password helper and rename the `auth_reset` variable to `modify_account` in order to fit both password reset and future account modification actions like renew account and change password.