### PR TITLE
Prevent concurrent migverifyarchives cronjobs and resulting interference

### DIFF
--- a/mig/install/migverifyarchives-template.sh.cronjob
+++ b/mig/install/migverifyarchives-template.sh.cronjob
@@ -29,6 +29,16 @@ if [ ! -d "$archivestaging" ]; then
     exit 42
 fi
 
+pidfile="__MIG_STATE__/mig_system_run/migverifyarchives.pid"
+if [ -e "$pidfile" ]; then
+    RUN_PID=$(cat $pidfile)
+    if /usr/bin/pgrep -f migverifyarchives | grep ${RUN_PID} ; then
+        echo "Warning: an existing instance of $0 is already active"
+        exit 1
+    fi
+fi
+echo $$ > $pidfile
+
 # Monthly long range search for pending finalized files, otherwise only look for today
 today=$(date +%Y%m%d)
 day_of_month=$(date +%d)
@@ -89,5 +99,7 @@ for archivelist in $(/bin/find "$archivestaging" -type f -regex "$marker_pattern
     totalcount=$((totalcount+verifycount))
     totalfailed=$((totalfailed+verifyfailed))
 done
+
+rm -f $pidfile
 
 exit $totalfailed

--- a/mig/install/migverifyarchives-template.sh.cronjob
+++ b/mig/install/migverifyarchives-template.sh.cronjob
@@ -31,8 +31,8 @@ fi
 
 pidfile="__MIG_STATE__/mig_system_run/migverifyarchives.pid"
 if [ -e "$pidfile" ]; then
-    RUN_PID=$(cat $pidfile)
-    if /usr/bin/pgrep -f migverifyarchives | grep ${RUN_PID} ; then
+    RUN_PID=$(/bin/cat $pidfile)
+    if /bin/pgrep -f migverifyarchives | /bin/grep "${RUN_PID}" ; then
         echo "Warning: an existing instance of $0 is already active"
         exit 1
     fi
@@ -100,6 +100,6 @@ for archivelist in $(/bin/find "$archivestaging" -type f -regex "$marker_pattern
     totalfailed=$((totalfailed+verifyfailed))
 done
 
-rm -f $pidfile
+/bin/rm -f $pidfile
 
 exit $totalfailed

--- a/tests/fixture/confs-stdlocal/migverifyarchives
+++ b/tests/fixture/confs-stdlocal/migverifyarchives
@@ -29,6 +29,16 @@ if [ ! -d "$archivestaging" ]; then
     exit 42
 fi
 
+pidfile="/home/mig/state/mig_system_run/migverifyarchives.pid"
+if [ -e "$pidfile" ]; then
+    RUN_PID=$(/bin/cat $pidfile)
+    if /bin/pgrep -f migverifyarchives | /bin/grep "${RUN_PID}" ; then
+        echo "Warning: an existing instance of $0 is already active"
+        exit 1
+    fi
+fi
+echo $$ > $pidfile
+
 # Monthly long range search for pending finalized files, otherwise only look for today
 today=$(date +%Y%m%d)
 day_of_month=$(date +%d)
@@ -89,5 +99,7 @@ for archivelist in $(/bin/find "$archivestaging" -type f -regex "$marker_pattern
     totalcount=$((totalcount+verifycount))
     totalfailed=$((totalfailed+verifyfailed))
 done
+
+/bin/rm -f $pidfile
 
 exit $totalfailed


### PR DESCRIPTION
If there are a many or big archives to verify the hourly run may not complete before the next one kicks in and messes with the same verification output file.
Add a simple PID file in the `migverifyarchives` cronjob and use it to prevent multiple running instances that would interfere with one another like that.