### PR TITLE
Explicit variable init for clarity and lint error fixing

### DIFF
--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -691,6 +691,8 @@ class Configuration:
                  disable_auth_log=False):
         self.config_file = config_file
         self.mig_server_id = None
+        # Explicitly init a few helpers hot-plugged and used in ways where it's
+        # less obvious if they are always guaranteed to already be initialized.
         self.default_page = None
         self.auth_logger_obj = None
         self.gdp_logger_obj = None

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -685,15 +685,15 @@ _CONFIGURATION_DEFAULTS = {
 
 
 class Configuration:
-
-    """Server configuration in parsed form"""
-
-    # constructor
+    """Server configuration in parsed form."""
 
     def __init__(self, config_file, verbose=False, skip_log=False,
                  disable_auth_log=False):
         self.config_file = config_file
         self.mig_server_id = None
+        self.default_page = None
+        self.auth_logger_obj = None
+        self.gdp_logger_obj = None
 
         configuration_options = copy.deepcopy(_CONFIGURATION_DEFAULTS)
 


### PR DESCRIPTION
Explicitly initialize the three variables used in places where it's not completely obvious that they are actually always hot-plugged before use. Some linters will also shout about that as seen in PR #236 checks.