### PR TITLE
Fix the routing of migcert password reset requests

### DIFF
--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # accountreq - helpers for certificate/OpenID account requests
-# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -602,7 +602,7 @@ def account_request_template(configuration, password=True, default_values={}):
 
 
 def account_pw_reset_template(configuration, default_values={}):
-    """A general form template used for various password reset requests"""
+    """A general form template used for various password reset requests."""
 
     html = """
 <div id='account-pw-reset-grid' class='form_container'>
@@ -633,7 +633,7 @@ and select which authentication method you want to change password for.
 <form method='%(form_method)s' action='%(target_op)s.py'>
     <input type='hidden' name='%(csrf_field)s' value='%(csrf_token)s' />
     <!-- NOTE: cert_id field to allow either full DN or email -->
-    <input type='text' name='cert_id' required />
+    <input type='text' name='cert_id' value='%(cert_id)s' required />
     <select class='form-control themed-select html-select' id='reset_auth_type'
         name='auth_type' minlength=3 maxlength=4
         placeholder='The kind of authentication for which to reset password'

--- a/mig/shared/functionality/reqpwreset.py
+++ b/mig/shared/functionality/reqpwreset.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # reqpwreset - Account password reset request backend
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -135,16 +135,16 @@ def main(client_id, user_arguments_dict, environ=None):
                             (configuration.user_mig_oid_title, auth_type)}
             output_objects.append(migoidc_link)
         elif auth_flavor == AUTH_MIG_CERT:
-            extcert_url = os.path.join(os.path.dirname(bin_url), 'extcert.py')
-            extcert_link = {'object_type': 'link', 'destination': extcert_url,
+            migcert_url = os.path.join(os.path.dirname(bin_url), 'migcert.py')
+            migcert_link = {'object_type': 'link', 'destination': migcert_url,
                             'text': 'Change %s %s password' %
                             (configuration.user_mig_cert_title, auth_type)}
-            output_objects.append(extcert_link)
+            output_objects.append(migcert_link)
     else:
         form_method = 'post'
         csrf_limit = get_csrf_limit(configuration)
         fill_helpers = {'form_method': form_method, 'csrf_field': csrf_field,
-                        'csrf_limit': csrf_limit,
+                        'csrf_limit': csrf_limit, 'cert_id': '',
                         'short_title': configuration.short_title}
         target_op = "reqpwresetaction"
         csrf_token = make_csrf_token(configuration, form_method, target_op,


### PR DESCRIPTION
Fix the routing of migcert password reset requests to really use internal certificate signup form and not the extcert one.