### PR TITLE
A basic janitor service to handle recurring tasks like clean up and cache updates

### DIFF
--- a/mig/install/MiGserver-template.conf
+++ b/mig/install/MiGserver-template.conf
@@ -645,6 +645,8 @@ enable_notify = __ENABLE_NOTIFY__
 enable_imnotify = __ENABLE_IMNOTIFY__
 # Enable users to schedule tasks with a cron/at-like interface
 enable_crontab = __ENABLE_CRONTAB__
+# Enable janitor servide to handel recurring tasks like clean up and cache updates
+enable_janitor = __ENABLE_JANITOR__
 # Enable 2FA for web access and IO services with any TOTP authenticator client
 # IMPORTANT: Do NOT change this option manually here (requires Apache changes)!
 #       use generateconfs.py --enable_twofactor=True|False

--- a/mig/install/migrid-init.d-deb-template
+++ b/mig/install/migrid-init.d-deb-template
@@ -51,6 +51,7 @@ MIG_MONITOR=${MIG_CODE}/server/grid_monitor.py
 MIG_SSHMUX=${MIG_CODE}/server/grid_sshmux.py
 MIG_EVENTS=${MIG_CODE}/server/grid_events.py
 MIG_CRON=${MIG_CODE}/server/grid_cron.py
+MIG_JANITOR=${MIG_CODE}/server/grid_janitor.py
 MIG_TRANSFERS=${MIG_CODE}/server/grid_transfers.py
 MIG_OPENID=${MIG_CODE}/server/grid_openid.py
 MIG_SFTP=${MIG_CODE}/server/grid_sftp.py
@@ -67,7 +68,7 @@ MIG_CHKSIDROOT=${MIG_CODE}/server/chksidroot.py
 show_usage() {
     echo "Usage: migrid {start|stop|status|restart|reload}[daemon DAEMON]"
     echo "where daemon is left out for all or given along with DAEMON as one of the following"
-    echo "(script|monitor|sshmux|events|cron|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)"
+    echo "(script|monitor|sshmux|events|cron|janitor|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)"
 }
 
 check_enabled() {
@@ -148,6 +149,19 @@ start_cron() {
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     # NOTE: cron jobs can be quite heavy so we lower sched prio a bit
     log_daemon_msg "Starting MiG cron daemon" ${SHORT_NAME} || true
+    if start-stop-daemon --start --quiet --oknodo --pidfile ${PID_FILE} --make-pidfile --user ${MIG_USER} --chuid ${MIG_USER} --nicelevel 10 --background --name ${SHORT_NAME} --startas ${DAEMON_PATH} ; then
+	log_end_msg 0 || true
+    else
+	log_end_msg 1 || true
+    fi
+}
+start_janitor() {
+    check_enabled "janitor" || return 0
+    DAEMON_PATH=${MIG_JANITOR}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    # NOTE: janitor tasks can be quite heavy so we lower sched prio a bit
+    log_daemon_msg "Starting MiG janitor daemon" ${SHORT_NAME} || true
     if start-stop-daemon --start --quiet --oknodo --pidfile ${PID_FILE} --make-pidfile --user ${MIG_USER} --chuid ${MIG_USER} --nicelevel 10 --background --name ${SHORT_NAME} --startas ${DAEMON_PATH} ; then
 	log_end_msg 0 || true
     else
@@ -267,6 +281,7 @@ start_all() {
     start_sshmux
     start_events
     start_cron
+    start_janitor
     start_transfers
     start_openid
     start_sftp
@@ -358,6 +373,28 @@ stop_cron() {
     SHORT_NAME=$(basename ${DAEMON_PATH})
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     log_daemon_msg "Stopping MiG cron" ${SHORT_NAME} || true
+    # Try graceful shutdown so that state is properly saved
+    start-stop-daemon --stop --signal INT --quiet --oknodo --pidfile ${PID_FILE}
+    for delay in 1 2 3; do
+	status_of_proc -p ${PID_FILE} ${DAEMON_PATH} ${SHORT_NAME} || break
+	sleep $delay
+    done
+    # Force kill if still running
+    status_of_proc -p ${PID_FILE} ${DAEMON_PATH} ${SHORT_NAME} && \
+	start-stop-daemon --stop --quiet --oknodo --pidfile ${PID_FILE}
+    if ! status_of_proc -p ${PID_FILE} ${DAEMON_PATH} ${SHORT_NAME}; then
+	rm -f ${PID_FILE}
+	log_end_msg 0 || true
+    else
+	log_end_msg 1 || true
+    fi
+}
+stop_janitor() {
+    check_enabled "janitor" || return 0
+    DAEMON_PATH=${MIG_JANITOR}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    log_daemon_msg "Stopping MiG janitor" ${SHORT_NAME} || true
     # Try graceful shutdown so that state is properly saved
     start-stop-daemon --stop --signal INT --quiet --oknodo --pidfile ${PID_FILE}
     for delay in 1 2 3; do
@@ -515,6 +552,7 @@ stop_all() {
     stop_sshmux
     stop_events
     stop_cron
+    stop_janitor
     stop_transfers
     stop_openid
     stop_sftp
@@ -583,6 +621,18 @@ reload_cron() {
     SHORT_NAME=$(basename ${DAEMON_PATH})
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     log_daemon_msg "Reloading MiG cron" ${SHORT_NAME} || true
+    if start-stop-daemon --stop --signal HUP --quiet --oknodo --pidfile ${PID_FILE} ; then
+	log_end_msg 0 || true
+    else
+	log_end_msg 1 || true
+    fi
+}
+reload_janitor() {
+    check_enabled "janitor" || return 0
+    DAEMON_PATH=${MIG_JANITOR}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    log_daemon_msg "Reloading MiG janitor" ${SHORT_NAME} || true
     if start-stop-daemon --stop --signal HUP --quiet --oknodo --pidfile ${PID_FILE} ; then
 	log_end_msg 0 || true
     else
@@ -726,6 +776,7 @@ reload_all() {
     reload_sshmux
     reload_events
     reload_cron
+    reload_janitor
     reload_transfers
     reload_openid
     reload_sftp
@@ -773,6 +824,13 @@ status_events() {
 status_cron() {
     check_enabled "crontab" || return 0
     DAEMON_PATH=${MIG_CRON}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    status_of_proc -p ${PID_FILE} ${DAEMON_PATH} ${SHORT_NAME}
+}
+status_janitor() {
+    check_enabled "janitor" || return 0
+    DAEMON_PATH=${MIG_JANITOR}
     SHORT_NAME=$(basename ${DAEMON_PATH})
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     status_of_proc -p ${PID_FILE} ${DAEMON_PATH} ${SHORT_NAME}
@@ -852,6 +910,7 @@ status_all() {
     status_sshmux
     status_events
     status_cron
+    status_janitor
     status_transfers
     status_openid
     status_sftp
@@ -873,7 +932,7 @@ test -f ${MIG_SCRIPT} || exit 0
 
 # Force valid target
 case "$2" in
-    script|monitor|sshmux|events|cron|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)
+    script|monitor|sshmux|events|cron|janitor|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)
         TARGET="$2"
 	;;
     '')

--- a/mig/install/migrid-init.d-rh-template
+++ b/mig/install/migrid-init.d-rh-template
@@ -26,6 +26,7 @@
 # processname: grid_sshmux.py
 # processname: grid_events.py
 # processname: grid_cron.py
+# processname: grid_janitor.py
 # processname: grid_transfers.py
 # processname: grid_openid.py
 # processname: grid_sftp.py
@@ -81,6 +82,7 @@ MIG_MONITOR=${MIG_CODE}/server/grid_monitor.py
 MIG_SSHMUX=${MIG_CODE}/server/grid_sshmux.py
 MIG_EVENTS=${MIG_CODE}/server/grid_events.py
 MIG_CRON=${MIG_CODE}/server/grid_cron.py
+MIG_JANITOR=${MIG_CODE}/server/grid_janitor.py
 MIG_TRANSFERS=${MIG_CODE}/server/grid_transfers.py
 MIG_OPENID=${MIG_CODE}/server/grid_openid.py
 MIG_SFTP=${MIG_CODE}/server/grid_sftp.py
@@ -97,7 +99,7 @@ MIG_CHKSIDROOT=${MIG_CODE}/server/chksidroot.py
 show_usage() {
     echo "Usage: migrid {start|stop|status|restart|reload}[daemon DAEMON]"
     echo "where daemon is left out for all or given along with DAEMON as one of the following"
-    echo "(script|monitor|sshmux|events|cron|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)"
+    echo "(script|monitor|sshmux|events|cron|janitor|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)"
 }
 
 check_enabled() {
@@ -213,6 +215,22 @@ start_cron() {
     [ $RET2 ] && success
     echo
     [ $RET2 ] || echo "Warning: cron not started."
+    echo
+}
+start_janitor() {
+    check_enabled "janitor" || return
+    DAEMON_PATH=${MIG_JANITOR}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    # NOTE: janitor tasks can be quite heavy so we lower sched prio a bit
+    echo -n "Starting MiG janitor daemon: $SHORT_NAME"
+    daemon +10 --user ${MIG_USER} --pidfile ${PID_FILE} \
+	   "${DAEMON_PATH} >> ${MIG_LOG}/janitor.out 2>&1 &"
+    fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
+    RET2=$?
+    [ $RET2 ] && success
+    echo
+    [ $RET2 ] || echo "Warning: janitor not started."
     echo
 }
 start_transfers() {
@@ -356,6 +374,7 @@ start_all() {
     start_sshmux
     start_events
     start_cron
+    start_janitor
     start_transfers
     start_openid
     start_sftp
@@ -423,6 +442,21 @@ stop_cron() {
     SHORT_NAME=$(basename ${DAEMON_PATH})
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     echo -n "Shutting down MiG cron: $SHORT_NAME "
+    # Try graceful shutdown so that state is properly saved
+    killproc ${DAEMON_PATH} -INT
+    for delay in 1 2 3; do
+        status ${DAEMON_PATH} || break
+        sleep $delay
+    done
+    echo
+    status ${DAEMON_PATH} && killproc ${DAEMON_PATH}
+}
+stop_janitor() {
+    check_enabled "janitor" || return
+    DAEMON_PATH=${MIG_JANITOR}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    echo -n "Shutting down MiG janitor: $SHORT_NAME "
     # Try graceful shutdown so that state is properly saved
     killproc ${DAEMON_PATH} -INT
     for delay in 1 2 3; do
@@ -538,6 +572,7 @@ stop_all() {
     stop_sshmux
     stop_events
     stop_cron
+    stop_janitor
     stop_transfers
     stop_openid
     stop_sftp
@@ -593,6 +628,15 @@ reload_cron() {
     SHORT_NAME=$(basename ${DAEMON_PATH})
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     echo -n "Reloading MiG cron: $SHORT_NAME "
+    killproc ${DAEMON_PATH} -HUP
+    echo
+}
+reload_janitor() {
+    check_enabled "janitor" || return
+    DAEMON_PATH=${MIG_JANITOR}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    echo -n "Reloading MiG janitor: $SHORT_NAME "
     killproc ${DAEMON_PATH} -HUP
     echo
 }
@@ -709,6 +753,7 @@ reload_all() {
     reload_sshmux
     reload_events
     reload_cron
+    reload_janitor
     reload_transfers
     reload_openid
     reload_sftp
@@ -756,6 +801,13 @@ status_events() {
 status_cron() {
     check_enabled "crontab" || return
     DAEMON_PATH=${MIG_CRON}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    status ${DAEMON_PATH}
+}
+status_janitor() {
+    check_enabled "janitor" || return
+    DAEMON_PATH=${MIG_JANITOR}
     SHORT_NAME=$(basename ${DAEMON_PATH})
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     status ${DAEMON_PATH}
@@ -835,6 +887,7 @@ status_all() {
     status_sshmux
     status_events
     status_cron
+    status_janitor
     status_transfers
     status_openid
     status_sftp
@@ -856,7 +909,7 @@ test -f ${MIG_SCRIPT} || exit 0
 
 # Force valid target
 case "$2" in
-    script|monitor|sshmux|events|cron|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)
+    script|monitor|sshmux|events|cron|janitor|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)
         TARGET="$2"
 	;;
     '')

--- a/mig/server/grid_janitor.py
+++ b/mig/server/grid_janitor.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# grid_janitor - daemon to handle recurring tasks like clean up and updates
+# Copyright (C) 2003-2025  The MiG Project lead by Brian Vinter
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# -- END_HEADER ---
+#
+
+"""Daemon to take care of various recurring tasks like clean up, cache updates
+and pruning of pending requests.
+"""
+
+from __future__ import absolute_import, print_function
+
+import multiprocessing
+import os
+import signal
+import sys
+import time
+
+from mig.shared.conf import get_configuration_object
+from mig.shared.logger import daemon_logger, register_hangup_handler
+
+stop_running = multiprocessing.Event()
+(configuration, logger) = (None, None)
+
+
+def stop_handler(sig, frame):
+    """A simple signal handler to quit on Ctrl+C (SIGINT) in main"""
+    # Print blank line to avoid mix with Ctrl-C line
+    print("")
+    stop_running.set()
+
+
+if __name__ == "__main__":
+    # Force no log init since we use separate logger
+    configuration = get_configuration_object(skip_log=True)
+
+    log_level = configuration.loglevel
+    if sys.argv[1:] and sys.argv[1] in ["debug", "info", "warning", "error"]:
+        log_level = sys.argv[1]
+
+    # Use separate logger
+
+    logger = daemon_logger("janitor", configuration.user_janitor_log, log_level)
+    configuration.logger = logger
+
+    # Allow e.g. logrotate to force log re-open after rotates
+    register_hangup_handler(configuration)
+
+    # Allow clean shutdown on SIGINT only to main process
+    signal.signal(signal.SIGINT, stop_handler)
+
+    if not configuration.site_enable_janitor:
+        err_msg = "Janitor support is disabled in configuration!"
+        logger.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    print(
+        """This is the MiG janitor daemon which cleans up stale state data,
+updates internal caches and prunes pending requests.
+
+Set the MIG_CONF environment to the server configuration path
+unless it is available in mig/server/MiGserver.conf
+"""
+    )
+
+    main_pid = os.getpid()
+    print("Starting janitor daemon - Ctrl-C to quit")
+    logger.info("(%s) Starting Janitor daemon" % main_pid)
+
+    logger.debug("(%s) Starting main loop" % main_pid)
+    print("%s: Start main loop" % os.getpid())
+    while not stop_running.is_set():
+        try:
+            time.sleep(1)
+        except KeyboardInterrupt:
+            stop_running.set()
+            # NOTE: we can't be sure if SIGINT was sent to only main process
+            #       so we make sure to propagate to monitor child
+            print("Interrupt requested - shutdown")
+        except Exception as exc:
+            logger.error(
+                "(%s) Caught unexpected exception: %s" % (os.getpid(), exc)
+            )
+
+    print("Janitor daemon shutting down")
+    logger.info("(%s) Janitor daemon shutting down" % main_pid)
+
+    sys.exit(0)

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -303,6 +303,7 @@ def fix_missing(config_file, verbose=True):
         'user_vmproxy_log': 'vmproxy.log',
         'user_events_log': 'events.log',
         'user_cron_log': 'cron.log',
+        'user_janitor_log': 'janitor.log',
         'user_transfers_log': 'transfers.log',
         'user_notify_log': 'notify.log',
         'user_auth_log': 'auth.log',
@@ -561,6 +562,7 @@ _CONFIGURATION_DEFAULTS = {
     'user_vmproxy_log': 'vmproxy.log',
     'user_events_log': 'events.log',
     'user_cron_log': 'cron.log',
+    'user_janitor_log': 'janitor.log',
     'user_transfers_log': 'transfers.log',
     'user_notify_log': 'notify.log',
     'user_auth_log': 'auth.log',
@@ -1407,6 +1409,13 @@ location.""" % self.config_file)
             self.site_enable_crontab = False
         if config.has_option('GLOBAL', 'user_cron_log'):
             self.user_cron_log = config.get('GLOBAL', 'user_cron_log')
+        if config.has_option('SITE', 'enable_janitor'):
+            self.site_enable_janitor = config.getboolean(
+                'SITE', 'enable_janitor')
+        else:
+            self.site_enable_janitor = False
+        if config.has_option('GLOBAL', 'user_janitor_log'):
+            self.user_janitor_log = config.get('GLOBAL', 'user_janitor_log')
         if config.has_option('SITE', 'enable_notify'):
             self.site_enable_notify = config.getboolean(
                 'SITE', 'enable_notify')
@@ -2558,10 +2567,10 @@ location.""" % self.config_file)
                          'user_openid_log', 'user_monitor_log',
                          'user_sshmux_log', 'user_vmproxy_log',
                          'user_events_log', 'user_cron_log',
-                         'user_transfers_log', 'user_notify_log',
-                         'user_imnotify_log', 'user_auth_log',
-                         'user_chkuserroot_log', 'user_chksidroot_log',
-                         'user_quota_log'):
+                         'user_janitor_log', 'user_transfers_log',
+                         'user_notify_log', 'user_imnotify_log',
+                         'user_auth_log', 'user_chkuserroot_log',
+                         'user_chksidroot_log', 'user_quota_log'):
             _log_path = getattr(self, _log_var)
             if not os.path.isabs(_log_path):
                 setattr(self, _log_var, os.path.join(self.log_dir, _log_path))

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -365,6 +365,7 @@ def generate_confs(
     enable_seafile=False,
     enable_duplicati=False,
     enable_crontab=True,
+    enable_janitor=False,
     enable_notify=False,
     enable_imnotify=False,
     enable_dev_accounts=False,
@@ -687,6 +688,7 @@ def _generate_confs_prepare(
     enable_seafile,
     enable_duplicati,
     enable_crontab,
+    enable_janitor,
     enable_notify,
     enable_imnotify,
     enable_dev_accounts,
@@ -941,6 +943,7 @@ def _generate_confs_prepare(
     user_dict['__ENABLE_SEAFILE__'] = "%s" % enable_seafile
     user_dict['__ENABLE_DUPLICATI__'] = "%s" % enable_duplicati
     user_dict['__ENABLE_CRONTAB__'] = "%s" % enable_crontab
+    user_dict['__ENABLE_JANITOR__'] = "%s" % enable_janitor
     user_dict['__ENABLE_NOTIFY__'] = "%s" % enable_notify
     user_dict['__ENABLE_IMNOTIFY__'] = "%s" % enable_imnotify
     user_dict['__ENABLE_DEV_ACCOUNTS__'] = "%s" % enable_dev_accounts
@@ -1734,7 +1737,7 @@ cert, oid and sid based https!
     else:
         user_dict['__APACHE_SUFFIX__'] = ""
 
-    # Helpers for the migstatecleanup cron job
+    # Helpers for the migstatecleanup cron job or janitor service
     user_dict['__CRON_VERBOSE_CLEANUP__'] = '1'
     user_dict['__CRON_EVENT_CLEANUP__'] = '1'
     if 'migoid' in signup_methods or 'migcert' in signup_methods:
@@ -2473,6 +2476,7 @@ You can install them with:
 chmod 755 %(destination)s/mig{stateclean,errors,sftpmon,importdoi,notifyexpire}
 sudo cp %(destination)s/mig{stateclean,errors,sftpmon,importdoi,notifyexpire} \\
         /etc/cron.daily/
+until the janitor service is ready to take care of those tasks.
 
 The migcheckssl, migverifyarchives and migacctexpire files are cron scripts to
 automatically check for LetsEncrypt certificate renewal, run pending archive

--- a/tests/fixture/confs-stdlocal/MiGserver.conf
+++ b/tests/fixture/confs-stdlocal/MiGserver.conf
@@ -645,6 +645,8 @@ enable_notify = False
 enable_imnotify = False
 # Enable users to schedule tasks with a cron/at-like interface
 enable_crontab = True
+# Enable janitor servide to handel recurring tasks like clean up and cache updates
+enable_janitor = False
 # Enable 2FA for web access and IO services with any TOTP authenticator client
 # IMPORTANT: Do NOT change this option manually here (requires Apache changes)!
 #       use generateconfs.py --enable_twofactor=True|False

--- a/tests/fixture/confs-stdlocal/migrid-init.d-deb
+++ b/tests/fixture/confs-stdlocal/migrid-init.d-deb
@@ -51,6 +51,7 @@ MIG_MONITOR=${MIG_CODE}/server/grid_monitor.py
 MIG_SSHMUX=${MIG_CODE}/server/grid_sshmux.py
 MIG_EVENTS=${MIG_CODE}/server/grid_events.py
 MIG_CRON=${MIG_CODE}/server/grid_cron.py
+MIG_JANITOR=${MIG_CODE}/server/grid_janitor.py
 MIG_TRANSFERS=${MIG_CODE}/server/grid_transfers.py
 MIG_OPENID=${MIG_CODE}/server/grid_openid.py
 MIG_SFTP=${MIG_CODE}/server/grid_sftp.py
@@ -67,7 +68,7 @@ MIG_CHKSIDROOT=${MIG_CODE}/server/chksidroot.py
 show_usage() {
     echo "Usage: migrid {start|stop|status|restart|reload}[daemon DAEMON]"
     echo "where daemon is left out for all or given along with DAEMON as one of the following"
-    echo "(script|monitor|sshmux|events|cron|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)"
+    echo "(script|monitor|sshmux|events|cron|janitor|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)"
 }
 
 check_enabled() {
@@ -148,6 +149,19 @@ start_cron() {
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     # NOTE: cron jobs can be quite heavy so we lower sched prio a bit
     log_daemon_msg "Starting MiG cron daemon" ${SHORT_NAME} || true
+    if start-stop-daemon --start --quiet --oknodo --pidfile ${PID_FILE} --make-pidfile --user ${MIG_USER} --chuid ${MIG_USER} --nicelevel 10 --background --name ${SHORT_NAME} --startas ${DAEMON_PATH} ; then
+	log_end_msg 0 || true
+    else
+	log_end_msg 1 || true
+    fi
+}
+start_janitor() {
+    check_enabled "janitor" || return 0
+    DAEMON_PATH=${MIG_JANITOR}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    # NOTE: janitor tasks can be quite heavy so we lower sched prio a bit
+    log_daemon_msg "Starting MiG janitor daemon" ${SHORT_NAME} || true
     if start-stop-daemon --start --quiet --oknodo --pidfile ${PID_FILE} --make-pidfile --user ${MIG_USER} --chuid ${MIG_USER} --nicelevel 10 --background --name ${SHORT_NAME} --startas ${DAEMON_PATH} ; then
 	log_end_msg 0 || true
     else
@@ -267,6 +281,7 @@ start_all() {
     start_sshmux
     start_events
     start_cron
+    start_janitor
     start_transfers
     start_openid
     start_sftp
@@ -358,6 +373,28 @@ stop_cron() {
     SHORT_NAME=$(basename ${DAEMON_PATH})
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     log_daemon_msg "Stopping MiG cron" ${SHORT_NAME} || true
+    # Try graceful shutdown so that state is properly saved
+    start-stop-daemon --stop --signal INT --quiet --oknodo --pidfile ${PID_FILE}
+    for delay in 1 2 3; do
+	status_of_proc -p ${PID_FILE} ${DAEMON_PATH} ${SHORT_NAME} || break
+	sleep $delay
+    done
+    # Force kill if still running
+    status_of_proc -p ${PID_FILE} ${DAEMON_PATH} ${SHORT_NAME} && \
+	start-stop-daemon --stop --quiet --oknodo --pidfile ${PID_FILE}
+    if ! status_of_proc -p ${PID_FILE} ${DAEMON_PATH} ${SHORT_NAME}; then
+	rm -f ${PID_FILE}
+	log_end_msg 0 || true
+    else
+	log_end_msg 1 || true
+    fi
+}
+stop_janitor() {
+    check_enabled "janitor" || return 0
+    DAEMON_PATH=${MIG_JANITOR}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    log_daemon_msg "Stopping MiG janitor" ${SHORT_NAME} || true
     # Try graceful shutdown so that state is properly saved
     start-stop-daemon --stop --signal INT --quiet --oknodo --pidfile ${PID_FILE}
     for delay in 1 2 3; do
@@ -515,6 +552,7 @@ stop_all() {
     stop_sshmux
     stop_events
     stop_cron
+    stop_janitor
     stop_transfers
     stop_openid
     stop_sftp
@@ -583,6 +621,18 @@ reload_cron() {
     SHORT_NAME=$(basename ${DAEMON_PATH})
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     log_daemon_msg "Reloading MiG cron" ${SHORT_NAME} || true
+    if start-stop-daemon --stop --signal HUP --quiet --oknodo --pidfile ${PID_FILE} ; then
+	log_end_msg 0 || true
+    else
+	log_end_msg 1 || true
+    fi
+}
+reload_janitor() {
+    check_enabled "janitor" || return 0
+    DAEMON_PATH=${MIG_JANITOR}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    log_daemon_msg "Reloading MiG janitor" ${SHORT_NAME} || true
     if start-stop-daemon --stop --signal HUP --quiet --oknodo --pidfile ${PID_FILE} ; then
 	log_end_msg 0 || true
     else
@@ -726,6 +776,7 @@ reload_all() {
     reload_sshmux
     reload_events
     reload_cron
+    reload_janitor
     reload_transfers
     reload_openid
     reload_sftp
@@ -773,6 +824,13 @@ status_events() {
 status_cron() {
     check_enabled "crontab" || return 0
     DAEMON_PATH=${MIG_CRON}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    status_of_proc -p ${PID_FILE} ${DAEMON_PATH} ${SHORT_NAME}
+}
+status_janitor() {
+    check_enabled "janitor" || return 0
+    DAEMON_PATH=${MIG_JANITOR}
     SHORT_NAME=$(basename ${DAEMON_PATH})
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     status_of_proc -p ${PID_FILE} ${DAEMON_PATH} ${SHORT_NAME}
@@ -852,6 +910,7 @@ status_all() {
     status_sshmux
     status_events
     status_cron
+    status_janitor
     status_transfers
     status_openid
     status_sftp
@@ -873,7 +932,7 @@ test -f ${MIG_SCRIPT} || exit 0
 
 # Force valid target
 case "$2" in
-    script|monitor|sshmux|events|cron|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)
+    script|monitor|sshmux|events|cron|janitor|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)
         TARGET="$2"
 	;;
     '')

--- a/tests/fixture/confs-stdlocal/migrid-init.d-rh
+++ b/tests/fixture/confs-stdlocal/migrid-init.d-rh
@@ -26,6 +26,7 @@
 # processname: grid_sshmux.py
 # processname: grid_events.py
 # processname: grid_cron.py
+# processname: grid_janitor.py
 # processname: grid_transfers.py
 # processname: grid_openid.py
 # processname: grid_sftp.py
@@ -81,6 +82,7 @@ MIG_MONITOR=${MIG_CODE}/server/grid_monitor.py
 MIG_SSHMUX=${MIG_CODE}/server/grid_sshmux.py
 MIG_EVENTS=${MIG_CODE}/server/grid_events.py
 MIG_CRON=${MIG_CODE}/server/grid_cron.py
+MIG_JANITOR=${MIG_CODE}/server/grid_janitor.py
 MIG_TRANSFERS=${MIG_CODE}/server/grid_transfers.py
 MIG_OPENID=${MIG_CODE}/server/grid_openid.py
 MIG_SFTP=${MIG_CODE}/server/grid_sftp.py
@@ -97,7 +99,7 @@ MIG_CHKSIDROOT=${MIG_CODE}/server/chksidroot.py
 show_usage() {
     echo "Usage: migrid {start|stop|status|restart|reload}[daemon DAEMON]"
     echo "where daemon is left out for all or given along with DAEMON as one of the following"
-    echo "(script|monitor|sshmux|events|cron|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)"
+    echo "(script|monitor|sshmux|events|cron|janitor|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)"
 }
 
 check_enabled() {
@@ -213,6 +215,22 @@ start_cron() {
     [ $RET2 ] && success
     echo
     [ $RET2 ] || echo "Warning: cron not started."
+    echo
+}
+start_janitor() {
+    check_enabled "janitor" || return
+    DAEMON_PATH=${MIG_JANITOR}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    # NOTE: janitor tasks can be quite heavy so we lower sched prio a bit
+    echo -n "Starting MiG janitor daemon: $SHORT_NAME"
+    daemon +10 --user ${MIG_USER} --pidfile ${PID_FILE} \
+	   "${DAEMON_PATH} >> ${MIG_LOG}/janitor.out 2>&1 &"
+    fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
+    RET2=$?
+    [ $RET2 ] && success
+    echo
+    [ $RET2 ] || echo "Warning: janitor not started."
     echo
 }
 start_transfers() {
@@ -356,6 +374,7 @@ start_all() {
     start_sshmux
     start_events
     start_cron
+    start_janitor
     start_transfers
     start_openid
     start_sftp
@@ -423,6 +442,21 @@ stop_cron() {
     SHORT_NAME=$(basename ${DAEMON_PATH})
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     echo -n "Shutting down MiG cron: $SHORT_NAME "
+    # Try graceful shutdown so that state is properly saved
+    killproc ${DAEMON_PATH} -INT
+    for delay in 1 2 3; do
+        status ${DAEMON_PATH} || break
+        sleep $delay
+    done
+    echo
+    status ${DAEMON_PATH} && killproc ${DAEMON_PATH}
+}
+stop_janitor() {
+    check_enabled "janitor" || return
+    DAEMON_PATH=${MIG_JANITOR}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    echo -n "Shutting down MiG janitor: $SHORT_NAME "
     # Try graceful shutdown so that state is properly saved
     killproc ${DAEMON_PATH} -INT
     for delay in 1 2 3; do
@@ -538,6 +572,7 @@ stop_all() {
     stop_sshmux
     stop_events
     stop_cron
+    stop_janitor
     stop_transfers
     stop_openid
     stop_sftp
@@ -593,6 +628,15 @@ reload_cron() {
     SHORT_NAME=$(basename ${DAEMON_PATH})
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     echo -n "Reloading MiG cron: $SHORT_NAME "
+    killproc ${DAEMON_PATH} -HUP
+    echo
+}
+reload_janitor() {
+    check_enabled "janitor" || return
+    DAEMON_PATH=${MIG_JANITOR}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    echo -n "Reloading MiG janitor: $SHORT_NAME "
     killproc ${DAEMON_PATH} -HUP
     echo
 }
@@ -709,6 +753,7 @@ reload_all() {
     reload_sshmux
     reload_events
     reload_cron
+    reload_janitor
     reload_transfers
     reload_openid
     reload_sftp
@@ -756,6 +801,13 @@ status_events() {
 status_cron() {
     check_enabled "crontab" || return
     DAEMON_PATH=${MIG_CRON}
+    SHORT_NAME=$(basename ${DAEMON_PATH})
+    PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
+    status ${DAEMON_PATH}
+}
+status_janitor() {
+    check_enabled "janitor" || return
+    DAEMON_PATH=${MIG_JANITOR}
     SHORT_NAME=$(basename ${DAEMON_PATH})
     PID_FILE="$PID_DIR/${SHORT_NAME}.pid"
     status ${DAEMON_PATH}
@@ -835,6 +887,7 @@ status_all() {
     status_sshmux
     status_events
     status_cron
+    status_janitor
     status_transfers
     status_openid
     status_sftp
@@ -856,7 +909,7 @@ test -f ${MIG_SCRIPT} || exit 0
 
 # Force valid target
 case "$2" in
-    script|monitor|sshmux|events|cron|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)
+    script|monitor|sshmux|events|cron|janitor|transfers|openid|sftp|sftpsubsys|webdavs|ftps|notify|imnotify|vmproxy|all)
         TARGET="$2"
 	;;
     '')

--- a/tests/fixture/mig_shared_configuration--new.json
+++ b/tests/fixture/mig_shared_configuration--new.json
@@ -581,6 +581,7 @@
     "V2",
     "V3"
   ],
+  "user_janitor_log": "janitor.log",
   "user_messages": "",
   "user_mig_cert_title": "",
   "user_mig_oid_provider": "",


### PR DESCRIPTION
This is a skeleton so far only implementing the basic service with configuration support and service handling in init scripts.

Pending transfer of actual clean up tasks from cron jobs, cache updates from client-triggered vgrid cache updates and implementation of pruning of pending requests.

The service goals are outlined in the associated milestone.