### PR TITLE
Switch logout to request base vhost as reentry page upon complete OIDC logout

### DIFF
--- a/mig/shared/functionality/logout.py
+++ b/mig/shared/functionality/logout.py
@@ -194,10 +194,8 @@ the %s Admins if it happens repeatedly.
                          % (auth_type, identity))
             # NOTE: OpenID Connect module handles remote logout on vanity url
             terminate_session_url = '/dynamic/redirect_uri'
-            # NOTE: upstream currently requires fixed logout callback url
-            # TODO: change return_page to reentry_page when upstream allows it
-            return_page = build_logout_url(configuration, environ)
-            terminate_query = urlencode({'logout': return_page})
+            # NOTE: we request return to reentry_page after logout
+            terminate_query = urlencode({'logout': reentry_page})
             reentry_page = terminate_session_url + '?%s' % terminate_query
             logger.debug("send %s to %s for logout" % (client_id,
                                                        reentry_page))


### PR DESCRIPTION
Switch logout to request base `vhost` as re-entry page upon complete OIDC logout for consistency and to improve user experience.
Tested to work with our own upstream OIDC provider where log out terminates active sessions and leaves users at the default login prompt ready for log in to the site again if they wish.