### PR TITLE
Enable HSTS in vhost on PUBLIC_ALIAS_FQDN as well for increased security

### DIFF
--- a/mig/install/apache-MiG-template.conf
+++ b/mig/install/apache-MiG-template.conf
@@ -480,7 +480,7 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
     __PREFER_HTTPS_COMMENTED__<IfDefine PUBLIC_HTTPS_PORT>
     __PREFER_HTTPS_COMMENTED__    RewriteCond %{HTTPS} off
     __PREFER_HTTPS_COMMENTED__    RewriteCond %{HTTP_HOST} ^${BASE_FQDN}$
-    __PREFER_HTTPS_COMMENTED__    RewriteRule ^/?(.*) https://${PUBLIC_FQDN}:${PUBLIC_HTTPS_PORT}/$1 [R,L]
+    __PREFER_HTTPS_COMMENTED__    RewriteRule ^/?(.*) https://${BASE_FQDN}:${PUBLIC_HTTPS_PORT}/$1 [R,L]
     __PREFER_HTTPS_COMMENTED__    
     __PREFER_HTTPS_COMMENTED__    RewriteCond %{HTTPS} off
     __PREFER_HTTPS_COMMENTED__    RewriteCond %{HTTP_HOST} ^${PUBLIC_FQDN}$

--- a/mig/install/apache-MiG-template.conf
+++ b/mig/install/apache-MiG-template.conf
@@ -781,6 +781,14 @@ __IS_VERIFYCERTS_COMMENTED__ <VirtualHost *:${PUBLIC_HTTP_PORT}>
     SSLCertificateKeyFile __MIG_CERTS__/${PUBLIC_ALIAS_FQDN}/server.key
     SSLCertificateChainFile __MIG_CERTS__/${PUBLIC_ALIAS_FQDN}/server.ca.pem
 
+    <IfModule mod_headers.c>
+        # Use HSTS if enabled
+        __HSTS_COMMENTED__ Header always set Strict-Transport-Security "max-age=31536000"
+        # As a precaution apply proxy limit in line with security advisory on:
+        # http://www.apache.org/security/asf-httpoxy-response.txt
+        RequestHeader unset Proxy early
+    </IfModule>
+
     #   SSL Engine Switch:
     #   Enable/Disable SSL for this virtual host.
     SSLEngine on

--- a/tests/fixture/confs-stdlocal/MiG.conf
+++ b/tests/fixture/confs-stdlocal/MiG.conf
@@ -781,6 +781,14 @@ Alias /status-events.json "/home/mig/state/wwwpublic/status-events.json"
     SSLCertificateKeyFile /home/mig/certs/${PUBLIC_ALIAS_FQDN}/server.key
     SSLCertificateChainFile /home/mig/certs/${PUBLIC_ALIAS_FQDN}/server.ca.pem
 
+    <IfModule mod_headers.c>
+        # Use HSTS if enabled
+        Header always set Strict-Transport-Security "max-age=31536000"
+        # As a precaution apply proxy limit in line with security advisory on:
+        # http://www.apache.org/security/asf-httpoxy-response.txt
+        RequestHeader unset Proxy early
+    </IfModule>
+
     #   SSL Engine Switch:
     #   Enable/Disable SSL for this virtual host.
     SSLEngine on

--- a/tests/fixture/confs-stdlocal/MiG.conf
+++ b/tests/fixture/confs-stdlocal/MiG.conf
@@ -480,7 +480,7 @@ Alias /status-events.json "/home/mig/state/wwwpublic/status-events.json"
     <IfDefine PUBLIC_HTTPS_PORT>
        RewriteCond %{HTTPS} off
        RewriteCond %{HTTP_HOST} ^${BASE_FQDN}$
-       RewriteRule ^/?(.*) https://${PUBLIC_FQDN}:${PUBLIC_HTTPS_PORT}/$1 [R,L]
+       RewriteRule ^/?(.*) https://${BASE_FQDN}:${PUBLIC_HTTPS_PORT}/$1 [R,L]
        
        RewriteCond %{HTTPS} off
        RewriteCond %{HTTP_HOST} ^${PUBLIC_FQDN}$


### PR DESCRIPTION
Add missing HSTS header on the `PUBLIC_ALIAS_FQDN` vhost to avoid security degradation if in use with less security focused clients.