### PR TITLE
Adjust our SSH algorithm tuning to better fit ssh-audit hardening guides

### DIFF
--- a/mig/shared/defaults.py
+++ b/mig/shared/defaults.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # defaults - default constant values used in many locations
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -488,7 +489,8 @@ STRONG_TLS_CURVES = "prime256v1:secp384r1:secp521r1"
 STRONG_SSH_HOSTKEYALGOS = "ssh-ed25519,rsa-sha2-512,rsa-sha2-256"
 LEGACY_SSH_HOSTKEYALGOS = ",".join([STRONG_SSH_HOSTKEYALGOS, "ssh-rsa"])
 FALLBACK_SSH_HOSTKEYALGOS = LEGACY_SSH_HOSTKEYALGOS
-STRONG_SSH_KEXALGOS = "sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,curve25519-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512"
+# TODO: add the quantum safe future default mlkem768x25519-sha256 on Rocky10+
+STRONG_SSH_KEXALGOS = "sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512"
 # NOTE: fall back to relatively safe DH group-exchange-sha256 on old paramiko etc.
 LEGACY_SSH_KEXALGOS = ",".join([STRONG_SSH_KEXALGOS,
                                 "diffie-hellman-group-exchange-sha256"])

--- a/mig/shared/defaults.py
+++ b/mig/shared/defaults.py
@@ -470,7 +470,8 @@ STRONG_TLS_CURVES = "prime256v1:secp384r1:secp521r1"
 # to allow in OpenSSH and native Paramiko SFTP daemons (on OpenSSH format).
 # NOTE: harden in line with Mozilla recommendations for modern versions:
 # https://wiki.mozilla.org/Security/Guidelines/OpenSSH#Configuration
-# Additional hardening based on https://github.com/arthepsy/ssh-audit
+# Additional hardening based on https://github.com/arthepsy/ssh-audit and
+# https://www.sshaudit.com/hardening_guides.html
 # Please note that the DH GroupX KexAlgorithms require OpenSSH 7.3+, but that
 # older versions can relatively safely fall back to instead use the
 # diffie-hellman-group-exchange-sha256 as long as the moduli tuning from
@@ -487,16 +488,16 @@ STRONG_TLS_CURVES = "prime256v1:secp384r1:secp521r1"
 STRONG_SSH_HOSTKEYALGOS = "ssh-ed25519,rsa-sha2-512,rsa-sha2-256"
 LEGACY_SSH_HOSTKEYALGOS = ",".join([STRONG_SSH_HOSTKEYALGOS, "ssh-rsa"])
 FALLBACK_SSH_HOSTKEYALGOS = LEGACY_SSH_HOSTKEYALGOS
-STRONG_SSH_KEXALGOS = "curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,diffie-hellman-group16-sha512"
+STRONG_SSH_KEXALGOS = "sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,curve25519-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512"
 # NOTE: fall back to relatively safe DH group-exchange-sha256 on old paramiko etc.
 LEGACY_SSH_KEXALGOS = ",".join([STRONG_SSH_KEXALGOS,
                                 "diffie-hellman-group-exchange-sha256"])
 FALLBACK_SSH_KEXALGOS = LEGACY_SSH_KEXALGOS
-STRONG_SSH_CIPHERS = "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
+STRONG_SSH_CIPHERS = "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-gcm@openssh.com,aes128-ctr"
 # NOTE: avoid chacha20-poly1305@openssh.com to mitigate Terrapin issue on old servers
-LEGACY_SSH_CIPHERS = "aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
+LEGACY_SSH_CIPHERS = "aes256-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-gcm@openssh.com,aes128-ctr"
 FALLBACK_SSH_CIPHERS = LEGACY_SSH_CIPHERS
-STRONG_SSH_MACS = "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com"
+STRONG_SSH_MACS = "hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com"
 LEGACY_SSH_MACS = STRONG_SSH_MACS
 # NOTE: fall back to safe MACS with the best possible alternatives on ancient paramiko
 #       to avoid falling back to really bad ones

--- a/tests/fixture/confs-stdlocal/sshd_config-MiG-sftp-subsys
+++ b/tests/fixture/confs-stdlocal/sshd_config-MiG-sftp-subsys
@@ -39,9 +39,9 @@ HostKey /home/mig/certs//server.key
 # IMPORTANT: these are *generated* hardened values based on generateconf
 # invocation. Any permanent changes need to be made there.
 HostKeyAlgorithms ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
-KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,diffie-hellman-group16-sha512,diffie-hellman-group-exchange-sha256
-Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
+KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,curve25519-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256
+Ciphers aes256-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-gcm@openssh.com,aes128-ctr
+MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
 
 # Logging
 # obsoletes QuietMode and FascistLogging

--- a/tests/fixture/confs-stdlocal/sshd_config-MiG-sftp-subsys
+++ b/tests/fixture/confs-stdlocal/sshd_config-MiG-sftp-subsys
@@ -39,7 +39,7 @@ HostKey /home/mig/certs//server.key
 # IMPORTANT: these are *generated* hardened values based on generateconf
 # invocation. Any permanent changes need to be made there.
 HostKeyAlgorithms ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
-KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,curve25519-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256
+KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256
 Ciphers aes256-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-gcm@openssh.com,aes128-ctr
 MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
 


### PR DESCRIPTION
Adjusted our SSH algorithm tuning to better fit the ssh-audit hardening recommendations for Rocky 9:
https://www.sshaudit.com/hardening_guides.html#rocky_9
The changes include added modern algos as well as small reordering to balance security and performance.

NOTE: the tuning possibly changes default negotiated security parameters. So we have verified that it still works correctly and that it doesn't degrade performance on one of our Rocky 9 pre-production deployments using the existing paramiko-3.5.x setup. It's only the key exchange (KEX) changing default, not the actual ciphers used to encrypt during transfers, so that makes perfect sense.