### PR TITLE
Address potential security issues in CamanJS dependencies.

### DIFF
--- a/mig/images/lib/CamanJS-4.1.1/package.json
+++ b/mig/images/lib/CamanJS-4.1.1/package.json
@@ -40,7 +40,7 @@
     "url": "http://github.com/meltingice/CamanJS.git"
   },
   "dependencies": {
-    "canvas": "*",
+    "canvas": ">= 1.6.11",
     "fibers": "*"
   },
   "devDependencies": {
@@ -51,7 +51,7 @@
     "mocha": "*",
     "chai": "*",
     "servedir": "*",
-    "cli": "*",
+    "cli": ">= 1.0.0",
     "cli-table": "*"
   },
   "scripts": {


### PR DESCRIPTION
Address potential security issues in CamanJS dependencies. No longer used and scheduled for retirement, but better safe than sorry until then.