### PR TITLE
Adjust central auth policy for IO services a bit

### DIFF
--- a/mig/shared/griddaemons/auth.py
+++ b/mig/shared/griddaemons/auth.py
@@ -316,6 +316,7 @@ to avoid exceeding this limit.""" % (configuration.short_title, max_sessions,
                 username, ip_addr, auth_msg,
                 notify=notify, hint=session_hint)
     elif invalid_username:
+        # Drop as this is publicly known to be an invalid user
         disconnect = True
         if re.match(CRACK_USERNAME_REGEX, username) is not None:
             auth_msg = "Crack username detected"
@@ -332,7 +333,8 @@ to avoid exceeding this limit.""" % (configuration.short_title, max_sessions,
         authlog(configuration, authlog_lvl, protocol, authtype,
                 username, ip_addr, auth_msg, notify=notify)
     elif invalid_user:
-        disconnect = True
+        # Do not indirectly give away information about user non-existence
+        disconnect = False
         auth_msg = "Invalid user"
         log_msg = auth_msg + " %s from %s" % (username, ip_addr)
         if tcp_port > 0:


### PR DESCRIPTION
Adjust auth policy a bit to avoid giving away information about the existence or non-existence of accounts with valid account usernames.
Follow up to PR206+208.