### PR TITLE
filemanager: Fix for issue #238 large file download error in GDP mode

### DIFF
--- a/mig/images/js/jquery.filemanager.js
+++ b/mig/images/js/jquery.filemanager.js
@@ -1081,11 +1081,11 @@ if (jQuery) (function($){
                     /* Path may contain URL-unfriendly characters */
                     var download_url = 'cat.py?path=' +
                         encodeURIComponent(path)+'&output_format=file';
-                    window.open(download_url, "_self");
+                    downloadWrapper(el, '#cmd_dialog', download_url);
                 }
                 else {
                     var path_enc = encodeURI(path);
-                    window.open('/cert_redirect/'+path_enc, "_self");
+                    window.open('/cert_redirect/'+path_enc);
                 }
             },
             download:   function (action, el, pos) {
@@ -1096,7 +1096,13 @@ if (jQuery) (function($){
 
                   NOTE: For GDP we always use 'cat' as we need to log file access
                 */
-                var max_stream_size = options.maxStreamSize;
+                var max_stream_size;
+                if (options.enableGDP) {
+                    max_stream_size = Number.MAX_SAFE_INTEGER;
+                }
+                else {
+                    max_stream_size = options.maxStreamSize;
+                }
                 var file_size = $("div.bytes", el).text();
                 //console.info("File size "+file_size+" vs stream size "+max_stream_size);
                 
@@ -1104,12 +1110,7 @@ if (jQuery) (function($){
 
                 if (!options.enableGDP && file_size > max_stream_size) {
                     var path_enc = encodeURI(path);
-                    window.open('/cert_redirect/'+path_enc, "_self");
-                } else if (options.enableGDP && file_size > max_stream_size) {
-                    /* Path may contain URL-unfriendly characters */
-                    var download_url = 'cat.py?path=' +
-                        encodeURIComponent(path)+'&output_format=file';
-                    window.open(download_url, "_self");
+                    window.open('/cert_redirect/'+path_enc);
                 } else {
                     /* Path may contain URL-unfriendly characters */
                     var download_url = 'cat.py?path=' +

--- a/mig/images/js/jquery.filemanager.js
+++ b/mig/images/js/jquery.filemanager.js
@@ -1028,21 +1028,14 @@ if (jQuery) (function($){
             $.ajax({
                 url: download_url,
                 dataType: 'binary',
-                method: 'GET',
+                method: 'HEAD',
                 xhrFields: {
                     responseType: 'blob' // Set the response type to 'blob'
                 },
                 success: function(blob) {
                     console.info("Starting download of "+file_name)
-                    let fileURL = URL.createObjectURL(blob);
-                    var link = document.createElement('a');
-                    link.href = fileURL;
-                    /* downloaded filename */
-                    link.download = file_name;
-                    document.body.appendChild(link);
-                    link.click();
-                    URL.revokeObjectURL(fileURL);
                     stopProgress("");
+                    window.open(download_url, "_self");
                 },
                 error: function(xhr, textStatus, errorThrown) {
                     console.error('Error downloading', file_name, ":", textStatus, ":", errorThrown);

--- a/mig/images/js/jquery.filemanager.js
+++ b/mig/images/js/jquery.filemanager.js
@@ -1081,11 +1081,11 @@ if (jQuery) (function($){
                     /* Path may contain URL-unfriendly characters */
                     var download_url = 'cat.py?path=' +
                         encodeURIComponent(path)+'&output_format=file';
-                    downloadWrapper(el, '#cmd_dialog', download_url);
+                    window.open(download_url, "_self");
                 }
                 else {
                     var path_enc = encodeURI(path);
-                    window.open('/cert_redirect/'+path_enc);
+                    window.open('/cert_redirect/'+path_enc, "_self");
                 }
             },
             download:   function (action, el, pos) {
@@ -1096,13 +1096,7 @@ if (jQuery) (function($){
 
                   NOTE: For GDP we always use 'cat' as we need to log file access
                 */
-                var max_stream_size;
-                if (options.enableGDP) {
-                    max_stream_size = Number.MAX_SAFE_INTEGER;
-                }
-                else {
-                    max_stream_size = options.maxStreamSize;
-                }
+                var max_stream_size = options.maxStreamSize;
                 var file_size = $("div.bytes", el).text();
                 //console.info("File size "+file_size+" vs stream size "+max_stream_size);
                 
@@ -1110,7 +1104,12 @@ if (jQuery) (function($){
 
                 if (!options.enableGDP && file_size > max_stream_size) {
                     var path_enc = encodeURI(path);
-                    window.open('/cert_redirect/'+path_enc);
+                    window.open('/cert_redirect/'+path_enc, "_self");
+                } else if (options.enableGDP && file_size > max_stream_size) {
+                    /* Path may contain URL-unfriendly characters */
+                    var download_url = 'cat.py?path=' +
+                        encodeURIComponent(path)+'&output_format=file';
+                    window.open(download_url, "_self");
                 } else {
                     /* Path may contain URL-unfriendly characters */
                     var download_url = 'cat.py?path=' +

--- a/mig/images/js/jquery.filemanager.js
+++ b/mig/images/js/jquery.filemanager.js
@@ -1034,7 +1034,7 @@ if (jQuery) (function($){
                 },
                 success: function(blob) {
                     console.info("Starting download of "+file_name)
-                    stopProgress("");
+                    stopProgress();
                     window.open(download_url, "_self");
                 },
                 error: function(xhr, textStatus, errorThrown) {


### PR DESCRIPTION
When in GDP mode download of largefiles fails through `downloadWrapper`. This fix align GDP mode with non-GDP mode and serve large files without using the 'downloadWrapper'.