### PR TITLE
Fix/migrid init sftpsubsys status

### DIFF
--- a/mig/install/migrid-init.d-deb-template
+++ b/mig/install/migrid-init.d-deb-template
@@ -836,14 +836,22 @@ status_vmproxy() {
 status_sftpsubsys_workers() {
     DAEMON_PATH=${MIG_SFTPSUBSYS_WORKER}
     SHORT_NAME=$(basename ${DAEMON_PATH})
-    pgrep -f ${DAEMON_PATH} > /dev/null
+    PIDS=$(pgrep -f ${DAEMON_PATH}) || true
+    [ -n "$PIDS" ] && echo "$SHORT_NAME: (pids: $PIDS) is running..."
 }
 status_sftpsubsys() {
     check_enabled "sftp_subsys" || return 0
+    status_sftpsubsys_workers
     DAEMON_PATH=${MIG_SFTPSUBSYS}
     SHORT_NAME=$(basename ${DAEMON_PATH})
-    pgrep -f "${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}" > /dev/null
-    status_sftpsubsys_workers
+    COMMAND_PATH="${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}"
+    PID=$(pgrep -f "${COMMAND_PATH}")
+    if [ -n "$PID" ]; then  
+       echo "${COMMAND_PATH}: (pid: $PID) is running..."
+       return 0
+    else
+       echo "${COMMAND_PATH} is stopped"
+       return 3
 }
 
 status_all() {

--- a/mig/install/migrid-init.d-rh-template
+++ b/mig/install/migrid-init.d-rh-template
@@ -516,6 +516,7 @@ stop_sftpsubsys_workers() {
     echo -n "Shutting down MiG sftpsubsys workers: $SHORT_NAME "
     # Proc only running if one or more clients are connected
     pkill -f ${DAEMON_PATH} || true
+    success
     echo
 }
 stop_sftpsubsys() {
@@ -524,6 +525,9 @@ stop_sftpsubsys() {
     SHORT_NAME=$(basename ${DAEMON_PATH})
     echo -n "Shutting down MiG sftpsubsys: $SHORT_NAME "
     pkill -f "${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}"
+    RET2=$?
+    [ $RET2 -eq 0 ] && success
+    [ $RET2 -ne 0 ] && failure
     echo
     # Workers don't react to parent stop and hang on to mount point etc. 
     sleep 1
@@ -674,6 +678,7 @@ reload_sftpsubsys_workers() {
     echo -n "Reloading MiG sftpsubsys workers: $SHORT_NAME "
     # Proc only running if one or more clients are connected
     pkill -HUP -f ${DAEMON_PATH} || true
+    success
     echo
 }
 reload_sftpsubsys() {
@@ -682,6 +687,9 @@ reload_sftpsubsys() {
     SHORT_NAME=$(basename ${DAEMON_PATH})
     echo -n "Reloading MiG sftpsubsys: $SHORT_NAME "
     pkill -HUP -f "${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}"
+    RET2=$?
+    [ $RET2 -eq 0 ] && success
+    [ $RET2 -ne 0 ] && failure
     echo
     # Workers don't react to parent reload and hang on to mount point etc. 
     sleep 1
@@ -819,14 +827,23 @@ status_vmproxy() {
 status_sftpsubsys_workers() {
     DAEMON_PATH=${MIG_SFTPSUBSYS_WORKER}
     SHORT_NAME=$(basename ${DAEMON_PATH})
-    pgrep -f ${DAEMON_PATH} > /dev/null
+    PIDS=$(pgrep -f ${DAEMON_PATH}) || true
+    [ -n "$PIDS" ] && echo "$SHORT_NAME: (pids: $PIDS) is running..."
 }
 status_sftpsubsys() {
     check_enabled "sftp_subsys" || return
+    status_sftpsubsys_workers
     DAEMON_PATH=${MIG_SFTPSUBSYS}
     SHORT_NAME=$(basename ${DAEMON_PATH})
-    pgrep -f "${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}" > /dev/null
-    status_sftpsubsys_workers
+    COMMAND_PATH="${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}"
+    PID=$(pgrep -f "${COMMAND_PATH}")
+    if [ -n "$PID" ]; then
+        echo "${COMMAND_PATH}: (pid: $PID) is running..."
+        return 0
+    else
+        echo "${COMMAND_PATH} is stopped"
+        return 3
+    fi
 }
 
 status_all() {

--- a/mig/install/migrid-init.d-rh-template
+++ b/mig/install/migrid-init.d-rh-template
@@ -163,9 +163,9 @@ start_monitor() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/monitor.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: monitor not started."
+    [ $RET2 -ne 0 ] && echo "Warning: monitor not started."
     echo
 }
 start_sshmux() {
@@ -178,9 +178,9 @@ start_sshmux() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/sshmux.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: sshmux not started."
+    [ $RET2 -ne 0 ] && echo "Warning: sshmux not started."
     echo
 }
 start_events() {
@@ -194,9 +194,9 @@ start_events() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/events.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: events not started."
+    [ $RET2 -ne 0 ] && echo "Warning: events not started."
     echo
 }
 start_cron() {
@@ -210,9 +210,9 @@ start_cron() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/cron.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: cron not started."
+    [ $RET2 -ne 0 ] && echo "Warning: cron not started."
     echo
 }
 start_transfers() {
@@ -225,9 +225,9 @@ start_transfers() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/transfers.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: transfers not started."
+    [ $RET2 -ne 0 ] && echo "Warning: transfers not started."
     echo
 }
 start_openid() {
@@ -240,9 +240,9 @@ start_openid() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/openid.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: openid not started."
+    [ $RET2 -ne 0 ] && echo "Warning: openid not started."
     echo
 }
 start_sftp() {
@@ -255,9 +255,9 @@ start_sftp() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/sftp.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: sftp not started."
+    [ $RET2 -ne 0 ] && echo "Warning: sftp not started."
     echo
 }
 start_webdavs() {
@@ -270,9 +270,9 @@ start_webdavs() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/webdavs.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: webdavs not started."
+    [ $RET2 -ne 0 ] && echo "Warning: webdavs not started."
     echo
 }
 start_ftps() {
@@ -285,9 +285,9 @@ start_ftps() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/ftps.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: ftps not started."
+    [ $RET2 -ne 0 ] && echo "Warning: ftps not started."
     echo
 }
 start_notify() {
@@ -300,9 +300,9 @@ start_notify() {
        "${DAEMON_PATH} >> ${MIG_LOG}/notify.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: notify not started."
+    [ $RET2 -ne 0 ] && echo "Warning: notify not started."
     echo
 }
 start_imnotify() {
@@ -315,9 +315,9 @@ start_imnotify() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/imnotify.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: imnotify not started."
+    [ $RET2 -ne 0 ] && echo "Warning: imnotify not started."
     echo
 }
 start_vmproxy() {
@@ -330,9 +330,9 @@ start_vmproxy() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/vmproxy.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: vmproxy not started."
+    [ $RET2 -ne 0 ] && echo "Warning: vmproxy not started."
     echo
 }
 start_sftpsubsys() {
@@ -342,9 +342,9 @@ start_sftpsubsys() {
     echo -n "Starting MiG sftpsubsys daemon: $SHORT_NAME"
     ${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: sftpsubsys not started."
+    [ $RET2 -ne 0 ] && echo "Warning: sftpsubsys not started."
     echo
     # NOTE: sftp subsys workers start automatically
 }

--- a/tests/fixture/confs-stdlocal/migrid-init.d-deb
+++ b/tests/fixture/confs-stdlocal/migrid-init.d-deb
@@ -836,14 +836,22 @@ status_vmproxy() {
 status_sftpsubsys_workers() {
     DAEMON_PATH=${MIG_SFTPSUBSYS_WORKER}
     SHORT_NAME=$(basename ${DAEMON_PATH})
-    pgrep -f ${DAEMON_PATH} > /dev/null
+    PIDS=$(pgrep -f ${DAEMON_PATH}) || true
+    [ -n "$PIDS" ] && echo "$SHORT_NAME: (pids: $PIDS) is running..."
 }
 status_sftpsubsys() {
     check_enabled "sftp_subsys" || return 0
+    status_sftpsubsys_workers
     DAEMON_PATH=${MIG_SFTPSUBSYS}
     SHORT_NAME=$(basename ${DAEMON_PATH})
-    pgrep -f "${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}" > /dev/null
-    status_sftpsubsys_workers
+    COMMAND_PATH="${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}"
+    PID=$(pgrep -f "${COMMAND_PATH}")
+    if [ -n "$PID" ]; then  
+       echo "${COMMAND_PATH}: (pid: $PID) is running..."
+       return 0
+    else
+       echo "${COMMAND_PATH} is stopped"
+       return 3
 }
 
 status_all() {

--- a/tests/fixture/confs-stdlocal/migrid-init.d-rh
+++ b/tests/fixture/confs-stdlocal/migrid-init.d-rh
@@ -163,9 +163,9 @@ start_monitor() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/monitor.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: monitor not started."
+    [ $RET2 -ne 0 ] && echo "Warning: monitor not started."
     echo
 }
 start_sshmux() {
@@ -178,9 +178,9 @@ start_sshmux() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/sshmux.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: sshmux not started."
+    [ $RET2 -ne 0 ] && echo "Warning: sshmux not started."
     echo
 }
 start_events() {
@@ -194,9 +194,9 @@ start_events() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/events.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: events not started."
+    [ $RET2 -ne 0 ] && echo "Warning: events not started."
     echo
 }
 start_cron() {
@@ -210,9 +210,9 @@ start_cron() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/cron.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: cron not started."
+    [ $RET2 -ne 0 ] && echo "Warning: cron not started."
     echo
 }
 start_transfers() {
@@ -225,9 +225,9 @@ start_transfers() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/transfers.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: transfers not started."
+    [ $RET2 -ne 0 ] && echo "Warning: transfers not started."
     echo
 }
 start_openid() {
@@ -240,9 +240,9 @@ start_openid() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/openid.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: openid not started."
+    [ $RET2 -ne 0 ] && echo "Warning: openid not started."
     echo
 }
 start_sftp() {
@@ -255,9 +255,9 @@ start_sftp() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/sftp.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: sftp not started."
+    [ $RET2 -ne 0 ] && echo "Warning: sftp not started."
     echo
 }
 start_webdavs() {
@@ -270,9 +270,9 @@ start_webdavs() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/webdavs.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: webdavs not started."
+    [ $RET2 -ne 0 ] && echo "Warning: webdavs not started."
     echo
 }
 start_ftps() {
@@ -285,9 +285,9 @@ start_ftps() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/ftps.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: ftps not started."
+    [ $RET2 -ne 0 ] && echo "Warning: ftps not started."
     echo
 }
 start_notify() {
@@ -300,9 +300,9 @@ start_notify() {
        "${DAEMON_PATH} >> ${MIG_LOG}/notify.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: notify not started."
+    [ $RET2 -ne 0 ] && echo "Warning: notify not started."
     echo
 }
 start_imnotify() {
@@ -315,9 +315,9 @@ start_imnotify() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/imnotify.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: imnotify not started."
+    [ $RET2 -ne 0 ] && echo "Warning: imnotify not started."
     echo
 }
 start_vmproxy() {
@@ -330,9 +330,9 @@ start_vmproxy() {
 	   "${DAEMON_PATH} >> ${MIG_LOG}/vmproxy.out 2>&1 &"
     fallback_save_pid "$DAEMON_PATH" "$PID_FILE" "$!"
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: vmproxy not started."
+    [ $RET2 -ne 0 ] && echo "Warning: vmproxy not started."
     echo
 }
 start_sftpsubsys() {
@@ -342,9 +342,9 @@ start_sftpsubsys() {
     echo -n "Starting MiG sftpsubsys daemon: $SHORT_NAME"
     ${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}
     RET2=$?
-    [ $RET2 ] && success
+    [ $RET2 -eq 0 ] && success
     echo
-    [ $RET2 ] || echo "Warning: sftpsubsys not started."
+    [ $RET2 -ne 0 ] && echo "Warning: sftpsubsys not started."
     echo
     # NOTE: sftp subsys workers start automatically
 }
@@ -516,6 +516,7 @@ stop_sftpsubsys_workers() {
     echo -n "Shutting down MiG sftpsubsys workers: $SHORT_NAME "
     # Proc only running if one or more clients are connected
     pkill -f ${DAEMON_PATH} || true
+    success
     echo
 }
 stop_sftpsubsys() {
@@ -524,6 +525,9 @@ stop_sftpsubsys() {
     SHORT_NAME=$(basename ${DAEMON_PATH})
     echo -n "Shutting down MiG sftpsubsys: $SHORT_NAME "
     pkill -f "${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}"
+    RET2=$?
+    [ $RET2 -eq 0 ] && success
+    [ $RET2 -ne 0 ] && failure
     echo
     # Workers don't react to parent stop and hang on to mount point etc. 
     sleep 1
@@ -674,6 +678,7 @@ reload_sftpsubsys_workers() {
     echo -n "Reloading MiG sftpsubsys workers: $SHORT_NAME "
     # Proc only running if one or more clients are connected
     pkill -HUP -f ${DAEMON_PATH} || true
+    success
     echo
 }
 reload_sftpsubsys() {
@@ -682,6 +687,9 @@ reload_sftpsubsys() {
     SHORT_NAME=$(basename ${DAEMON_PATH})
     echo -n "Reloading MiG sftpsubsys: $SHORT_NAME "
     pkill -HUP -f "${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}"
+    RET2=$?
+    [ $RET2 -eq 0 ] && success
+    [ $RET2 -ne 0 ] && failure
     echo
     # Workers don't react to parent reload and hang on to mount point etc. 
     sleep 1
@@ -819,14 +827,23 @@ status_vmproxy() {
 status_sftpsubsys_workers() {
     DAEMON_PATH=${MIG_SFTPSUBSYS_WORKER}
     SHORT_NAME=$(basename ${DAEMON_PATH})
-    pgrep -f ${DAEMON_PATH} > /dev/null
+    PIDS=$(pgrep -f ${DAEMON_PATH}) || true
+    [ -n "$PIDS" ] && echo "$SHORT_NAME: (pids: $PIDS) is running..."
 }
 status_sftpsubsys() {
     check_enabled "sftp_subsys" || return
+    status_sftpsubsys_workers
     DAEMON_PATH=${MIG_SFTPSUBSYS}
     SHORT_NAME=$(basename ${DAEMON_PATH})
-    pgrep -f "${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}" > /dev/null
-    status_sftpsubsys_workers
+    COMMAND_PATH="${DAEMON_PATH} -f ${MIG_SFTPSUBSYS_CONF}"
+    PID=$(pgrep -f "${COMMAND_PATH}")
+    if [ -n "$PID" ]; then
+        echo "${COMMAND_PATH}: (pid: $PID) is running..."
+        return 0
+    else
+        echo "${COMMAND_PATH} is stopped"
+        return 3
+    fi
 }
 
 status_all() {


### PR DESCRIPTION
'service migrid statusdaemon sftpsubsys' currently returns 1 if there are no worker processes regardless if the 'sshd' process is running and ready to serve.

This fix adjusts the output messages from sftpsubsys 'stop/status' as well as the exit codes from 'status'