### PR TITLE
Fix missing requirements for lint

### DIFF
--- a/.github/workflows/python-sanity-check.yml
+++ b/.github/workflows/python-sanity-check.yml
@@ -76,7 +76,9 @@ jobs:
         run: |
           sudo apt install -y libenchant-2-dev libcrack2-dev libssl-dev
           python -m pip install --upgrade pip
-          pip install flake8 pylint #pytest
+          if [ -f local-requirements.txt ]; then pip install -r local-requirements.txt; fi
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f recommended.txt ]; then pip install -r recommended.txt; fi
       # We may need git installed to get a full repo clone rather than unpacked archive
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -125,7 +127,7 @@ jobs:
         run: |
           dnf install -y enchant cracklib openssl-devel
           python -m pip install --upgrade pip
-          pip install flake8 pylint #pytest
+          if [ -f local-requirements.txt ]; then pip install -r local-requirements.txt; fi
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f recommended.txt ]; then pip install -r recommended.txt; fi
       # We need git installed to get a full repo clone rather than unpacked archive

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -3,8 +3,10 @@
 # This list is mainly used to specify addons needed for the unit tests.
 # We only need autopep8 on py 3 as it's used in 'make fmt' (with py3)
 autopep8;python_version >= "3"
+flake8
 # We need paramiko for the ssh unit tests
 # NOTE: paramiko-3.0.0 dropped python2 and python3.6 support
 paramiko;python_version >= "3.7"
 paramiko<3;python_version < "3.7"
+pylint
 werkzeug


### PR DESCRIPTION
Use local-requirements.txt as the mechanism through which flake8 and pylint and provisioned. Switch over to this and make the lint package installs consistent. Install all deps via pip otherwise changes within code that has external dependencies will fail to lint with missing modules.