### PR TITLE
Fix handling of binary output with output format override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,10 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+usr/lib/
+/lib64/
+usr/lib64/
 parts/
 sdist/
 var/

--- a/mig/lib/README
+++ b/mig/lib/README
@@ -1,8 +1,10 @@
 = Modernization and Clean Up =
-We will gradually move code here in the on-going modedrnization and clean up
+We will gradually move code here in the on-going modernization and clean up
 efforts.
 That also means that any code placed here MUST comply with the project style
 guides, be lint clean, documented and have decent unit test coverage.
 
 You may want to use autopep8, pylint, ruff or any available make lint targets
 to help verify.
+The black code formatter and isort may also come in handy. You can see usage
+hints in `.github/workflows/python-stylecheck.yml`.

--- a/mig/lib/README
+++ b/mig/lib/README
@@ -1,8 +1,8 @@
 = Modernization and Clean Up =
-We will radually move code here in the on-going modedrnization and clean up
-process.
-That also means that any code placed here must comply with the project style
-guide, be lint clean and have decent unit test coverage of all functions.
+We will gradually move code here in the on-going modedrnization and clean up
+efforts.
+That also means that any code placed here MUST comply with the project style
+guides, be lint clean, documented and have decent unit test coverage.
 
-You may want to use autopep8, pylint, ruff or any available make lint target
+You may want to use autopep8, pylint, ruff or any available make lint targets
 to help verify.

--- a/mig/lib/README
+++ b/mig/lib/README
@@ -1,0 +1,8 @@
+= Modernization and Clean Up =
+We will radually move code here in the on-going modedrnization and clean up
+process.
+That also means that any code placed here must comply with the project style
+guide, be lint clean and have decent unit test coverage of all functions.
+
+You may want to use autopep8, pylint, ruff or any available make lint target
+to help verify.

--- a/mig/lib/xgicore.py
+++ b/mig/lib/xgicore.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# xgicore - Xgi wrapper functions for functionality backends
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# -- END_HEADER ---
+#
+
+"""Shared helpers for CGI+WSGI interface to functionality backends."""
+
+
+def get_output_format(configuration, user_args, default_format='html'):
+    """Get output_format from user_args."""
+    return user_args.get('output_format', [default_format])[0]
+
+
+def override_output_format(configuration, user_args, out_objs, out_format):
+    """Override output_format if requested in start entry of output_objs."""
+    if not [i for i in out_objs if i.get('object_type', None) == 'start' and
+            i.get('override_format', False)]:
+        return out_format
+    return get_output_format(configuration, user_args)
+
+
+def fill_start_headers(configuration, out_objs, out_format):
+    """Make sure out_objs has start entry with basic content headers."""
+    start_entry = None
+    for entry in out_objs:
+        if entry['object_type'] == 'start':
+            start_entry = entry
+    if not start_entry:
+        start_entry = {'object_type': 'start', 'headers': []}
+        out_objs.insert(0, start_entry)
+    elif not start_entry.get('headers', False):
+        start_entry['headers'] = []
+    # Now fill headers to match output format
+    default_content = 'text/html'
+    if 'json' == out_format:
+        default_content = 'application/json'
+    elif 'file' == out_format:
+        default_content = 'application/octet-stream'
+    elif 'html' != out_format:
+        default_content = 'text/plain'
+    if not start_entry['headers']:
+        start_entry['headers'].append(('Content-Type', default_content))
+    return start_entry

--- a/mig/lib/xgicore.py
+++ b/mig/lib/xgicore.py
@@ -28,15 +28,18 @@
 """Shared helpers for CGI+WSGI interface to functionality backends."""
 
 
-def get_output_format(configuration, user_args, default_format='html'):
+def get_output_format(configuration, user_args, default_format="html"):
     """Get output_format from user_args."""
-    return user_args.get('output_format', [default_format])[0]
+    return user_args.get("output_format", [default_format])[0]
 
 
 def override_output_format(configuration, user_args, out_objs, out_format):
     """Override output_format if requested in start entry of output_objs."""
-    if not [i for i in out_objs if i.get('object_type', None) == 'start' and
-            i.get('override_format', False)]:
+    if not [
+        i
+        for i in out_objs
+        if i.get("object_type", None) == "start" and i.get("override_format", False)
+    ]:
         return out_format
     return get_output_format(configuration, user_args)
 
@@ -45,21 +48,21 @@ def fill_start_headers(configuration, out_objs, out_format):
     """Make sure out_objs has start entry with basic content headers."""
     start_entry = None
     for entry in out_objs:
-        if entry['object_type'] == 'start':
+        if entry["object_type"] == "start":
             start_entry = entry
     if not start_entry:
-        start_entry = {'object_type': 'start', 'headers': []}
+        start_entry = {"object_type": "start", "headers": []}
         out_objs.insert(0, start_entry)
-    elif not start_entry.get('headers', False):
-        start_entry['headers'] = []
+    elif not start_entry.get("headers", False):
+        start_entry["headers"] = []
     # Now fill headers to match output format
-    default_content = 'text/html'
-    if 'json' == out_format:
-        default_content = 'application/json'
-    elif 'file' == out_format:
-        default_content = 'application/octet-stream'
-    elif 'html' != out_format:
-        default_content = 'text/plain'
-    if not start_entry['headers']:
-        start_entry['headers'].append(('Content-Type', default_content))
+    default_content = "text/html"
+    if "json" == out_format:
+        default_content = "application/json"
+    elif "file" == out_format:
+        default_content = "application/octet-stream"
+    elif "html" != out_format:
+        default_content = "text/plain"
+    if not start_entry["headers"]:
+        start_entry["headers"].append(("Content-Type", default_content))
     return start_entry

--- a/mig/lib/xgicore.py
+++ b/mig/lib/xgicore.py
@@ -38,7 +38,8 @@ def override_output_format(configuration, user_args, out_objs, out_format):
     if not [
         i
         for i in out_objs
-        if i.get("object_type", None) == "start" and i.get("override_format", False)
+        if i.get("object_type", None) == "start"
+        and i.get("override_format", False)
     ]:
         return out_format
     return get_output_format(configuration, user_args)

--- a/mig/shared/cgiscriptstub.py
+++ b/mig/shared/cgiscriptstub.py
@@ -42,8 +42,8 @@ try:
 except:
     pass
 
-from mig.lib.xgicore import get_output_format, override_output_format, \
-    fill_start_headers
+from mig.lib.xgicore import fill_start_headers, get_output_format, \
+    override_output_format
 from mig.shared.bailout import crash_helper
 from mig.shared.base import requested_backend, allow_script, \
     is_default_str_coding, force_default_str_coding_rec

--- a/mig/shared/functionality/showvgridprivatefile.py
+++ b/mig/shared/functionality/showvgridprivatefile.py
@@ -116,6 +116,9 @@ private files dir.''' % label})
         if force_file:
             content = read_file(abs_path, logger, mode=src_mode)
             lines = [content]
+            # Force delivery of binary as file download
+            user_arguments_dict['output_format'] =  ['file']
+            start_entry['refresh_format'] = True
         else:
             content = lines = read_file_lines(abs_path, logger,
                                               mode=src_mode)

--- a/mig/shared/functionality/showvgridprivatefile.py
+++ b/mig/shared/functionality/showvgridprivatefile.py
@@ -117,8 +117,8 @@ private files dir.''' % label})
             content = read_file(abs_path, logger, mode=src_mode)
             lines = [content]
             # Force delivery of binary as file download
-            user_arguments_dict['output_format'] =  ['file']
-            start_entry['refresh_format'] = True
+            user_arguments_dict['output_format'] = ['file']
+            start_entry['override_format'] = True
         else:
             content = lines = read_file_lines(abs_path, logger,
                                               mode=src_mode)

--- a/mig/wsgi-bin/migwsgi.py
+++ b/mig/wsgi-bin/migwsgi.py
@@ -34,8 +34,8 @@ import os
 import sys
 import time
 
-from mig.lib.xgicore import get_output_format, override_output_format, \
-    fill_start_headers
+from mig.lib.xgicore import fill_start_headers, get_output_format, \
+    override_output_format
 from mig.shared import returnvalues
 from mig.shared.bailout import bailout_helper, crash_helper, compact_string
 from mig.shared.base import requested_backend, allow_script, \

--- a/tests/test_mig_lib_xgicore.py
+++ b/tests/test_mig_lib_xgicore.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# test_mig_lib_xgicore - unit test of the corresponding mig lib module
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# --- END_HEADER ---
+#
+
+"""Unit test xgicore functions"""
+
+import os
+import sys
+
+from tests.support import MigTestCase, FakeConfiguration, temppath, testmain
+
+from mig.lib.xgicore import *
+
+
+class MigLibXgicore__get_output_format(MigTestCase):
+    """Unit test get_output_format"""
+
+    def test_default_when_missing(self):
+        """Test that default output_format is returned when not set."""
+        expected = "html"
+        user_args = {}
+        actual = get_output_format(FakeConfiguration(), user_args,
+                                   default_format=expected)
+        self.assertEqual(actual, expected,
+                         "mismatch in default output_format")
+
+    def test_get_single_requested_format(self):
+        """Test that the requested output_format is returned."""
+        expected = "file"
+        user_args = {'output_format': [expected]}
+        actual = get_output_format(FakeConfiguration(), user_args,
+                                   default_format='BOGUS')
+        self.assertEqual(actual, expected,
+                         "mismatch in extracted output_format")
+
+    def test_get_first_requested_format(self):
+        """Test that first requested output_format is returned."""
+        expected = "file"
+        user_args = {'output_format': [expected, 'BOGUS']}
+        actual = get_output_format(FakeConfiguration(), user_args,
+                                   default_format='BOGUS')
+        self.assertEqual(actual, expected,
+                         "mismatch in extracted output_format")
+
+
+class MigLibXgicore__override_output_format(MigTestCase):
+    """Unit test override_output_format"""
+
+    def test_unchanged_without_override(self):
+        """Test that existing output_format is returned when not overriden."""
+        expected = "html"
+        user_args = {}
+        out_objs = []
+        actual = override_output_format(FakeConfiguration(), user_args,
+                                        out_objs, expected)
+        self.assertEqual(actual, expected,
+                         "mismatch in unchanged output_format")
+
+    def test_get_single_requested_format(self):
+        """Test that the requested output_format is returned if overriden."""
+        expected = "file"
+        user_args = {'output_format': [expected]}
+        out_objs = [{'object_type': 'start', 'override_format': True}]
+        actual = override_output_format(FakeConfiguration(), user_args,
+                                        out_objs, 'OVERRIDE')
+        self.assertEqual(actual, expected,
+                         "mismatch in overriden output_format")
+
+    def test_get_first_requested_format(self):
+        """Test that first requested output_format is returned if overriden."""
+        expected = "file"
+        user_args = {'output_format': [expected, 'BOGUS']}
+        actual = get_output_format(FakeConfiguration(), user_args,
+                                   default_format='BOGUS')
+        self.assertEqual(actual, expected,
+                         "mismatch in extracted output_format")
+
+
+class MigLibXgicore__fill_start_headers(MigTestCase):
+    """Unit test fill_start_headers"""
+
+    def test_unchanged_when_set(self):
+        """Test that existing valid start entry is returned as-is."""
+        out_format = "file"
+        headers = [('Content-Type', 'application/octet-stream'),
+                   ('Content-Size', 42)]
+        expected = {'object_type': 'start', 'headers': headers}
+        out_objs = [expected, {'object_type': 'binary', 'data': 42*b'0'}]
+        actual = fill_start_headers(FakeConfiguration(), out_objs, out_format)
+        self.assertEqual(actual, expected,
+                         "mismatch in unchanged start entry")
+
+    def test_headers_added_when_missing(self):
+        """Test that start entry headers are added if missing."""
+        out_format = "file"
+        headers = [('Content-Type', 'application/octet-stream')]
+        minimal_start = {'object_type': 'start'}
+        expected = {'object_type': 'start', 'headers': headers}
+        out_objs = [minimal_start, {'object_type': 'binary', 'data': 42*b'0'}]
+        actual = fill_start_headers(FakeConfiguration(), out_objs, out_format)
+        self.assertEqual(actual, expected,
+                         "mismatch in auto initialized start entry")
+
+    def test_start_added_when_missing(self):
+        """Test that start entry is added if missing."""
+        out_format = "file"
+        headers = [('Content-Type', 'application/octet-stream')]
+        expected = {'object_type': 'start', 'headers': headers}
+        out_objs = [{'object_type': 'binary', 'data': 42*b'0'}]
+        actual = fill_start_headers(FakeConfiguration(), out_objs, out_format)
+        self.assertEqual(actual, expected,
+                         "mismatch in auto initialized start entry")
+
+
+if __name__ == '__main__':
+    testmain()

--- a/tests/test_mig_lib_xgicore.py
+++ b/tests/test_mig_lib_xgicore.py
@@ -30,7 +30,7 @@
 import os
 import sys
 
-from tests.support import MigTestCase, FakeConfiguration, temppath, testmain
+from tests.support import MigTestCase, FakeConfiguration, testmain
 
 from mig.lib.xgicore import *
 


### PR DESCRIPTION
Adjust `cgiscriptstub` and `migwsgi` to allow consistent overriding of `output_format` in the functionality backends.
Reuses the `delay_format` idea only available in CGI, but generalizes it to use the `start` output_object entry, which is trivially available both in CGI and WSGI.
Includes refactoring of previously duplicated cgi and wsgi code for `output_format` parsing and `start` entry init plus header mangling into a shared `xgicore` helper in the new `mig/lib` subdir. Please refer to the included README there for details. 
Synchronizes CGI `output_format` parsing with that in WSGI to use first instead of last entry; probably never an issue but better safe than sorry.