### PR TITLE
Embellish fixture asserts with the paths and carve out fixture support file.

### DIFF
--- a/tests/test_mig_shared_configuration.py
+++ b/tests/test_mig_shared_configuration.py
@@ -31,7 +31,7 @@ import inspect
 import os
 import unittest
 
-from tests.support import MigTestCase, TEST_DATA_DIR, PY2, testmain, fixturefile
+from tests.support import MigTestCase, TEST_DATA_DIR, PY2, testmain
 from mig.shared.configuration import Configuration
 
 
@@ -71,7 +71,7 @@ class MigSharedConfiguration(MigTestCase):
 
     @unittest.skipIf(PY2, "Python 3 only")
     def test_default_object(self):
-        expected_values = fixturefile(
+        prepared_fixture = self.prepareFixtureAssert(
             'mig_shared_configuration--new', fixture_format='json')
 
         configuration = Configuration(None)
@@ -84,8 +84,7 @@ class MigSharedConfiguration(MigTestCase):
 
         actual_values = _to_dict(configuration)
 
-        self.maxDiff = None
-        self.assertEqual(actual_values, expected_values)
+        prepared_fixture.assertAgainstFixture(actual_values)
 
     def test_object_isolation(self):
         configuration_1 = Configuration(None)

--- a/tests/test_mig_shared_functionality_cat.py
+++ b/tests/test_mig_shared_functionality_cat.py
@@ -35,7 +35,7 @@ import sys
 import unittest
 
 from tests.support import MIG_BASE, PY2, TEST_DATA_DIR, MigTestCase, testmain, \
-    fixturefile, fixturefile_normname, ensure_dirs_exist, temppath
+    temppath, ensure_dirs_exist
 
 from mig.shared.base import client_id_dir
 from mig.shared.functionality.cat import _main as submain, main as realmain
@@ -78,13 +78,12 @@ class MigSharedFunctionalityCat(MigTestCase):
 
         conf_user_db_home = ensure_dirs_exist(self.configuration.user_db_home)
         temppath(conf_user_db_home, self)
-        db_fixture, db_fixture_file = fixturefile('MiG-users.db--example',
-                                                  fixture_format='binary',
-                                                  include_path=True)
-        test_db_file = temppath(fixturefile_normname('MiG-users.db--example',
-                                                     prefix=conf_user_db_home),
-                                self)
-        shutil.copyfile(db_fixture_file, test_db_file)
+        prepared_fixture = self.prepareFixtureAssert(
+            'MiG-users.db--example',
+            fixture_format='binary',
+        )
+
+        test_db_file = prepared_fixture.copy_as_temp(prefix=conf_user_db_home)
 
         # create the test user home directory
         self.test_user_dir = ensure_dirs_exist(test_user_dir)


### PR DESCRIPTION
It was pointed out that assertions against snapshots was an odd-one-out with respect to the emphasis on helpful information in the face a test failure that we usually strive for. Specifically, we had not arrange the developer being told which fixture was failing its tests.

The reason for this was the fixture code had been written as grab  fixture data via  path then do whatever comparison as desired as opposed to exposing a compound assertion that would take a fixture file path and value and do an equality check - this formulation would have access to the path for display at the point the equality fails. Note we trade assertion flexibility for output quality but fixtures are almost always going to be an equality so not a problem.

Ride on the coattails of adding the abstraction and place all the fixture support code in its own separate support file whcih happens to follow a growing and healthy convention in the tree.