### PR TITLE
filemanager: GDP Move to Trash

### DIFF
--- a/mig/shared/functionality/rm.py
+++ b/mig/shared/functionality/rm.py
@@ -320,6 +320,9 @@ to permanently delete""" % relative_path})
                 trash_relative_path = \
                     trash_relative_path.replace(
                         configuration.vgrid_files_home, '')
+                trash_relative_path = \
+                    trash_relative_path.replace(
+                        configuration.vgrid_files_writable, '')
                 gdp_iolog_paths.append(trash_relative_path)
             try:
                 gdp_iolog(configuration,

--- a/mig/shared/functionality/rm.py
+++ b/mig/shared/functionality/rm.py
@@ -317,9 +317,11 @@ to permanently delete""" % relative_path})
                     get_trash_location(configuration, abs_path, True)
                 trash_relative_path = \
                     trash_base_path.replace(configuration.user_home, '')
+                # Legacy vgrids use 'vgrid_files_home' as data storage
                 trash_relative_path = \
                     trash_relative_path.replace(
                         configuration.vgrid_files_home, '')
+                # Current vgrids use 'vgrid_files_writable' as data storage
                 trash_relative_path = \
                     trash_relative_path.replace(
                         configuration.vgrid_files_writable, '')


### PR DESCRIPTION
In the 'old' days project files were located in 'vgrid_files_home'. Now days files are located in 'vgrid_files_writable'. Take the latter into account when extracting the relative path for GDP 'move to trash' log.