### PR TITLE
Changes static text to reflect it belongs to DeiC Storage

### DIFF
--- a/state/wwwpublic/.well-known/security-disclosure-policy-erda.dk.txt
+++ b/state/wwwpublic/.well-known/security-disclosure-policy-erda.dk.txt
@@ -7,11 +7,10 @@ security monitoring as well as the national DK-Cert monitoring. So we
 do NOT have a bug/vulnerability reward program. Yet, we are of course
 grateful for any bug or security reports, which might improve our
 services or prevent abuse.
-
-If you disclose a bug/vulnerability of value, we will make sure
-to mention your contribution in our release notes, when possible.
-We develop the underlying platform as Free Software, so actual
-mentions will be available for everyone online to see.
+If you report such a bug/vulnerability of significance, we will make
+sure to accredit your contribution in our corresponding release notes.
+We develop the underlying platform as Free and Open Source Software,
+so such mentions will be available for everyone online to see.
 
 Like e.g. Google we do NOT consider the presence of version
 information a security vulnerability in itself. Flaws affecting only

--- a/state/wwwpublic/.well-known/security-disclosure-policy-erda.dk.txt
+++ b/state/wwwpublic/.well-known/security-disclosure-policy-erda.dk.txt
@@ -8,6 +8,11 @@ do NOT have a bug/vulnerability reward program. Yet, we are of course
 grateful for any bug or security reports, which might improve our
 services or prevent abuse.
 
+If you disclose a bug/vulnerability of value, we will make sure
+to mention your contribution in our release notes, when possible.
+We develop the underlying platform as Free Software, so actual
+mentions will be available for everyone online to see.
+
 Like e.g. Google we do NOT consider the presence of version
 information a security vulnerability in itself. Flaws affecting only
 users of out-of-date browsers and software are similarly of limited

--- a/state/wwwpublic/.well-known/security-disclosure-policy-migrid.org.txt
+++ b/state/wwwpublic/.well-known/security-disclosure-policy-migrid.org.txt
@@ -7,11 +7,10 @@ security monitoring as well as the national DK-Cert monitoring. So we
 do NOT have a bug/vulnerability reward program. Yet, we are of course
 grateful for any bug or security reports, which might improve our
 services or prevent abuse.
-
-If you disclose a bug/vulnerability of value, we will make sure
-to mention your contribution in our release notes, when possible.
-We develop the underlying platform as Free Software, so actual
-mentions will be available for everyone online to see.
+If you report such a bug/vulnerability of significance, we will make
+sure to accredit your contribution in our corresponding release notes.
+We develop the underlying platform as Free and Open Source Software,
+so such mentions will be available for everyone online to see.
 
 Like e.g. Google we do NOT consider the presence of version
 information a security vulnerability in itself. Flaws affecting only

--- a/state/wwwpublic/.well-known/security-disclosure-policy-migrid.org.txt
+++ b/state/wwwpublic/.well-known/security-disclosure-policy-migrid.org.txt
@@ -8,6 +8,11 @@ do NOT have a bug/vulnerability reward program. Yet, we are of course
 grateful for any bug or security reports, which might improve our
 services or prevent abuse.
 
+If you disclose a bug/vulnerability of value, we will make sure
+to mention your contribution in our release notes, when possible.
+We develop the underlying platform as Free Software, so actual
+mentions will be available for everyone online to see.
+
 Like e.g. Google we do NOT consider the presence of version
 information a security vulnerability in itself. Flaws affecting only
 users of out-of-date browsers and software are similarly of limited

--- a/state/wwwpublic/.well-known/security-disclosure-policy-sif.erda.dk.txt
+++ b/state/wwwpublic/.well-known/security-disclosure-policy-sif.erda.dk.txt
@@ -7,11 +7,10 @@ security monitoring as well as the national DK-Cert monitoring. So we
 do NOT have a bug/vulnerability reward program. Yet, we are of course
 grateful for any bug or security reports, which might improve our
 services or prevent abuse.
-
-If you disclose a bug/vulnerability of value, we will make sure
-to mention your contribution in our release notes, when possible.
-We develop the underlying platform as Free Software, so actual
-mentions will be available for everyone online to see.
+If you report such a bug/vulnerability of significance, we will make
+sure to accredit your contribution in our corresponding release notes.
+We develop the underlying platform as Free and Open Source Software,
+so such mentions will be available for everyone online to see.
 
 Like e.g. Google we do NOT consider the presence of version
 information a security vulnerability in itself. Flaws affecting only

--- a/state/wwwpublic/.well-known/security-disclosure-policy-sif.erda.dk.txt
+++ b/state/wwwpublic/.well-known/security-disclosure-policy-sif.erda.dk.txt
@@ -8,6 +8,11 @@ do NOT have a bug/vulnerability reward program. Yet, we are of course
 grateful for any bug or security reports, which might improve our
 services or prevent abuse.
 
+If you disclose a bug/vulnerability of value, we will make sure
+to mention your contribution in our release notes, when possible.
+We develop the underlying platform as Free Software, so actual
+mentions will be available for everyone online to see.
+
 Like e.g. Google we do NOT consider the presence of version
 information a security vulnerability in itself. Flaws affecting only
 users of out-of-date browsers and software are similarly of limited

--- a/state/wwwpublic/terms-storage.deic.dk.html
+++ b/state/wwwpublic/terms-storage.deic.dk.html
@@ -161,7 +161,7 @@
                     </p>
                     <p>
                         We may choose to review public content for compliance with our community
-                        guidelines, but you acknowledge that DeiC Storage has no obligationElectronic Research Data Archive to
+                        guidelines, but you acknowledge that DeiC Storage has no obligation to
                         monitor any information on the Services. We are not responsible for the
                         accuracy, completeness, appropriateness, or legality of files, user
                         posts, or any other information you may be able to access using the

--- a/state/wwwpublic/terms-storage.deic.dk.html
+++ b/state/wwwpublic/terms-storage.deic.dk.html
@@ -75,7 +75,7 @@
                 <img src="/images/skin/deic-basic/banner-logo.jpg" id="logoimagecenter"
                      class="staticpage" alt="site logo center"/>
                 <span id="logotitle" class="staticpage">
-                    Electronic Research Data Archive
+                    DeiC Storage
                 </span>
             </div>
             <div id="toplogoright" class="staticpage">
@@ -140,8 +140,8 @@
                         technically administer our Services, for example, how we redundantly
                         backup data to keep it safe. You give us the permissions we need to do
                         those things solely to provide the Services. This permission also
-                        extends to any trusted third parties at UCPH we work with to provide the Services,
-                        for example University IT, which provides our UCPH OpenID login (again, only to
+                        extends to any trusted third parties at DeiC Storage we work with to provide the Services,
+                        for example University IT, which provides our WAYF login (again, only to
                         provide the Services).
                     </p>
                     <p>
@@ -161,7 +161,7 @@
                     </p>
                     <p>
                         We may choose to review public content for compliance with our community
-                        guidelines, but you acknowledge that DeiC Storage has no obligation to
+                        guidelines, but you acknowledge that DeiC Storage has no obligationElectronic Research Data Archive to
                         monitor any information on the Services. We are not responsible for the
                         accuracy, completeness, appropriateness, or legality of files, user
                         posts, or any other information you may be able to access using the
@@ -293,7 +293,7 @@
                 <div id="copyright">
                     <img src="/images/copyright.png" id="creditsimage" alt=""/>
                     <span id="credits">
-                        2003-2021, <a href="https://www.migrid.org">The MiG Project</a>
+                        2003-2025, <a href="https://www.migrid.org">The MiG Project</a>
                     </span>
                 </div>
             </div>

--- a/state/wwwpublic/tips-storage.deic.dk.html
+++ b/state/wwwpublic/tips-storage.deic.dk.html
@@ -122,7 +122,7 @@
                     </div>
 
                     <div class="tips-entries accordion col-lg-12">
-                        <div class="tips-entry">
+                        <!-- NOT-IN-DEIC-STORAGE-SOLUTIONS div class="tips-entry">
                             <h4 class="staticpage">New User Interface</h4>
                             <p>
                                 Did you know that you can test-drive the new modernized DeiC Storage user
@@ -131,7 +131,7 @@
                                 interface by changing User Interface from V2 to V3 or vice versa
                                 on your <a href="settings.py" target="_blank">Settings</a>.
                             </p>
-                        </div>
+                        </div -->
                         <div class="tips-entry">
                             <h4 class="staticpage">2-Factor Authentication (2FA)</h4>
                             <p>
@@ -145,7 +145,7 @@
                                 wizard.
                             </p>
                         </div>
-                        <div class="tips-entry">
+                        <!-- AWATING-METADATA-SERVICE-DATAVERSE div class="tips-entry">
                             <h4 class="staticpage">Digital Object Identifiers (DOIs) for your Data</h4>
                             <p>
                                 Are you aware of the
@@ -162,7 +162,7 @@
                                 <a href="/public/ucph-erda-user-guide.pdf">user guide</a> for more
                                 details.
                             </p>
-                        </div>
+                        </div -->
                         <div class="tips-entry">
                             <h4 class="staticpage">Custom Start Page</h4>
                             <p>
@@ -217,7 +217,7 @@
                                 details.
                             </p>
                         </div>
-                        <div class="tips-entry">
+                        <!-- AWAITING-COMPUTE-INTEGRATION div class="tips-entry">
                             <h4 class="staticpage">Easy Data Analysis and Presentation</h4>
                             <p>
                                 Why worry about having the right tools for your data analysis and
@@ -233,8 +233,8 @@
                                 Please refer to the
                                 <a href="/public/ucph-erda-user-guide.pdf">user guide</a> for details.
                             </p>
-                        </div>
-                        <div class="tips-entry">
+                        </div -->
+                        <!-- SEAFILE-NOT-AVAILABLE div class="tips-entry">
                             <h4 class="staticpage">Cloud File Sync like Dropdox, OneDrive, etc.</h4>
                             <p>
                                 Do you miss the synchronization features from Dropbox and similar to
@@ -251,7 +251,7 @@
                                 <a href="/public/ucph-erda-user-guide.pdf">user guide</a> for further
                                 details.
                             </p>
-                        </div>
+                        </div -->
                         <div class="tips-entry">
                             <h4 class="staticpage">Data Distribution with Import Sharelink</h4>
                             <p>
@@ -265,7 +265,7 @@
                                 convenient for Jupyter notebooks to be used in exercises.
                             </p>
                         </div>
-                        <div class="tips-entry">
+                        <!-- EXTERNAL-PEERS-HANDLED-DIFFERENTLY div class="tips-entry">
                             <h4 class="staticpage">External User Accounts with Peers</h4>
                             <p>
                                 What if you want to invite externals onto DeiC Storage for collaboration or
@@ -285,19 +285,19 @@
                                 if needed, however. Peers can similarly be used to preserve access for
                                 your former colleagues if you need it for continued collaboration.
                             </p>
-                        </div>
+                        </div -->
                         <div class="tips-entry">
                             <h4 class="staticpage">YubiKey For Multifactor Authentication</h4>
                             <p>
                                 Can I use a YubiKey security device for stronger and safer
                                 authentication?
-                                UCPH generally recommends securing your logins with MFA and offer
+                                It generally recommends securing your logins with MFA and offer
                                 employees e.g. the small keyring-format hardware security keys from
                                 Yubico for the purpose. 
                                 You might want to have a word with your local leader about perhaps
                                 getting one if you haven't done so already. It can be used for various
-                                common UCPH services and we offer basic support for it on DeiC Storage
-                                and SIF, too. For now you can use it along with the 
+                                common IT services and we offer basic support for it on DeiC Storage
+                                and DeiC Sensitive Storage, too. For now you can use it along with the 
                                 <a href="https://www.yubico.com/products/yubico-authenticator/">Yubico 
                                 Authenticator app</a> to actually get a 3-factor authentication. 
                                 Namely, your usual user credentials, your physical YubiKey and the
@@ -331,15 +331,17 @@
 
                     <div class="tips-entries accordion col-lg-12">
                         <div class="tips-entry">
-                            <h4 class="staticpage">Ny brugergrænseflade</h4>
+                            <h4 class="staticpage">2-faktor godkendelse (2FA)</h4>
                             <p>
-                                Vidste du at du kan prøvekøre DeiC Storages nye moderniserede
-                                brugergrænseflade?
-                                Du kan nemt skifte mellem den traditionelle - og den nye
-                                brugergrænseflade ved at skifte User Interface fra V2 til V3 eller
-                                omvendt på din <a href="settings.py" target="_blank">Settings</a>.
+                                Bekymrer du dig om sikkerheden på din konto hos DeiC Storage? DeiC Storage tilbyder valgfri
+                                2FA på alle tjenester. Dette reducerer risikoen for misbrug af kontoen betragteligt.
+                                Selv i tilfælde, hvor nogen har opsnappet dit kodeord. Grundet generelle sikkerhedsovervejelser,
+                                og nylig øgning af phishing-angreb, så anbefaler vi at slå 2FA til. Det sker ved at følge
+                                en kort guide til
+                                <a href="setup.py?topic=twofactor" target="_blank">opsætning af 2-faktor godkendelse</a>.
                             </p>
                         </div>
+
                         <!-- TODO: translate the other English tips -->
 
                         <!-- TODO: add more tips like

--- a/state/wwwpublic/tips-storage.deic.dk.html
+++ b/state/wwwpublic/tips-storage.deic.dk.html
@@ -333,7 +333,8 @@
                         <div class="tips-entry">
                             <h4 class="staticpage">2-faktor godkendelse (2FA)</h4>
                             <p>
-                                Bekymrer du dig om sikkerheden på din konto hos DeiC Storage? DeiC Storage tilbyder valgfri
+                                De fleste organisationer tilbyder multifaktorgodkendelse til WAYF-login. 
+                                Ønsker du yderligere sikkerhed på din konto hos DeiC Storage? DeiC Storage tilbyder valgfri
                                 2FA på alle tjenester. Dette reducerer risikoen for misbrug af kontoen betragteligt.
                                 Selv i tilfælde, hvor nogen har opsnappet dit kodeord. Grundet generelle sikkerhedsovervejelser,
                                 og nylig øgning af phishing-angreb, så anbefaler vi at slå 2FA til. Det sker ved at følge

--- a/state/wwwpublic/tips-storage.deic.dk.html
+++ b/state/wwwpublic/tips-storage.deic.dk.html
@@ -291,7 +291,7 @@
                             <p>
                                 Can I use a YubiKey security device for stronger and safer
                                 authentication?
-                                It generally recommends securing your logins with MFA and offer
+                                Several organizations generally recommends securing your logins with MFA and offer
                                 employees e.g. the small keyring-format hardware security keys from
                                 Yubico for the purpose. 
                                 You might want to have a word with your local leader about perhaps

--- a/state/wwwpublic/tips-storage.deic.dk.html
+++ b/state/wwwpublic/tips-storage.deic.dk.html
@@ -248,7 +248,7 @@
                                 <a href="setup.py?topic=seafile" target="_blank">Seafile Setup</a>
                                 guide.
                                 Please refer to the
-                                <a href="/public/ucph-erda-user-guide.pdf">user guide</a> for further
+                                <a href="/public/deic-storage-user-guide.pdf">user guide</a> for further
                                 details.
                             </p>
                         </div -->

--- a/state/wwwpublic/tips-storage.deic.dk.html
+++ b/state/wwwpublic/tips-storage.deic.dk.html
@@ -159,7 +159,7 @@
                                 interoperable and reusable, which is increasingly becoming a common
                                 requirement when applying for funding.
                                 Please refer to our FAQ and the 
-                                <a href="/public/ucph-erda-user-guide.pdf">user guide</a> for more
+                                <a href="/public/deic-storage-user-guide.pdf">user guide</a> for more
                                 details.
                             </p>
                         </div -->


### PR DESCRIPTION
The aim has been to reflect DeiC Storage/DeiC better in the solution, so that screenshots can be made.
The static HTML snippets have been edited, so UCPH centric passages, sections, and functionality got altered or removed.

Examples are Seafile, Jupyter, and different login types for internal/external users. These are currently limited to UCPH. 

- As Dataverse is expected to integrate to DeiC Storage at a later phase; therefore mention on OID service have been kept, but commented out.
- Skins in V2/V3 is not an option on DeiC Storage, so Quick tip regarding this have been removed.

Changes have sometimes been made to allow for later inclusion, simply by commenting out a HTML element.
In text passages text were removed, or altered. 

There are still decisions left to be made regarding, say, external users, quotas, and so on. Once these decision have been made, it will be easier to decide which parts to completely exclude, reintroduce, and adjust.