### PR TITLE
Implement the python side of SFTP access to all sharelinks

### DIFF
--- a/mig/server/grid_sftp.py
+++ b/mig/server/grid_sftp.py
@@ -123,6 +123,7 @@ _write_ops = ['mkdir', 'rmdir', 'remove', 'rename', 'chmod', 'chown',
 _filter_ops = ['chattr', 'lstat', 'stat']
 _other_ops = ['close']
 
+
 def list_attr_changes(configuration, path, attr):
     """Decipher actual attribute changes requested in attr on path"""
     _logger = configuration.logger
@@ -130,12 +131,13 @@ def list_attr_changes(configuration, path, attr):
     changes = []
     for field in ('st_size', 'st_uid', 'st_gid', 'st_mode', 'st_atime',
                   'st_mtime'):
-        #_logger.debug("checking path %s attr %s" % (path, field))
+        # _logger.debug("checking path %s attr %s" % (path, field))
         val = getattr(attr, field, None)
         if val is not None:
             _logger.debug("found %s attr %s value %s" % (path, field, val))
             changes.append(field)
     return changes
+
 
 def filter_data_access(configuration, path, access_mode, operation, args=[]):
     """Filter access to what operation is allowed to do based on path, args
@@ -160,7 +162,7 @@ def filter_data_access(configuration, path, access_mode, operation, args=[]):
             return True
         # NOTE: allow non-changing chattr
         # TODO: allow non-changing chown and chmod, too?
-        if operation  == 'chattr' and args:
+        if operation == 'chattr' and args:
             if not list_attr_changes(configuration, path, args[0]):
                 return True
 
@@ -176,6 +178,7 @@ def filter_data_access(configuration, path, access_mode, operation, args=[]):
         _logger.warning("invalid %s operation on %s in %s session" %
                         (operation, path, access_mode))
         return False
+
 
 def check_data_access(configuration, user_id, path, access_mode, operation,
                       args=[]):
@@ -908,7 +911,8 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         path = force_native_str(path)
         self.logger.debug("_chattr %r %r" % (path, attr))
         try:
-            real_path = self._get_fs_path(path, operation='chattr', args=[attr])
+            real_path = self._get_fs_path(path, operation='chattr',
+                                          args=[attr])
         except AccessError as aer:
             self.logger.warning('chattr %s: %s' % ([path], [aer]))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1048,7 +1052,8 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
             open_flavor = 'open+read'
 
         try:
-            real_path = self._get_fs_path(path, operation=open_flavor, args=[flags])
+            real_path = self._get_fs_path(path, operation=open_flavor,
+                                          args=[flags])
         except ValueError as err:
             self.logger.warning('open %s: %s' % ([path], [err]))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1122,7 +1127,8 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         """Handle operations of same name"""
         # self.logger.debug('list_folder %s' % [path])
         try:
-            real_path = self._get_fs_path(path, operation='list_folder', args=[])
+            real_path = self._get_fs_path(path, operation='list_folder',
+                                          args=[])
         except ValueError as err:
             self.logger.warning('list_folder %s: %s' % ([path], [err]))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1268,7 +1274,8 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # newpath = force_utf8(newpath)
         # self.logger.debug("rename %s %s" % (oldpath, newpath))
         try:
-            real_oldpath = self._get_fs_path(oldpath, operation='rename', args=[])
+            real_oldpath = self._get_fs_path(oldpath, operation='rename',
+                                             args=[])
         except ValueError as err:
             self.logger.warning('rename %s %s: %s' % (oldpath, newpath, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1684,8 +1691,8 @@ def update_sftp_login_map(daemon_conf, username, password=False, key=False):
             _, changed_users = refresh_user_creds(configuration,
                                                   'sftp', username)
         if possible_sharelink_id(configuration, username):
-            allow_modes = [READ_WRITE_ACCESS, READ_ONLY_ACCESS,
-                           WRITE_ONLY_ACCESS]
+            allow_modes = (READ_WRITE_ACCESS, READ_ONLY_ACCESS,
+                           WRITE_ONLY_ACCESS)
             _, changed_shares = refresh_share_creds(configuration,
                                                     'sftp', username,
                                                     share_modes=allow_modes)

--- a/mig/server/grid_sftp.py
+++ b/mig/server/grid_sftp.py
@@ -89,7 +89,8 @@ from mig.shared.conf import get_configuration_object
 from mig.shared.defaults import keyword_auto, STRONG_SSH_KEXALGOS, \
     STRONG_SSH_CIPHERS, STRONG_SSH_MACS, LEGACY_SSH_KEXALGOS, \
     LEGACY_SSH_CIPHERS, LEGACY_SSH_MACS, FALLBACK_SSH_KEXALGOS, \
-    FALLBACK_SSH_CIPHERS, FALLBACK_SSH_MACS
+    FALLBACK_SSH_CIPHERS, FALLBACK_SSH_MACS, READ_WRITE_ACCESS, \
+    READ_ONLY_ACCESS, WRITE_ONLY_ACCESS
 from mig.shared.fileio import check_write_access, user_chroot_exceptions, \
     read_file
 from mig.shared.gdp.all import project_open, project_close, project_log
@@ -114,6 +115,49 @@ from mig.shared.vgridaccess import is_vgrid_parent_placeholder
 from mig.shared.workflows import add_workflow_job_history_entry
 
 configuration, logger = None, None
+
+_read_ops = ['stat', 'lstat', 'list_folder', 'check', 'read', 'readlink',
+             'open+read']
+_write_ops = ['mkdir', 'rmdir', 'remove', 'rename', 'chmod', 'chown',
+              'chattr', 'write', 'truncate', 'open+write']
+_other_ops = ['close']
+
+
+def check_data_access(configuration, user_id, path, access_mode, operation):
+    """A simple helper to check if user_id has access to execute operation on path
+    under the constraints set by access_mode. Namely, check if operation
+    could potentially modify data in a read-only session or lookup/read data
+    from a write-only session. This check covers both metadata and contents.
+    """
+    _logger = configuration.logger
+    if operation in _write_ops:
+        if access_mode == READ_ONLY_ACCESS:
+            _logger.warning("invalid %s operation for %s in %s session" %
+                            (operation, user_id, access_mode))
+            return False
+    elif operation in _read_ops:
+        if access_mode == WRITE_ONLY_ACCESS:
+            _logger.warning("invalid %s operation for %s in %s session" %
+                            (operation, user_id, access_mode))
+            return False
+    elif operation in _other_ops:
+        _logger.debug("ignoring %s operation for %r in %s session" %
+                      (operation, user_id, access_mode))
+    else:
+        _logger.error("invalid %s operation for %s in %s session" %
+                      (operation, user_id, access_mode))
+        return False
+
+    _logger.debug("accept %s operation for %s in %s session" %
+                  (operation, user_id, access_mode))
+    return True
+
+
+class AccessError(Exception):
+    """A simple helper used for access control when read-only or write-only
+    logins are in play.
+    """
+    pass
 
 
 class SFTPHandle(paramiko.SFTPHandle):
@@ -300,7 +344,8 @@ class SFTPHandle(paramiko.SFTPHandle):
                     msg = "GDP log calculated endpos: %s != " \
                         % endpos \
                         + " file endpos: %s, '%s'" % \
-                        (file_endpos, self.sftpserver._get_fs_path(path))
+                        (file_endpos, self.sftpserver._get_fs_path(
+                            path, operation=method.__name__))
                     logger.warning(msg)
 
             # close
@@ -408,6 +453,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
     logger = None
     transport = None
     root = None
+    access = READ_WRITE_ACCESS
     ip_addr = None
     src_port = None
 
@@ -487,6 +533,11 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
                 self.root = force_native_str("%s/%s" % (self.root, entry.home))
                 break
         # logger.debug('auth user chroot is %s' % self.root)
+        for entry in entries:
+            if entry.access:
+                self.access = entry.access
+                break
+        logger.info('auth user access is %s' % self.access)
 
     def _abort_on_missing_client_var(self, caller):
         """Simple helper to abort further action in session_started and
@@ -742,8 +793,16 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
 
     # Use shared daemon fs helper functions
 
-    def _get_fs_path(self, sftp_path):
+    def _get_fs_path(self, sftp_path, operation=None):
         """Wrap helper"""
+        # self.logger.debug("get_fs_path: check access to %s" % [sftp_path])
+        if not check_data_access(configuration, self.user_name, sftp_path,
+                                 self.access, operation):
+            self.logger.warning("get_fs_path: refused %s %s access to %r" %
+                                (self.user_name, operation, sftp_path))
+            raise AccessError("%r not allowed to %s %r in this %s session" %
+                              (self.user_name, operation, sftp_path,
+                               self.access))
         try:
             # self.logger.debug("get_fs_path: %s" % [sftp_path])
             abs_path = os.path.abspath(os.path.join(self.root,
@@ -789,7 +848,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         path = force_native_str(path)
         # self.logger.debug("_chattr %s" % [path])
         try:
-            real_path = self._get_fs_path(path)
+            real_path = self._get_fs_path(path, operation='chattr')
         except ValueError as err:
             self.logger.warning('chattr %s: %s' % ([path], [err]))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -869,7 +928,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("_chmod %s" % path)
         try:
-            real_path = self._get_fs_path(path)
+            real_path = self._get_fs_path(path, operation='chmod')
         except ValueError as err:
             self.logger.warning('chmod %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -917,8 +976,16 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # TODO: where should we force utf8 now?
         # path = force_utf8(path)
         # self.logger.debug('open %s' % [path])
+        if flags & (os.O_CREAT | os.O_RDWR | os.O_WRONLY |
+                    os.O_APPEND | os.O_TRUNC):
+            open_write = True
+            open_flavor = 'open+write'
+        else:
+            open_write = False
+            open_flavor = 'open+read'
+
         try:
-            real_path = self._get_fs_path(path)
+            real_path = self._get_fs_path(path, operation=open_flavor)
         except ValueError as err:
             self.logger.warning('open %s: %s' % ([path], [err]))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -931,15 +998,11 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
             self.logger.error("open existing file on missing path %s :: %s" %
                               (path, real_path))
             return paramiko.SFTP_NO_SUCH_FILE
-        if (flags & (os.O_CREAT |
-                     os.O_RDWR |
-                     os.O_WRONLY |
-                     os.O_APPEND |
-                     os.O_TRUNC)) \
-                and not check_write_access(real_path, parent_dir=True):
+        if open_write and not check_write_access(real_path, parent_dir=True):
             self.logger.error("open for modify on read-only path %s :: %s" %
                               (path, real_path))
             return paramiko.SFTP_PERMISSION_DENIED
+
         if not self.__gdp_log("open", path, flags=flags):
             return paramiko.SFTP_FAILURE
         # self.logger.debug("open SFTPHandle on %s" % [path])
@@ -996,7 +1059,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         """Handle operations of same name"""
         # self.logger.debug('list_folder %s' % [path])
         try:
-            real_path = self._get_fs_path(path)
+            real_path = self._get_fs_path(path, operation='list_folder')
         except ValueError as err:
             self.logger.warning('list_folder %s: %s' % ([path], [err]))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1044,7 +1107,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug('stat %s' % path)
         try:
-            real_path = self._get_fs_path(path)
+            real_path = self._get_fs_path(path, operation='stat')
         except ValueError as err:
             self.logger.warning('stat %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1058,6 +1121,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
             # self.logger.debug("stat on missing path %s :: %s" %
             #                  (path, real_path))
             return paramiko.SFTP_NO_SUCH_FILE
+            return paramiko.SFTP_PERMISSION_DENIED
         try:
             return paramiko.SFTPAttributes.from_stat(os.stat(real_path), path)
         except Exception as err:
@@ -1071,7 +1135,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug('lstat %s' % path)
         try:
-            real_path = self._get_fs_path(path)
+            real_path = self._get_fs_path(path, operation='lstat')
         except ValueError as err:
             self.logger.warning('lstat %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1095,7 +1159,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("remove %s" % path)
         try:
-            real_path = self._get_fs_path(path)
+            real_path = self._get_fs_path(path, operation='remove')
         except ValueError as err:
             self.logger.warning('remove %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1141,7 +1205,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # newpath = force_utf8(newpath)
         # self.logger.debug("rename %s %s" % (oldpath, newpath))
         try:
-            real_oldpath = self._get_fs_path(oldpath)
+            real_oldpath = self._get_fs_path(oldpath, operation='rename')
         except ValueError as err:
             self.logger.warning('rename %s %s: %s' % (oldpath, newpath, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1167,7 +1231,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
             self.logger.warning('move on read-only old path %s :: %s' %
                                 (oldpath, real_oldpath))
             return paramiko.SFTP_PERMISSION_DENIED
-        real_newpath = self._get_fs_path(newpath)
+        real_newpath = self._get_fs_path(newpath, operation='rename')
         if not check_write_access(real_newpath, parent_dir=True):
             self.logger.warning('move on read-only new path %s :: %s' %
                                 (newpath, real_newpath))
@@ -1194,7 +1258,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("mkdir %s" % path)
         try:
-            real_path = self._get_fs_path(path)
+            real_path = self._get_fs_path(path, operation='mkdir')
         except ValueError as err:
             self.logger.warning('mkdir %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1225,7 +1289,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("rmdir %s" % path)
         try:
-            real_path = self._get_fs_path(path)
+            real_path = self._get_fs_path(path, operation='rmdir')
         except ValueError as err:
             self.logger.warning('rmdir %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1278,7 +1342,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("readlink %s" % path)
         try:
-            real_path = self._get_fs_path(path)
+            real_path = self._get_fs_path(path, operation='readlink')
         except ValueError as err:
             self.logger.warning('readlink %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1557,8 +1621,11 @@ def update_sftp_login_map(daemon_conf, username, password=False, key=False):
             _, changed_users = refresh_user_creds(configuration,
                                                   'sftp', username)
         if possible_sharelink_id(configuration, username):
+            allow_modes = [READ_WRITE_ACCESS, READ_ONLY_ACCESS,
+                           WRITE_ONLY_ACCESS]
             _, changed_shares = refresh_share_creds(configuration,
-                                                    'sftp', username)
+                                                    'sftp', username,
+                                                    share_modes=allow_modes)
     if key:
         # Jobs and jupyter only use keys
         if possible_job_id(configuration, username):

--- a/mig/server/grid_sftp.py
+++ b/mig/server/grid_sftp.py
@@ -116,14 +116,69 @@ from mig.shared.workflows import add_workflow_job_history_entry
 
 configuration, logger = None, None
 
-_read_ops = ['stat', 'lstat', 'list_folder', 'check', 'read', 'readlink',
+_read_ops = ['list_folder', 'check', 'read', 'readlink',
              'open+read']
 _write_ops = ['mkdir', 'rmdir', 'remove', 'rename', 'chmod', 'chown',
-              'chattr', 'write', 'truncate', 'open+write']
+              'write', 'truncate', 'open+write']
+_filter_ops = ['chattr', 'lstat', 'stat']
 _other_ops = ['close']
 
+def list_attr_changes(configuration, path, attr):
+    """Decipher actual attribute changes requested in attr on path"""
+    _logger = configuration.logger
+    _logger.debug("check %s attr changes: %s" % (path, attr))
+    changes = []
+    for field in ('st_size', 'st_uid', 'st_gid', 'st_mode', 'st_atime',
+                  'st_mtime'):
+        #_logger.debug("checking path %s attr %s" % (path, field))
+        val = getattr(attr, field, None)
+        if val is not None:
+            _logger.debug("found %s attr %s value %s" % (path, field, val))
+            changes.append(field)
+    return changes
 
-def check_data_access(configuration, user_id, path, access_mode, operation):
+def filter_data_access(configuration, path, access_mode, operation, args=[]):
+    """Filter access to what operation is allowed to do based on path, args
+    and access_mode.
+    In read-write mode all operations are allowed to proceed path checks.
+    In write-only mode the potentially changing operations are always allowed
+    and specific stat/lstat is allowed as well to make most clients behave
+    without conusing errors. It doesn't reveal any directory or file contents
+    apart from metadata about paths the user already knows about.
+    In read-only mode stat is always allowed while the potentially changing
+    operations are rejected if they would actually modify anything.
+    """
+    _logger = configuration.logger
+    _logger.debug("filter %s operation on %s with %s args in %s session" %
+                  (operation, path, args, access_mode))
+    if access_mode == READ_WRITE_ACCESS:
+        return True
+    if access_mode == READ_ONLY_ACCESS:
+        _logger.debug("checking %s on %s with %s in %s session" %
+                      (operation, path, args, access_mode))
+        if operation in ['lstat', 'stat']:
+            return True
+        # NOTE: allow non-changing chattr
+        # TODO: allow non-changing chown and chmod, too?
+        if operation  == 'chattr' and args:
+            if not list_attr_changes(configuration, path, args[0]):
+                return True
+
+        _logger.warning("invalid %s operation on %s in %s session" %
+                        (operation, path, access_mode))
+        return False
+    if access_mode == WRITE_ONLY_ACCESS:
+        if operation in ['chattr']:
+            return True
+        # NOTE: allow specific lstat/stat for write-only shares
+        if operation in ['lstat', 'stat']:
+            return True
+        _logger.warning("invalid %s operation on %s in %s session" %
+                        (operation, path, access_mode))
+        return False
+
+def check_data_access(configuration, user_id, path, access_mode, operation,
+                      args=[]):
     """A simple helper to check if user_id has access to execute operation on path
     under the constraints set by access_mode. Namely, check if operation
     could potentially modify data in a read-only session or lookup/read data
@@ -140,6 +195,11 @@ def check_data_access(configuration, user_id, path, access_mode, operation):
             _logger.warning("invalid %s operation for %s in %s session" %
                             (operation, user_id, access_mode))
             return False
+    elif operation in _filter_ops:
+        _logger.debug("filter %s operation on %s with %s args for %r in %s session" %
+                      (operation, path, args, user_id, access_mode))
+        return filter_data_access(configuration, path, access_mode, operation,
+                                  args)
     elif operation in _other_ops:
         _logger.debug("ignoring %s operation for %r in %s session" %
                       (operation, user_id, access_mode))
@@ -345,7 +405,7 @@ class SFTPHandle(paramiko.SFTPHandle):
                         % endpos \
                         + " file endpos: %s, '%s'" % \
                         (file_endpos, self.sftpserver._get_fs_path(
-                            path, operation=method.__name__))
+                            path, operation=method.__name__, args=[]))
                     logger.warning(msg)
 
             # close
@@ -793,13 +853,13 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
 
     # Use shared daemon fs helper functions
 
-    def _get_fs_path(self, sftp_path, operation=None):
+    def _get_fs_path(self, sftp_path, operation=None, args=[]):
         """Wrap helper"""
         # self.logger.debug("get_fs_path: check access to %s" % [sftp_path])
         if not check_data_access(configuration, self.user_name, sftp_path,
-                                 self.access, operation):
-            self.logger.warning("get_fs_path: refused %s %s access to %r" %
-                                (self.user_name, operation, sftp_path))
+                                 self.access, operation, args):
+            self.logger.warning("get_fs_path: refused %s %s (%s) access to %r" %
+                                (self.user_name, operation, args, sftp_path))
             raise AccessError("%r not allowed to %s %r in this %s session" %
                               (self.user_name, operation, sftp_path,
                                self.access))
@@ -846,11 +906,14 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # Paramiko seems to handle *native* strings correctly across py version
         path = force_native_str(path)
-        # self.logger.debug("_chattr %s" % [path])
+        self.logger.debug("_chattr %r %r" % (path, attr))
         try:
-            real_path = self._get_fs_path(path, operation='chattr')
-        except ValueError as err:
-            self.logger.warning('chattr %s: %s' % ([path], [err]))
+            real_path = self._get_fs_path(path, operation='chattr', args=[attr])
+        except AccessError as aer:
+            self.logger.warning('chattr %s: %s' % ([path], [aer]))
+            return paramiko.SFTP_PERMISSION_DENIED
+        except ValueError as ver:
+            self.logger.warning('chattr %s: %s' % ([path], [ver]))
             return paramiko.SFTP_PERMISSION_DENIED
         if not os.path.exists(real_path):
             self.logger.warning("chattr on missing path %s :: %s" %
@@ -928,7 +991,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("_chmod %s" % path)
         try:
-            real_path = self._get_fs_path(path, operation='chmod')
+            real_path = self._get_fs_path(path, operation='chmod', args=[mode])
         except ValueError as err:
             self.logger.warning('chmod %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -985,7 +1048,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
             open_flavor = 'open+read'
 
         try:
-            real_path = self._get_fs_path(path, operation=open_flavor)
+            real_path = self._get_fs_path(path, operation=open_flavor, args=[flags])
         except ValueError as err:
             self.logger.warning('open %s: %s' % ([path], [err]))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1059,7 +1122,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         """Handle operations of same name"""
         # self.logger.debug('list_folder %s' % [path])
         try:
-            real_path = self._get_fs_path(path, operation='list_folder')
+            real_path = self._get_fs_path(path, operation='list_folder', args=[])
         except ValueError as err:
             self.logger.warning('list_folder %s: %s' % ([path], [err]))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1107,7 +1170,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug('stat %s' % path)
         try:
-            real_path = self._get_fs_path(path, operation='stat')
+            real_path = self._get_fs_path(path, operation='stat', args=[])
         except ValueError as err:
             self.logger.warning('stat %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1135,7 +1198,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug('lstat %s' % path)
         try:
-            real_path = self._get_fs_path(path, operation='lstat')
+            real_path = self._get_fs_path(path, operation='lstat', args=[])
         except ValueError as err:
             self.logger.warning('lstat %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1159,7 +1222,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("remove %s" % path)
         try:
-            real_path = self._get_fs_path(path, operation='remove')
+            real_path = self._get_fs_path(path, operation='remove', args=[])
         except ValueError as err:
             self.logger.warning('remove %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1205,7 +1268,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # newpath = force_utf8(newpath)
         # self.logger.debug("rename %s %s" % (oldpath, newpath))
         try:
-            real_oldpath = self._get_fs_path(oldpath, operation='rename')
+            real_oldpath = self._get_fs_path(oldpath, operation='rename', args=[])
         except ValueError as err:
             self.logger.warning('rename %s %s: %s' % (oldpath, newpath, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1231,7 +1294,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
             self.logger.warning('move on read-only old path %s :: %s' %
                                 (oldpath, real_oldpath))
             return paramiko.SFTP_PERMISSION_DENIED
-        real_newpath = self._get_fs_path(newpath, operation='rename')
+        real_newpath = self._get_fs_path(newpath, operation='rename', args=[])
         if not check_write_access(real_newpath, parent_dir=True):
             self.logger.warning('move on read-only new path %s :: %s' %
                                 (newpath, real_newpath))
@@ -1258,7 +1321,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("mkdir %s" % path)
         try:
-            real_path = self._get_fs_path(path, operation='mkdir')
+            real_path = self._get_fs_path(path, operation='mkdir', args=[mode])
         except ValueError as err:
             self.logger.warning('mkdir %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1289,7 +1352,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("rmdir %s" % path)
         try:
-            real_path = self._get_fs_path(path, operation='rmdir')
+            real_path = self._get_fs_path(path, operation='rmdir', args=[])
         except ValueError as err:
             self.logger.warning('rmdir %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1342,7 +1405,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("readlink %s" % path)
         try:
-            real_path = self._get_fs_path(path, operation='readlink')
+            real_path = self._get_fs_path(path, operation='readlink', args=[])
         except ValueError as err:
             self.logger.warning('readlink %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED

--- a/mig/server/grid_sftp.py
+++ b/mig/server/grid_sftp.py
@@ -139,7 +139,7 @@ def list_attr_changes(configuration, path, attr):
     return changes
 
 
-def filter_data_access(configuration, path, access_mode, operation, args=[]):
+def filter_data_access(configuration, path, access_mode, operation, args):
     """Filter access to what operation is allowed to do based on path, args
     and access_mode.
     In read-write mode all operations are allowed to proceed path checks.
@@ -181,7 +181,7 @@ def filter_data_access(configuration, path, access_mode, operation, args=[]):
 
 
 def check_data_access(configuration, user_id, path, access_mode, operation,
-                      args=[]):
+                      args):
     """A simple helper to check if user_id has access to execute operation on path
     under the constraints set by access_mode. Namely, check if operation
     could potentially modify data in a read-only session or lookup/read data
@@ -408,7 +408,7 @@ class SFTPHandle(paramiko.SFTPHandle):
                         % endpos \
                         + " file endpos: %s, '%s'" % \
                         (file_endpos, self.sftpserver._get_fs_path(
-                            path, operation=method.__name__, args=[]))
+                            path, operation=method.__name__))
                     logger.warning(msg)
 
             # close
@@ -856,8 +856,12 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
 
     # Use shared daemon fs helper functions
 
-    def _get_fs_path(self, sftp_path, operation=None, args=[]):
+    # NOTE: avoid mutable default arguments with delayed init on None-pattern
+    # https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments
+    def _get_fs_path(self, sftp_path, operation=None, args=None):
         """Wrap helper"""
+        if args is None:
+            args = []
         # self.logger.debug("get_fs_path: check access to %s" % [sftp_path])
         if not check_data_access(configuration, self.user_name, sftp_path,
                                  self.access, operation, args):
@@ -1127,8 +1131,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         """Handle operations of same name"""
         # self.logger.debug('list_folder %s' % [path])
         try:
-            real_path = self._get_fs_path(path, operation='list_folder',
-                                          args=[])
+            real_path = self._get_fs_path(path, operation='list_folder')
         except ValueError as err:
             self.logger.warning('list_folder %s: %s' % ([path], [err]))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1176,7 +1179,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug('stat %s' % path)
         try:
-            real_path = self._get_fs_path(path, operation='stat', args=[])
+            real_path = self._get_fs_path(path, operation='stat')
         except ValueError as err:
             self.logger.warning('stat %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1204,7 +1207,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug('lstat %s' % path)
         try:
-            real_path = self._get_fs_path(path, operation='lstat', args=[])
+            real_path = self._get_fs_path(path, operation='lstat')
         except ValueError as err:
             self.logger.warning('lstat %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1228,7 +1231,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("remove %s" % path)
         try:
-            real_path = self._get_fs_path(path, operation='remove', args=[])
+            real_path = self._get_fs_path(path, operation='remove')
         except ValueError as err:
             self.logger.warning('remove %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1274,8 +1277,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # newpath = force_utf8(newpath)
         # self.logger.debug("rename %s %s" % (oldpath, newpath))
         try:
-            real_oldpath = self._get_fs_path(oldpath, operation='rename',
-                                             args=[])
+            real_oldpath = self._get_fs_path(oldpath, operation='rename')
         except ValueError as err:
             self.logger.warning('rename %s %s: %s' % (oldpath, newpath, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1301,7 +1303,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
             self.logger.warning('move on read-only old path %s :: %s' %
                                 (oldpath, real_oldpath))
             return paramiko.SFTP_PERMISSION_DENIED
-        real_newpath = self._get_fs_path(newpath, operation='rename', args=[])
+        real_newpath = self._get_fs_path(newpath, operation='rename')
         if not check_write_access(real_newpath, parent_dir=True):
             self.logger.warning('move on read-only new path %s :: %s' %
                                 (newpath, real_newpath))
@@ -1359,7 +1361,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("rmdir %s" % path)
         try:
-            real_path = self._get_fs_path(path, operation='rmdir', args=[])
+            real_path = self._get_fs_path(path, operation='rmdir')
         except ValueError as err:
             self.logger.warning('rmdir %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED
@@ -1412,7 +1414,7 @@ class SimpleSftpServer(paramiko.SFTPServerInterface):
         # path = force_utf8(path)
         # self.logger.debug("readlink %s" % path)
         try:
-            real_path = self._get_fs_path(path, operation='readlink', args=[])
+            real_path = self._get_fs_path(path, operation='readlink')
         except ValueError as err:
             self.logger.warning('readlink %s: %s' % (path, err))
             return paramiko.SFTP_PERMISSION_DENIED

--- a/mig/shared/accountstate.py
+++ b/mig/shared/accountstate.py
@@ -42,7 +42,8 @@ from mig.shared.defaults import expire_marks_dir, status_marks_dir, \
     valid_account_status, oid_auto_extend_days, oidc_auto_extend_days, \
     cert_auto_extend_days, attempt_auto_extend_days, AUTH_GENERIC, \
     AUTH_CERTIFICATE, AUTH_OPENID_V2, AUTH_OPENID_CONNECT, \
-    X509_USER_ID_FORMAT, UUID_USER_ID_FORMAT
+    X509_USER_ID_FORMAT, UUID_USER_ID_FORMAT, READ_WRITE_ACCESS, \
+    READ_ONLY_ACCESS, WRITE_ONLY_ACCESS
 from mig.shared.filemarks import get_filemark, update_filemark, reset_filemark
 from mig.shared.gdp.userid import get_base_client_id
 from mig.shared.userdb import load_user_dict, default_db_path, update_user_dict
@@ -381,7 +382,9 @@ def detect_special_login(configuration, username, proto):
     try:
         if proto in ('sftp', 'sftp-subsys', 'ftps', 'davs') and \
                 possible_sharelink_id(configuration, username):
-            for mode in ['read-write']:
+            _valid_modes = [READ_WRITE_ACCESS, READ_ONLY_ACCESS,
+                            WRITE_ONLY_ACCESS]
+            for mode in _valid_modes:
                 real_path = os.path.realpath(os.path.join(
                     configuration.sharelink_home, mode, username))
                 if os.path.exists(real_path):

--- a/mig/shared/defaults.py
+++ b/mig/shared/defaults.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # defaults - default constant values used in many locations
-# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -436,6 +436,10 @@ io_session_stale = {'davs': 120,
                     'sftp': 120,
                     'ftps': 120,
                     }
+
+READ_ONLY_ACCESS = "read-only"
+WRITE_ONLY_ACCESS = "write-only"
+READ_WRITE_ACCESS = "read-write"
 
 # Strong SSL/TLS ciphers and curves to allow in Apache and other SSL/TLS-based
 # daemons (on Apache/OpenSSL format).

--- a/mig/shared/griddaemons/login.py
+++ b/mig/shared/griddaemons/login.py
@@ -38,7 +38,7 @@ import time
 from mig.shared.base import client_dir_id, client_id_dir, client_alias, \
     force_utf8, get_short_id
 from mig.shared.defaults import dav_domain, X509_USER_ID_FORMAT, \
-    UUID_USER_ID_FORMAT
+    UUID_USER_ID_FORMAT, READ_WRITE_ACCESS, READ_ONLY_ACCESS, WRITE_ONLY_ACCESS
 from mig.shared.fileio import unpickle
 from mig.shared.gdp.all import get_project_from_user_id
 from mig.shared.sharelinks import extract_mode_id
@@ -76,6 +76,7 @@ class Login(object):
                  digest=None,
                  public_key=None,
                  chroot=True,
+                 access=None,
                  ip_addr=None,
                  user_dict=None):
         self.username = username
@@ -83,6 +84,7 @@ class Login(object):
         self.digest = digest
         self.public_key = public_key
         self.chroot = chroot
+        self.access = access
         self.ip_addr = ip_addr
         self.user_dict = user_dict
         self.last_update = time.time()
@@ -266,6 +268,7 @@ def add_user_object(configuration,
                     digest=None,
                     pubkey=None,
                     chroot=True,
+                    access=None,
                     user_dict=None):
     """Add a single Login object to active user list"""
     conf = configuration.daemon_conf
@@ -278,6 +281,7 @@ def add_user_object(configuration,
                  digest=digest,
                  public_key=pubkey,
                  chroot=chroot,
+                 access=access,
                  user_dict=user_dict)
     # logger.debug("Adding user login:\n%s" % user)
     if creds_lock:
@@ -294,6 +298,7 @@ def add_job_object(configuration,
                    digest=None,
                    pubkey=None,
                    chroot=True,
+                   access=None,
                    ip_addr=None):
     """Add a single Login object to active jobs list"""
     conf = configuration.daemon_conf
@@ -306,6 +311,7 @@ def add_job_object(configuration,
                 digest=digest,
                 public_key=pubkey,
                 chroot=chroot,
+                access=access,
                 ip_addr=ip_addr)
     # logger.debug("Adding job login:\n%s" % job)
     if creds_lock:
@@ -316,7 +322,7 @@ def add_job_object(configuration,
 
 
 def add_share_object(configuration, login, home, password=None, digest=None,
-                     pubkey=None, chroot=True, ip_addr=None):
+                     pubkey=None, chroot=True, access=None, ip_addr=None):
     """Add a single Login object to active shares list"""
     conf = configuration.daemon_conf
     logger = conf.get("logger", logging.getLogger())
@@ -328,6 +334,7 @@ def add_share_object(configuration, login, home, password=None, digest=None,
                   digest=digest,
                   public_key=pubkey,
                   chroot=chroot,
+                  access=access,
                   ip_addr=ip_addr)
     # logger.debug("Adding share login:\n%s" % share)
     if creds_lock:
@@ -338,7 +345,7 @@ def add_share_object(configuration, login, home, password=None, digest=None,
 
 
 def add_jupyter_object(configuration, login, home, password=None, digest=None,
-                       pubkey=None, chroot=True, ip_addr=None):
+                       pubkey=None, chroot=True, access=None, ip_addr=None):
     """Add a single Login object to active jupyter mount list"""
     conf = configuration.daemon_conf
     logger = conf.get('logger', logging.getLogger())
@@ -350,6 +357,7 @@ def add_jupyter_object(configuration, login, home, password=None, digest=None,
                           digest=digest,
                           public_key=pubkey,
                           chroot=chroot,
+                          access=access,
                           ip_addr=ip_addr)
     # logger.debug("Adding jupyter login:\n%s" % jupyter_mount)
     if creds_lock:
@@ -445,17 +453,20 @@ def update_user_objects(configuration, auth_file, path, user_vars, auth_protos,
                            (user_key, user_id, exc))
             continue
         for login_id in user_id_list:
-            add_user_object(configuration, login_id, user_dir, pubkey=user_key)
+            add_user_object(configuration, login_id, user_dir, pubkey=user_key,
+                            access=READ_WRITE_ACCESS)
     for user_password in all_passwords:
         user_password = user_password.strip()
         for login_id in user_id_list:
             add_user_object(configuration, login_id, user_dir,
-                            password=user_password, user_dict=user_dict)
+                            password=user_password, access=READ_WRITE_ACCESS,
+                            user_dict=user_dict)
     for user_digest in all_digests:
         user_digest = user_digest.strip()
         for login_id in user_id_list:
             add_user_object(configuration, login_id, user_dir,
-                            digest=user_digest, user_dict=user_dict)
+                            digest=user_digest, access=READ_WRITE_ACCESS,
+                            user_dict=user_dict)
     # logger.debug("after update users list is:\n%s" %
     #              '\n'.join(["%s" % i for i in conf['users']]))
 
@@ -665,6 +676,7 @@ def refresh_job_creds(configuration, protocol, username):
                            user_alias,
                            user_dir,
                            pubkey=user_key,
+                           access=READ_WRITE_ACCESS,
                            ip_addr=user_ip)
             changed_jobs.append(user_alias)
 
@@ -682,7 +694,7 @@ def refresh_job_creds(configuration, protocol, username):
 
 
 def refresh_share_creds(configuration, protocol, username,
-                        share_modes=['read-write']):
+                        share_modes=[READ_WRITE_ACCESS]):
     """Reload sharelink credentials for username (SHARE_ID) if they changed on
     disk. That is, add user entries in configuration.daemon_conf['shares'] for
     any corresponding active sharelinks.
@@ -694,6 +706,7 @@ def refresh_share_creds(configuration, protocol, username,
     have guards in place to support read-only or write-only mode in daemons.
     NOTE: we further limit to directory sharelinks for chroot'ing.
     """
+    _valid_modes = [READ_WRITE_ACCESS, READ_ONLY_ACCESS, WRITE_ONLY_ACCESS]
     # Must end in sep
     base_dir = configuration.user_home.rstrip(os.sep) + os.sep
     changed_shares = []
@@ -704,7 +717,7 @@ def refresh_share_creds(configuration, protocol, username,
     if not protocol in ('sftp', 'davs', 'ftps', ):
         logger.error("invalid protocol: %s" % protocol)
         return (conf, changed_shares)
-    if [kind for kind in share_modes if kind != 'read-write']:
+    if [kind for kind in share_modes if kind not in _valid_modes]:
         logger.error("invalid share_modes: %s" % share_modes)
         return (conf, changed_shares)
     if not possible_sharelink_id(configuration, username):
@@ -799,14 +812,16 @@ def refresh_share_creds(configuration, protocol, username,
                          user_alias,
                          user_dir,
                          password=user_password,
-                         digest=user_digest)
+                         digest=user_digest,
+                         access=mode)
         logger.info("Adding key login(s) for share %s: %s" %
                     (user_alias, user_pubkeys))
         for share_pubkey in user_pubkeys:
             add_share_object(configuration,
                              user_alias,
                              user_dir,
-                             pubkey=share_pubkey)
+                             pubkey=share_pubkey,
+                             access=mode)
         changed_shares.append(user_alias)
 
     # Share was removed: remove from logins and mark as changed
@@ -882,7 +897,8 @@ def refresh_jupyter_creds(configuration, protocol, username):
 
             # Add the new valid keyset that gives access to user_dir
             add_jupyter_object(configuration, user_alias,
-                               user_dir, pubkey=user_key)
+                               user_dir, pubkey=user_key,
+                               access=READ_WRITE_ACCESS)
             active_jupyter_creds.append(user_alias)
 
     if creds_lock:

--- a/mig/shared/griddaemons/login.py
+++ b/mig/shared/griddaemons/login.py
@@ -694,7 +694,7 @@ def refresh_job_creds(configuration, protocol, username):
 
 
 def refresh_share_creds(configuration, protocol, username,
-                        share_modes=[READ_WRITE_ACCESS]):
+                        share_modes=(READ_WRITE_ACCESS, )):
     """Reload sharelink credentials for username (SHARE_ID) if they changed on
     disk. That is, add user entries in configuration.daemon_conf['shares'] for
     any corresponding active sharelinks.
@@ -702,11 +702,12 @@ def refresh_share_creds(configuration, protocol, username,
     too. The protocol argument specifies which auth files to use.
     Returns a tuple with the updated daemon_conf and the list of changed share
     IDs.
-    NOTE: we limit share_modes to read-write sharelinks for now since we don't
-    have guards in place to support read-only or write-only mode in daemons.
+    NOTE: by default we limit share_modes to read-write sharelinks for now
+    since we don't have guards in place to support read-only or write-only mode
+    in all daemons, yet.
     NOTE: we further limit to directory sharelinks for chroot'ing.
     """
-    _valid_modes = [READ_WRITE_ACCESS, READ_ONLY_ACCESS, WRITE_ONLY_ACCESS]
+    _valid_modes = (READ_WRITE_ACCESS, READ_ONLY_ACCESS, WRITE_ONLY_ACCESS)
     # Must end in sep
     base_dir = configuration.user_home.rstrip(os.sep) + os.sep
     changed_shares = []

--- a/mig/shared/sharelinks.py
+++ b/mig/shared/sharelinks.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # sharelinks - share link helper functions
-# Copyright (C) 2003-2022  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -37,7 +37,8 @@ from random import SystemRandom
 
 from mig.shared.base import client_id_dir, extract_field
 from mig.shared.defaults import sharelinks_filename, csrf_field, \
-    share_mode_charset, share_id_charset
+    share_mode_charset, share_id_charset, READ_WRITE_ACCESS, READ_ONLY_ACCESS, \
+    WRITE_ONLY_ACCESS
 from mig.shared.fileio import makedirs_rec, make_symlink, delete_symlink
 from mig.shared.serial import load, dump
 
@@ -49,8 +50,8 @@ __mode_len = len(share_mode_charset) // 3
 __ro_mode_chars = share_mode_charset[:__mode_len]
 __rw_mode_chars = share_mode_charset[__mode_len:2 * __mode_len]
 __wo_mode_chars = share_mode_charset[2 * __mode_len:]
-mode_chars_map = {'read-only': __ro_mode_chars, 'read-write': __rw_mode_chars,
-                  'write-only': __wo_mode_chars}
+mode_chars_map = {READ_ONLY_ACCESS: __ro_mode_chars, READ_WRITE_ACCESS: __rw_mode_chars,
+                  WRITE_ONLY_ACCESS: __wo_mode_chars}
 
 __bool_map = {True: 'Yes', False: 'No'}
 
@@ -446,11 +447,11 @@ def modify_share_links(action, share_dict, client_id, configuration,
     rel_path = share_dict['path'].lstrip(os.sep)
     access = share_dict['access']
     if 'read' in access and 'write' in access:
-        access_dir = 'read-write'
+        access_dir = READ_WRITE_ACCESS
     elif 'read' in access:
-        access_dir = 'read-only'
+        access_dir = READ_ONLY_ACCESS
     elif 'write' in access:
-        access_dir = 'write-only'
+        access_dir = WRITE_ONLY_ACCESS
     else:
         logger.error("modify_share_links invalid access: %s" % access)
         return (load_status, share_map)

--- a/mig/src/include/auth/migauth.h
+++ b/mig/src/include/auth/migauth.h
@@ -115,8 +115,14 @@
 #ifndef SHARELINK_LENGTH
 #define SHARELINK_LENGTH 42
 #endif
-#ifndef SHARELINK_SUBDIR
-#define SHARELINK_SUBDIR "read-write"
+#ifndef SHARELINK_RW_DIR
+#define SHARELINK_RW_DIR "read-write"
+#endif
+#ifndef SHARELINK_RO_DIR
+#define SHARELINK_RO_DIR "read-only"
+#endif
+#ifndef SHARELINK_WO_DIR
+#define SHARELINK_WO_DIR "write-only"
 #endif
 #endif                          /* !DISABLE_SHARELINK */
 

--- a/mig/src/include/auth/migauth.h
+++ b/mig/src/include/auth/migauth.h
@@ -178,7 +178,7 @@
     fprintf(stderr, #priority ": " __FILE__"("TOSTRING(__LINE__)"): " format, ##__VA_ARGS__)
 #else                           /* DEBUG_LOG_STDERR */
 #define WRITELOGMESSAGE(priority, format, ...) \
-    openlog("pam_mig", LOG_PID, LOG_AUTHPRIV); \
+    openlog("nss-pam_mig", LOG_PID, LOG_AUTHPRIV); \
     syslog(priority, #priority ": " __FILE__"("TOSTRING(__LINE__)"): " format, ##__VA_ARGS__);
 #endif                          /* DEBUG_LOG_STDERR */
 #else                           /* DEBUG || DEBUG_LOG_STDERR */
@@ -194,7 +194,7 @@
 */
 #define WRITELOGMESSAGE(priority, ...) \
     if (priority != LOG_DEBUG) { \
-        openlog("pam_mig", LOG_PID, LOG_AUTHPRIV); \
+        openlog("nss-pam_mig", LOG_PID, LOG_AUTHPRIV); \
         syslog(priority, ##__VA_ARGS__); \
     }
 #endif                          /* DEBUG || DEBUG_LOG_STDERR */

--- a/mig/src/libnss-mig/libnss_mig.c
+++ b/mig/src/libnss-mig/libnss_mig.c
@@ -191,8 +191,9 @@ _nss_mig_getpwnam_r(const char *name,
     if (keep_trying && name_len == get_sharelink_length()) {
         WRITELOGMESSAGE(LOG_DEBUG, "Checking for sharelink: %s\n", name);
 
+        uint8_t i;
         char sharelink_modes[3][11] = { SHARELINK_RW_DIR, SHARELINK_RO_DIR, SHARELINK_WO_DIR };
-        for (uint8_t i = 0; i < 3; i++)
+        for (i = 0; i < 3; i++)
         {
 
         memset(pathbuf, 0, PATH_BUF_LEN);

--- a/mig/src/libnss-mig/libnss_mig.c
+++ b/mig/src/libnss-mig/libnss_mig.c
@@ -185,18 +185,23 @@ _nss_mig_getpwnam_r(const char *name,
 #ifdef ENABLE_SHARELINK
     /* Optional anonymous share link access:
        - username must have fixed length matching get_sharelink_length()
-       - get_sharelink_home()/SHARELINK_SUBDIR/username must exist as a symlink
+       - get_sharelink_home()/SHARELINK_X_DIR/username must exist as a symlink
        - username and password must be identical or pub key fit authorized_keys
      */
     if (keep_trying && name_len == get_sharelink_length()) {
         WRITELOGMESSAGE(LOG_DEBUG, "Checking for sharelink: %s\n", name);
+
+        char sharelink_modes[][10] = { SHARELINK_RW_DIR, SHARELINK_RO_DIR, SHARELINK_WO_DIR };
+        for (size_t i = 0; i < sizeof(sharelink_modes) / sizeof(sharelink_modes[0]); i++)
+        {
+
         memset(pathbuf, 0, PATH_BUF_LEN);
         if (PATH_BUF_LEN <=
             snprintf(pathbuf, PATH_BUF_LEN, "%s/%s/%s",
-                     get_sharelink_home(), SHARELINK_SUBDIR, name)) {
+                     get_sharelink_home(), sharelink_modes[i], name)) {
             WRITELOGMESSAGE(LOG_WARNING,
                             "Path construction overflow for: %s/%s/%s\n",
-                            get_sharelink_home(), SHARELINK_SUBDIR, name);
+                            get_sharelink_home(), sharelink_modes[i], name);
             return NSS_STATUS_NOTFOUND;
         }
         /* Make sure prefix of direct sharelink target is user home */
@@ -230,8 +235,12 @@ _nss_mig_getpwnam_r(const char *name,
             is_share = 1;
             pathlen =
                 strlen(get_sharelink_home()) +
-                strlen(SHARELINK_SUBDIR) + name_len + 2;
+                strlen(sharelink_modes[i]) + name_len + 2;
+            break;
         }
+
+        }
+
     }
     WRITELOGMESSAGE(LOG_DEBUG, "Detect sharelink: %d\n", is_share);
 #endif                          /* ENABLE_SHARELINK */

--- a/mig/src/libnss-mig/libnss_mig.c
+++ b/mig/src/libnss-mig/libnss_mig.c
@@ -192,7 +192,7 @@ _nss_mig_getpwnam_r(const char *name,
         WRITELOGMESSAGE(LOG_DEBUG, "Checking for sharelink: %s\n", name);
 
         char sharelink_modes[3][11] = { SHARELINK_RW_DIR, SHARELINK_RO_DIR, SHARELINK_WO_DIR };
-        for (uint i = 0; i < 3; i++)
+        for (uint8_t i = 0; i < 3; i++)
         {
 
         memset(pathbuf, 0, PATH_BUF_LEN);

--- a/mig/src/libnss-mig/libnss_mig.c
+++ b/mig/src/libnss-mig/libnss_mig.c
@@ -191,8 +191,8 @@ _nss_mig_getpwnam_r(const char *name,
     if (keep_trying && name_len == get_sharelink_length()) {
         WRITELOGMESSAGE(LOG_DEBUG, "Checking for sharelink: %s\n", name);
 
-        char sharelink_modes[][10] = { SHARELINK_RW_DIR, SHARELINK_RO_DIR, SHARELINK_WO_DIR };
-        for (size_t i = 0; i < sizeof(sharelink_modes) / sizeof(sharelink_modes[0]); i++)
+        char sharelink_modes[3][11] = { SHARELINK_RW_DIR, SHARELINK_RO_DIR, SHARELINK_WO_DIR };
+        for (uint i = 0; i < 3; i++)
         {
 
         memset(pathbuf, 0, PATH_BUF_LEN);

--- a/mig/src/libpam-mig/libpam_mig.c
+++ b/mig/src/libpam-mig/libpam_mig.c
@@ -724,8 +724,8 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags,
     if (strlen(pUsername) == get_sharelink_length()) {
         char share_path[MAX_PATH_LENGTH];
 
-        char sharelink_modes[][10] = { SHARELINK_RW_DIR, SHARELINK_RO_DIR, SHARELINK_WO_DIR };
-        for (size_t i = 0; i < sizeof(sharelink_modes) / sizeof(sharelink_modes[0]); i++)
+        char sharelink_modes[3][11] = { SHARELINK_RW_DIR, SHARELINK_RO_DIR, SHARELINK_WO_DIR };
+        for (uint i = 0; i < 3; i++)
         {
 
         memset(share_path, 0, MAX_PATH_LENGTH);

--- a/mig/src/libpam-mig/libpam_mig.c
+++ b/mig/src/libpam-mig/libpam_mig.c
@@ -717,27 +717,36 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags,
 #ifdef ENABLE_SHARELINK
     /* Optional anonymous share link access:
        - username must have fixed length matching get_sharelink_length()
-       - get_sharelink_home()/SHARELINK_SUBDIR/username must exist as a symlink
+       - get_sharelink_home()/SHARELINK_X_DIR/username must exist as a symlink
        - username and password must be identical if we get here (key skips PAM)
      */
     WRITELOGMESSAGE(LOG_DEBUG, "Checking for sharelink: %s\n", pUsername);
     if (strlen(pUsername) == get_sharelink_length()) {
         char share_path[MAX_PATH_LENGTH];
+
+        char sharelink_modes[][10] = { SHARELINK_RW_DIR, SHARELINK_RO_DIR, SHARELINK_WO_DIR };
+        for (size_t i = 0; i < sizeof(sharelink_modes) / sizeof(sharelink_modes[0]); i++)
+        {
+
+        memset(share_path, 0, MAX_PATH_LENGTH);
+
         if (MAX_PATH_LENGTH <=
             snprintf(share_path, MAX_PATH_LENGTH, "%s/%s/%s",
-                     get_sharelink_home(), SHARELINK_SUBDIR, pUsername)) {
+                     get_sharelink_home(), sharelink_modes[i], pUsername)) {
             WRITELOGMESSAGE(LOG_WARNING,
                             "Path construction failed for: %s/%s/%s\n",
-                            get_sharelink_home(), SHARELINK_SUBDIR, pUsername);
+                            get_sharelink_home(), sharelink_modes[i], pUsername);
             return pam_sm_authenticate_exit(PAM_AUTH_ERR, pwresp);
         }
         /* NSS lookup assures sharelink target is valid and inside user home */
         /* Just check simple access here to make sure it is a share link */
         if (access(share_path, R_OK) == 0) {
             WRITELOGMESSAGE(LOG_DEBUG,
-                            "Checking sharelink id %s password\n", pUsername);
+                            "Checking %s sharelink id %s password\n", sharelink_modes[i],
+                            pUsername);
             if (strcmp(pUsername, pPassword) == 0) {
-                WRITELOGMESSAGE(LOG_DEBUG, "Return sharelink success\n");
+                WRITELOGMESSAGE(LOG_DEBUG, "Return %s sharelink success\n",
+                                sharelink_modes[i]);
 #ifdef ENABLE_AUTHHANDLER
                 if (false == mig_reg_auth_attempt(MIG_SKIP_TWOFA_CHECK
                                                    | MIG_SKIP_NOTIFY
@@ -768,11 +777,18 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags,
 #endif                          /* ENABLE_AUTHHANDLER */
                 return pam_sm_authenticate_exit(PAM_AUTH_ERR, pwresp);
             }
+        } else if (i < sizeof(sharelink_modes) - 1) {
+            WRITELOGMESSAGE(LOG_DEBUG,
+                            "Ignore no match on %s sharelink: %s\n", sharelink_modes[i],
+                            pUsername);
         } else {
             WRITELOGMESSAGE(LOG_DEBUG,
                             "No matching sharelink: %s. Try next auth.\n",
                             share_path);
         }
+
+        }
+
     } else {
         WRITELOGMESSAGE(LOG_DEBUG,
                         "Not a sharelink username: %s. Try next auth.\n",

--- a/mig/src/libpam-mig/libpam_mig.c
+++ b/mig/src/libpam-mig/libpam_mig.c
@@ -724,8 +724,9 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags,
     if (strlen(pUsername) == get_sharelink_length()) {
         char share_path[MAX_PATH_LENGTH];
 
+        uint8_t i;
         char sharelink_modes[3][11] = { SHARELINK_RW_DIR, SHARELINK_RO_DIR, SHARELINK_WO_DIR };
-        for (uint8_t i = 0; i < 3; i++)
+        for (i = 0; i < 3; i++)
         {
 
         memset(share_path, 0, MAX_PATH_LENGTH);

--- a/mig/src/libpam-mig/libpam_mig.c
+++ b/mig/src/libpam-mig/libpam_mig.c
@@ -704,7 +704,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags,
     if (encpw_size >= MAX_DIGEST_SIZE) {
         WRITELOGMESSAGE(LOG_WARNING,
                         "Cannot build hash from password of extreme length: %d\n",
-                        (uint)strlen(pPassword));
+                        (uint64_t)strlen(pPassword));
         return pam_sm_authenticate_exit(PAM_AUTH_ERR, pwresp);
     }
     b64_encode((const uint8_t *)pPassword, encpw_size, (uint8_t *) & encpw);
@@ -725,7 +725,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags,
         char share_path[MAX_PATH_LENGTH];
 
         char sharelink_modes[3][11] = { SHARELINK_RW_DIR, SHARELINK_RO_DIR, SHARELINK_WO_DIR };
-        for (uint i = 0; i < 3; i++)
+        for (uint8_t i = 0; i < 3; i++)
         {
 
         memset(share_path, 0, MAX_PATH_LENGTH);


### PR DESCRIPTION
Implement SFTP access to all sharelinks with added server-side access limitations on all operations when in read-only or write-only mode.

~This is still work in progress and the PAM and NSS bits are still missing for sftpsubsys support.~
We may still want to look into pointing all read-only sharelink access to a separate read-only (bind-) mount of the persistent storage file system to be extra protected against any missing access limitations.

As @aputtu pointed out after initial testing of the write-only sharelinks they felt somewhat crippled when used e.g. mounted from a file manager like `Nautilus` or `Thunar` because we initially rejected **all** read operations including  `stat`/`lstat` calls to query basic file and folder info. After some reconsideration that restriction was loosened up to allow explicit `stat`/`lstat` calls on explicitly given paths to make most clients behave. Similarly it turned out that simple get downloads from `sftp` on read-only shares would fail when empty `chattr` calls were rejected. So such non-changing `chattr` calls are now also allowed. 
We may still want to similarly allow non-changing `chown`/`chmod` calls and perhaps even override `list_folder` to always just return an empty list for write-only shares.