### PR TITLE
Sweep the tree switching to is_*() methods across Thread and Thread.Event.

### DIFF
--- a/mig/server/grid_script.py
+++ b/mig/server/grid_script.py
@@ -97,7 +97,7 @@ def time_out_jobs(stop_event):
         # Keep running until main sends stop signal
 
         counter = 0
-        while not stop_event.isSet():
+        while not stop_event.is_set():
             counter = (counter + 1) % 60
 
             # Responsive sleep for 60 seconds
@@ -1706,7 +1706,7 @@ while True:
     elif cap_line.find('CHECKTIMEOUTTHREAD') == 0:
         logger.info('--- CHECKING TIME OUT THREAD ---')
         logger.info('--- TIME OUT THREAD IS ALIVE: %s ---'
-                    % job_time_out_thread.isAlive())
+                    % job_time_out_thread.is_alive())
     elif cap_line.find('RELOADCONFIG') == 0:
         logger.info('--- RELOADING CONFIGURATION ---')
         configuration.reload_config(True)
@@ -1727,11 +1727,11 @@ while True:
 
     # TMP: Auto restart time out thread until we find the death cause
 
-    if not job_time_out_thread.isAlive():
+    if not job_time_out_thread.is_alive():
         logger.warning('--- TIME OUT THREAD DIED: %s %s %s---'
                        % (job_time_out_thread,
-                           job_time_out_thread.isAlive(),
-                           job_time_out_stop.isSet()))
+                           job_time_out_thread.is_alive(),
+                           job_time_out_stop.is_set()))
         logger.info('ressurect time out thread with executing queue:')
         logger.info('%s' % executing_queue.show_queue(['ALL']))
         job_time_out_stop.clear()

--- a/mig/server/sftp_subsys.py
+++ b/mig/server/sftp_subsys.py
@@ -259,7 +259,7 @@ if __name__ == '__main__':
                     # Join with 1s timeout to stay responsive but catch finish
                     sftp_server.join(1)
                     # Check alive to decide if join succeeded or timed out
-                    if not sftp_server.isAlive():
+                    if not sftp_server.is_alive():
                         # logger.debug(
                         #     '(%d) Joined sftp subsys server worker' % pid)
                         configuration.daemon_conf['stop_running'].set()

--- a/mig/shared/functionality/sharelink.py
+++ b/mig/shared/functionality/sharelink.py
@@ -334,7 +334,7 @@ comma-separated recipients.
                             logger.debug('check done %s' % invite_list[i])
                             notify = threads[i]
                             notify.join(3)
-                            notify_done[i] = not notify.isAlive()
+                            notify_done[i] = not notify.is_alive()
                 notify_sent, notify_failed = [], []
                 for i in range(len(invite_list)):
                     if notify_done[i]:

--- a/mig/shared/worker.py
+++ b/mig/shared/worker.py
@@ -47,7 +47,7 @@ def dummy_test(delay):
 
 def throttle_max_concurrent(workers, concurrent=__max_concurrent):
     """Wait until at most max_concurrent workers are active"""
-    while len([w for w in workers if w.isAlive()]) >= concurrent:
+    while len([w for w in workers if w.is_alive()]) >= concurrent:
         time.sleep(1)
     return
 


### PR DESCRIPTION
The Thread isAlive() method was deprecated in Python 3.8 and removed from 3.9. While doing this also noted that the old alias for is_set() is also marked as deprecated so also preemptively switch that over. Doing so for both makes calls to those APIs consistent.