### PR TITLE
Add simple `migstats` weekly cronjob using `usagestats.py`

### DIFF
--- a/mig/install/migstats-template.sh.cronjob
+++ b/mig/install/migstats-template.sh.cronjob
@@ -4,6 +4,6 @@
 
 # We default to include disk use for gluster and lustre mounts and write
 # reports in various file formats
-su - mig -c "PYTHONPATH=__MIG_BASE__ mig/server/usagestats.py -t 'fuse.glusterfs lustre' -s AUTO  -o 'txt json pickle csv'"
+su - mig -c "PYTHONPATH=__MIG_BASE__ mig/server/usagestats.py -t 'fuse.glusterfs lustre' -s AUTO -o 'txt json pickle csv'"
 
 exit 0

--- a/mig/install/migstats-template.sh.cronjob
+++ b/mig/install/migstats-template.sh.cronjob
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Run usagestats as mig user to generate stats for Server Admin
+
+# We default to include disk use for gluster and lustre mounts and write
+# reports in various file formats
+su - mig -c "PYTHONPATH=__MIG_BASE__ mig/server/usagestats.py -t 'fuse.glusterfs lustre' -s AUTO  -o 'txt json pickle csv'"
+
+exit 0

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -2524,7 +2524,7 @@ The migcheckssl, migverifyarchives, migstats, migacctexpire and miglustrequota
 files are cron scripts to automatically check for LetsEncrypt certificate
 renewal, run pending archive verification before sending a copy to tape, save
 various usage stats, generate account expire stats and create/update lustre
- quota.
+quota.
 You can install them with:
 chmod 700 %(destination)s/migcheckssl
 sudo cp %(destination)s/migcheckssl /etc/cron.daily/

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -2341,6 +2341,7 @@ def _generate_confs_writefiles(options, user_dict, insert_list=[], cleanup_list=
         ("migcheckssl-template.sh.cronjob", "migcheckssl"),
         ("migacctexpire-template.sh.cronjob", "migacctexpire"),
         ("migverifyarchives-template.sh.cronjob", "migverifyarchives"),
+        ("migstats-template.sh.cronjob", "migstats"),
         ("miglustrequota-template.sh.cronjob", "miglustrequota"),
     ]
     overrides_out_name = {
@@ -2519,15 +2520,18 @@ chmod 755 %(destination)s/mig{stateclean,errors,sftpmon,importdoi,notifyexpire}
 sudo cp %(destination)s/mig{stateclean,errors,sftpmon,importdoi,notifyexpire} \\
         /etc/cron.daily/
 
-The migcheckssl, migverifyarchives, migacctexpire and miglustrequota files
-are cron scripts to automatically check for LetsEncrypt certificate renewal,
-run pending archive verification before sending a copy to tape,
-generate account expire stats and create/update lustre quota.
+The migcheckssl, migverifyarchives, migstats, migacctexpire and miglustrequota
+files are cron scripts to automatically check for LetsEncrypt certificate
+renewal, run pending archive verification before sending a copy to tape, save
+various usage stats, generate account expire stats and create/update lustre
+ quota.
 You can install them with:
 chmod 700 %(destination)s/migcheckssl
 sudo cp %(destination)s/migcheckssl /etc/cron.daily/
 chmod 700 %(destination)s/migverifyarchives
 sudo cp %(destination)s/migverifyarchives /etc/cron.hourly/
+chmod 700 %(destination)s/migstats
+sudo cp %(destination)s/migstats /etc/cron.weekly/
 chmod 700 %(destination)s/migacctexpire
 sudo cp %(destination)s/migacctexpire /etc/cron.monthly/
 chmod 700 %(destination)s/miglustrequota

--- a/tests/fixture/confs-stdlocal/migstats
+++ b/tests/fixture/confs-stdlocal/migstats
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Run usagestats as mig user to generate stats for Server Admin
+
+# We default to include disk use for gluster and lustre mounts and write
+# reports in various file formats
+su - mig -c "PYTHONPATH=/home/mig mig/server/usagestats.py -t 'fuse.glusterfs lustre' -s AUTO  -o 'txt json pickle csv'"
+
+exit 0

--- a/tests/fixture/confs-stdlocal/migstats
+++ b/tests/fixture/confs-stdlocal/migstats
@@ -4,6 +4,6 @@
 
 # We default to include disk use for gluster and lustre mounts and write
 # reports in various file formats
-su - mig -c "PYTHONPATH=/home/mig mig/server/usagestats.py -t 'fuse.glusterfs lustre' -s AUTO  -o 'txt json pickle csv'"
+su - mig -c "PYTHONPATH=/home/mig mig/server/usagestats.py -t 'fuse.glusterfs lustre' -s AUTO -o 'txt json pickle csv'"
 
 exit 0


### PR DESCRIPTION
Add simple `migstats` weekly cronjob using `usagestats.py` to generate various usage stats e.g. used on Server Admin page.