### PR TITLE
sftpsubsys: Fixed login to GDP projects with spaces in their name

### DIFF
--- a/mig/src/libnss-mig/Makefile
+++ b/mig/src/libnss-mig/Makefile
@@ -25,7 +25,7 @@ MIG_DEFAULTS=-D'MIG_UID=$(shell id -u mig)' \
 	-D'JOBSIDMOUNT_LENGTH=64' \
 	-D'JUPYTERSIDMOUNT_HOME="$(shell ~mig/mig/server/readconfval.py sessid_to_jupyter_mount_link_home)"' \
 	-D'JUPYTERSIDMOUNT_LENGTH=64' \
-	-D'USERNAME_REGEX="^[a-zA-Z0-9][ a-zA-Z0-9.@_-]{0,127}$$"'
+	-D'USERNAME_REGEX="^[a-zA-Z0-9][a-zA-Z0-9.@_\\-\\ ]{0,127}$$"'
 ### End of MiG site variables
 
 #### Start of compiler configuration section ### 

--- a/mig/src/libnss-mig/Makefile
+++ b/mig/src/libnss-mig/Makefile
@@ -25,7 +25,7 @@ MIG_DEFAULTS=-D'MIG_UID=$(shell id -u mig)' \
 	-D'JOBSIDMOUNT_LENGTH=64' \
 	-D'JUPYTERSIDMOUNT_HOME="$(shell ~mig/mig/server/readconfval.py sessid_to_jupyter_mount_link_home)"' \
 	-D'JUPYTERSIDMOUNT_LENGTH=64' \
-	-D'USERNAME_REGEX="^[a-zA-Z0-9][a-zA-Z0-9.@_-]{0,127}$$"'
+	-D'USERNAME_REGEX="^[a-zA-Z0-9][ a-zA-Z0-9.@_-]{0,127}$$"'
 ### End of MiG site variables
 
 #### Start of compiler configuration section ### 

--- a/mig/src/libpam-mig/Makefile
+++ b/mig/src/libpam-mig/Makefile
@@ -29,7 +29,7 @@ MIG_DEFAULTS=-D'MIG_UID=$(shell id -u mig)' \
 	-D'PASSWORD_MIN_CLASSES=3' \
 	-D'SHARELINK_HOME="$(shell ~mig/mig/server/readconfval.py sharelink_home)"' \
 	-D'SHARELINK_LENGTH=10' \
-	-D'USERNAME_REGEX="^[a-zA-Z0-9][ a-zA-Z0-9.@_-]{0,127}$$"'
+	-D'USERNAME_REGEX="^[a-zA-Z0-9][a-zA-Z0-9.@_\\-\\ ]{0,127}$$"'
 ### End of MiG site variables
 
 #### Start of compiler configuration section ### 

--- a/mig/src/libpam-mig/Makefile
+++ b/mig/src/libpam-mig/Makefile
@@ -29,7 +29,7 @@ MIG_DEFAULTS=-D'MIG_UID=$(shell id -u mig)' \
 	-D'PASSWORD_MIN_CLASSES=3' \
 	-D'SHARELINK_HOME="$(shell ~mig/mig/server/readconfval.py sharelink_home)"' \
 	-D'SHARELINK_LENGTH=10' \
-	-D'USERNAME_REGEX="^[a-zA-Z0-9][a-zA-Z0-9.@_-]{0,127}$$"'
+	-D'USERNAME_REGEX="^[a-zA-Z0-9][ a-zA-Z0-9.@_-]{0,127}$$"'
 ### End of MiG site variables
 
 #### Start of compiler configuration section ### 


### PR DESCRIPTION
libnss and libpam currently prevent spaces in usernames which block sftpsubsys login to GDP projects with spaces in their name.

This fix allow spaces in usernames as long as the username doesn't start with a space.