### PR TITLE
Address pylint possible variable use before init errors

### DIFF
--- a/mig/shared/accountstate.py
+++ b/mig/shared/accountstate.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # accountstate - various user account state helpers
-# Copyright (C) 2020-2024  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -452,6 +452,9 @@ def check_account_accessible(configuration, username, proto, environ=None,
         elif configuration.site_user_id_format == UUID_USER_ID_FORMAT:
             # Only follow first username -> client_id_dir symlink with UUID
             expanded_home = os.readlink(home_dir)
+        else:
+            raise ValueError("invalid user ID format requested: %s" %
+                             configuration.site_user_id_format)
         real_id = os.path.basename(expanded_home)
         client_id = client_dir_id(real_id)
 

--- a/mig/shared/griddaemons/login.py
+++ b/mig/shared/griddaemons/login.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # login - grid daemon login helper functions
-# Copyright (C) 2010-2024  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -551,7 +551,9 @@ def refresh_user_creds(configuration, protocol, username):
             # then build user_home from there as link may be just the name
             user_dir = os.path.basename(os.readlink(user_home))
             user_home = os.path.join(configuration.user_home, user_dir)
-
+        else:
+            raise ValueError("invalid user ID format requested: %s" %
+                             configuration.site_user_id_format)
         # Check that user home exists
         if not os.path.exists(user_home):
             logger.warning("Skipping user without home %s" % user_home)
@@ -617,7 +619,7 @@ def refresh_job_creds(configuration, protocol, username):
         # logger.debug("No job creds changes for %s" % username)
         return (conf, changed_jobs)
 
-    job_dict = None
+    job_dict, sessionid = None, None
     if os.path.islink(link_path) and os.path.exists(link_path) and \
             last_update < os.path.getmtime(link_path):
         sessionid = username
@@ -844,7 +846,7 @@ def refresh_jupyter_creds(configuration, protocol, username):
     # logger.debug("jupyter linkpath: %s jupyter path exists: %s" % \
     #                 (os.path.islink(link_path), os.path.exists(link_path)))
 
-    jupyter_dict = None
+    jupyter_dict, sessionid = None, None
     if os.path.islink(link_path) and os.path.exists(link_path):
         sessionid = username
         jupyter_dict = unpickle(link_path, logger)


### PR DESCRIPTION
Add a few variable initializations to address related `pylint` errors in PR #284.

None of them are all that important since we _should_ already have prior checks in place e.g. in configuration init to bail out, but better safe than sorry.