### PR TITLE
Add state check to verifyarchives helper and use to verify FINAL Archives only

### DIFF
--- a/mig/install/migverifyarchives-template.sh.cronjob
+++ b/mig/install/migverifyarchives-template.sh.cronjob
@@ -68,7 +68,7 @@ for archivelist in $(/bin/find "$archivestaging" -type f -regex "$marker_pattern
         verifycount=$((verifycount+1))
         email=$(echo "$archpath" | sed 's@.*emailAddress=\([^/]*\)\/archive-.*@\1@g')
         archname=$(echo "$archpath"|sed 's@.*\/\(archive-.*\)@\1@g')
-        su - mig -c "PYTHONPATH=__MIG_BASE__ mig/server/verifyarchives.py -A $(date +%s -d 'a month ago') -I \"*${email}*\" -n \"$archname\""
+        su - mig -c "PYTHONPATH=__MIG_BASE__ mig/server/verifyarchives.py -A $(date +%s -d 'a month ago') -I \"*${email}*\" -n \"$archname\" -s FINAL"
         checkfailed=$?
         if [ $checkfailed -eq 0 ]; then
             echo "$archpath" >> "$tmppassedlist"

--- a/mig/server/verifyarchives.py
+++ b/mig/server/verifyarchives.py
@@ -30,7 +30,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-import datetime
 import fnmatch
 import getopt
 import os
@@ -40,7 +39,7 @@ import time
 from mig.shared.base import client_dir_id, distinguished_name_to_user
 from mig.shared.defaults import freeze_meta_filename, freeze_lock_filename, \
     public_archive_index, public_archive_files, public_archive_doi, \
-    keyword_pending, keyword_final
+    keyword_pending, keyword_final, keyword_any
 from mig.shared.freezefunctions import sorted_hash_algos, checksum_file
 from mig.shared.serial import load
 
@@ -54,7 +53,8 @@ def fuzzy_match(i, j, offset=2.0):
     return (i - offset < j and j < i + offset)
 
 
-def check_archive_integrity(configuration, user_id, freeze_path, verbose=False):
+def check_archive_integrity(configuration, user_id, freeze_path,
+                            required_state=keyword_any, verbose=False):
     """Inspect Archives in freeze_path and compare contents to pickled cache.
     The cache is a list with one dictionary per file using the format:
     {'sha512sum': '...', 'name': 'relpath/to/file.ext',
@@ -62,6 +62,8 @@ def check_archive_integrity(configuration, user_id, freeze_path, verbose=False):
     'sha1sum': '...', 'size': 123247} and where the checksums are only actually
     informative if the user requested them on showfreeze. Thus, just check
     timestamp and size in general.
+    If required_state argument is passed a given archive state the check also
+    fails if the archive is in any other state.
     """
     if verbose:
         print("Compare cache and contents for %s" % freeze_path)
@@ -87,6 +89,11 @@ def check_archive_integrity(configuration, user_id, freeze_path, verbose=False):
         print("Could not open archive helpers %s and %s for verification: %s" %
               (cache_path, meta_path, exc))
         return False
+    meta_state = meta.get('STATE', keyword_pending)
+    if required_state != keyword_any and meta_state != required_state:
+        print("Archive in %s is in %r state but check demanded state %r" %
+              (freeze_path, meta_state, required_state))
+        return False
     for entry in cache:
         if entry['name'] in ignore_files:
             continue
@@ -96,7 +103,6 @@ def check_archive_integrity(configuration, user_id, freeze_path, verbose=False):
             archived_size = archived_stat.st_size
             archived_created = archived_stat.st_ctime
             archived_modified = archived_stat.st_mtime
-            meta_state = meta.get('STATE', keyword_pending)
             if archived_size != entry['size']:
                 if meta_state == keyword_final:
                     print("Archive entry %s has wrong size %d (expected %d)" %
@@ -162,11 +168,12 @@ Where VERIFY_OPTIONS may be one or more of:
 if '__main__' == __name__:
     conf_path = None
     verbose = False
-    opt_args = 'A:B:c:hI:n:v'
+    opt_args = 'A:B:c:hI:n:s:v'
     now = int(time.time())
     created_after, created_before = 0, now
     distinguished_name = '*'
     archive_name = '*'
+    required_state = keyword_any
     try:
         (opts, args) = getopt.getopt(sys.argv[1:], opt_args)
     except getopt.GetoptError as err:
@@ -202,6 +209,8 @@ if '__main__' == __name__:
             distinguished_name = val
         elif opt == '-n':
             archive_name = val
+        elif opt == '-s':
+            required_state = val
         elif opt == '-v':
             verbose = True
         else:
@@ -229,7 +238,9 @@ if '__main__' == __name__:
             continue
 
         for freeze_name in os.listdir(base_path):
-            if not fnmatch.fnmatch(freeze_name, "archive-??????"):
+            # NOTE: tempfile increased random part from 6 to 8 chars in py3
+            if not fnmatch.fnmatch(freeze_name, "archive-??????") and \
+               not fnmatch.fnmatch(freeze_name, "archive-????????"):
                 continue
             if not fnmatch.fnmatch(freeze_name, archive_name):
                 if verbose:
@@ -253,7 +264,7 @@ if '__main__' == __name__:
     for (user_id, archive_list) in archive_hits.items():
         for freeze_path in archive_list:
             verified = check_archive_integrity(
-                configuration, user_id, freeze_path, verbose)
+                configuration, user_id, freeze_path, required_state, verbose)
             if verified:
                 print("%s [PASS]" % freeze_path)
             else:

--- a/mig/server/verifyarchives.py
+++ b/mig/server/verifyarchives.py
@@ -161,6 +161,7 @@ Where VERIFY_OPTIONS may be one or more of:
    -h                  Show this help
    -I CERT_DN          Filter to Archives of user ID (distinguished name pattern)
    -n ARCHIVE_NAME     Filter to specific Archive name(s) (pattern)
+   -s REQUIRED_STATE   Fail if Archive is not in REQUIRED_STATE (default is ANY)
    -v                  Verbose output
 """ % {'name': name})
 

--- a/tests/fixture/confs-stdlocal/migverifyarchives
+++ b/tests/fixture/confs-stdlocal/migverifyarchives
@@ -68,7 +68,7 @@ for archivelist in $(/bin/find "$archivestaging" -type f -regex "$marker_pattern
         verifycount=$((verifycount+1))
         email=$(echo "$archpath" | sed 's@.*emailAddress=\([^/]*\)\/archive-.*@\1@g')
         archname=$(echo "$archpath"|sed 's@.*\/\(archive-.*\)@\1@g')
-        su - mig -c "PYTHONPATH=/home/mig mig/server/verifyarchives.py -A $(date +%s -d 'a month ago') -I \"*${email}*\" -n \"$archname\""
+        su - mig -c "PYTHONPATH=/home/mig mig/server/verifyarchives.py -A $(date +%s -d 'a month ago') -I \"*${email}*\" -n \"$archname\" -s FINAL"
         checkfailed=$?
         if [ $checkfailed -eq 0 ]; then
             echo "$archpath" >> "$tmppassedlist"


### PR DESCRIPTION
Implement a simple `-s STATE` option in the verifyarchives.py helper to make it fail if the verified archive is not actually in `STATE`. Use it by default in the generated `migverifyarchives` cron job with `-s FINAL`, so that in case a non-FINAL archive should enter the list of archives to verify it will fail and tell why.

Also added proper support for the python3 on Rocky9 default of 8 random characters in the generated `Archive-????????` names from tempfile, which used to be only 6 characters on python2 in CentOS7.