### PR TITLE
Rework the logout handler to fix session cleanup during OIDC logout

### DIFF
--- a/mig/shared/functionality/logout.py
+++ b/mig/shared/functionality/logout.py
@@ -36,7 +36,7 @@ from mig.shared.auth import expire_twofactor_session
 from mig.shared.base import requested_backend
 from mig.shared.defaults import AUTH_CERTIFICATE, AUTH_OPENID_V2, \
     AUTH_OPENID_CONNECT, AUTH_MIG_OID, AUTH_EXT_OID, AUTH_MIG_OIDC, \
-    AUTH_EXT_OIDC
+    AUTH_EXT_OIDC, AUTH_MIG_CERT, AUTH_EXT_CERT
 from mig.shared.functional import validate_input_and_cert
 from mig.shared.gdp.all import project_logout, get_client_id_from_project_client_id
 from mig.shared.httpsclient import extract_client_id, detect_client_auth, \
@@ -199,7 +199,8 @@ the %s Admins if it happens repeatedly.
             return_page = build_logout_url(configuration, environ)
             terminate_query = urlencode({'logout': return_page})
             reentry_page = terminate_session_url + '?%s' % terminate_query
-            logger.debug("send %s to %s for logout" % (client_id, reentry_page))
+            logger.debug("send %s to %s for logout" % (client_id,
+                                                       reentry_page))
             success, found, remaining = True, True, []
         elif auth_type == AUTH_CERTIFICATE:
             logger.info("no manual cleanup needed for %s session of %s" %

--- a/mig/shared/httpsclient.py
+++ b/mig/shared/httpsclient.py
@@ -233,6 +233,7 @@ def build_logout_url(configuration, environ):
     (auth_type, auth_flavor) = detect_client_auth(configuration, environ)
     local_logout = '%(SCRIPT_URI)s?logout=true' % environ
     if auth_type == AUTH_OPENID_V2:
+        _logger.debug("logout chaining needed for %s auth" % auth_type)
         # NOTE: OpenID 2.0 logout requires local session database scrubbing.
         #       Logout at provider and return to local logout page for that.
         login = extract_plain_login(configuration, environ)
@@ -240,27 +241,11 @@ def build_logout_url(configuration, environ):
         logout_query = urlencode({'return_to': local_logout})
         logout_url = logout_base + '/logout?%s' % logout_query
     elif auth_type == AUTH_OPENID_CONNECT:
-        # NOTE: OpenID Connect module handles chained logout on vanity url.
-        #       Use it to first log out at provider if supported and then
-        #       return for local logout with 2fa session clean up.
-        # TODO: test RP-initiated logout on provider with end_session endpoint!
-        logout_base = '/dynamic/redirect_uri'
-        logout_query = urlencode({'logout': local_logout})
-        logout_url = logout_base + '?%s' % logout_query
-
-        # NOTE: the MicroFocus provider we know does not offer end_session
-        #       so the user currently needs to close browser upon logout.
-        # TODO: can we implement an alterntive explicit logout?
-        # Something like this might be a qualified guess based on
-        # https://www.microfocus.com/documentation/access-manager/developer-documentation-5.0/oauth-application-developer-guide/logout-endpoint.html
-        # if auth_flavor == AUTH_MIG_OIDC:
-        #     logout_base = configuration.migserver_https_mig_oidc_url
-        # elif auth_flavor == AUTH_EXT_OIDC:
-        #     logout_base = configuration.migserver_https_ext_oidc_url
-        # logout_query = urlencode({'post_logout_redirect_uri': local_logout})
-        # logout_url = os.path.join(logout_base, 'nidp/oauth/v1/nam',
-        #                           'end_session?%s' % logout_query)
-
+        _logger.debug("no logout chaining needed for %s auth" % auth_type)
+        logout_url = local_logout
+    elif auth_type == AUTH_CERTIFICATE:
+        _logger.debug("no logout chaining needed for %s auth" % auth_type)
+        logout_url = local_logout
     else:
         _logger.warning("unknown logout chaining for %s" % auth_type)
         logout_url = local_logout


### PR DESCRIPTION
 1) Generally act in reverse order of login regarding gdp project logout, 2FA
    session clean up and local+remote IDP logout
 2) Disable the OpenID 2.0 workaround with interleaved remote IDP logout when
    using OpenID Connect

This should make logout more consistent and more importantly address the issue with missing local 2FA session termination during OpenID Connect logout we currently see in issue #222 .