### PR TITLE
 Implement default Content Type Options header in Apache

### DIFF
--- a/mig/install/apache-MiG-template.conf
+++ b/mig/install/apache-MiG-template.conf
@@ -169,6 +169,10 @@ Alias /status-events.json "__MIG_STATE__/wwwpublic/status-events.json"
     # recommended by W3C and security scans.
     Header always set Referrer-Policy "strict-origin-when-cross-origin"
 
+    # Set X-Content-Type-Options to harden for XSS abusing script or styles as
+    # recommended by W3C and security scans.
+    Header always set X-Content-Type-Options: "nosniff"
+
     # Force IE browsers to exit compatibility mode even if enabled for all 
     # intranet sites, which is the standard policy in some places.
     <FilesMatch "(^$|\.(htm|html)$)">

--- a/tests/fixture/confs-stdlocal/MiG.conf
+++ b/tests/fixture/confs-stdlocal/MiG.conf
@@ -169,6 +169,10 @@ Alias /status-events.json "/home/mig/state/wwwpublic/status-events.json"
     # recommended by W3C and security scans.
     Header always set Referrer-Policy "strict-origin-when-cross-origin"
 
+    # Set X-Content-Type-Options to harden for XSS abusing script or styles as
+    # recommended by W3C and security scans.
+    Header always set X-Content-Type-Options: "nosniff"
+
     # Force IE browsers to exit compatibility mode even if enabled for all 
     # intranet sites, which is the standard policy in some places.
     <FilesMatch "(^$|\.(htm|html)$)">


### PR DESCRIPTION
Add X-Content-Type-Options 'nosniff'` header in apache to harden against XSS attacks sneaking in scripts or stylesheets from arbitrary files.