### PR TITLE
Add common local disk file systems to migstats and prevent output on success

### DIFF
--- a/mig/install/migstats-template.sh.cronjob
+++ b/mig/install/migstats-template.sh.cronjob
@@ -4,6 +4,6 @@
 
 # We default to include disk use for gluster and lustre mounts and write
 # reports in various file formats
-su - mig -c "PYTHONPATH=__MIG_BASE__ mig/server/usagestats.py -t 'ext4 xfs fuse.glusterfs lustre' -s AUTO -o 'txt json pickle csv'"
+su - mig -c "PYTHONPATH=__MIG_BASE__ mig/server/usagestats.py -q -t 'ext4 xfs fuse.glusterfs lustre' -s AUTO -o 'txt json pickle csv'"
 
 exit 0

--- a/mig/install/migstats-template.sh.cronjob
+++ b/mig/install/migstats-template.sh.cronjob
@@ -4,6 +4,6 @@
 
 # We default to include disk use for gluster and lustre mounts and write
 # reports in various file formats
-su - mig -c "PYTHONPATH=__MIG_BASE__ mig/server/usagestats.py -t 'fuse.glusterfs lustre' -s AUTO -o 'txt json pickle csv'"
+su - mig -c "PYTHONPATH=__MIG_BASE__ mig/server/usagestats.py -t 'ext4 xfs fuse.glusterfs lustre' -s AUTO -o 'txt json pickle csv'"
 
 exit 0

--- a/mig/server/usagestats.py
+++ b/mig/server/usagestats.py
@@ -63,6 +63,7 @@ Where OPTIONS may be one or more of:
    -s SITE_STATS       Save collected stats in SITE_STATS (AUTO for conf value)
    -t FS_TYPE          Limit disk stats to mounts of given FS_TYPE
    -v                  Verbose output
+   -q                  Quiet mode e.g. for cron use
 """ % {'name': name})
 
 
@@ -215,11 +216,12 @@ if '__main__' == __name__:
     expire = None
     force = False
     verbose = False
+    quiet = False
     sitestats_home = None
     output_formats = []
     search_filter = default_search()
     expire_before, expire_after = None, None
-    opt_args = 'a:b:c:d:fho:s:t:u:v'
+    opt_args = 'a:b:c:d:fho:qs:t:u:v'
     try:
         (opts, args) = getopt.getopt(args, opt_args)
     except getopt.GetoptError as err:
@@ -247,12 +249,16 @@ if '__main__' == __name__:
                     output_formats.append(ext)
                 else:
                     print("Error: unsupported output format: %s" % ext)
+        elif opt == '-q':
+            quiet = True
+            verbose = False
         elif opt == '-s':
             sitestats_home = val
         elif opt == '-t':
             only_fs_types += val.split()
         elif opt == '-v':
             verbose = True
+            quiet = False
         else:
             print('Error: %s not supported!' % opt)
             sys.exit(1)
@@ -283,8 +289,9 @@ if '__main__' == __name__:
         sitestats_path = os.path.join(sitestats_home, 'usagestats-%d' % now)
         if not output_formats:
             output_formats = ['json']
-        print("Writing collected site stats in %s.{%s}" % (
-            sitestats_path, ','.join(output_formats)))
+        if not quiet:
+            print("Writing collected site stats in %s.{%s}" %
+                  (sitestats_path, ','.join(output_formats)))
 
     if not verbose and sitestats_path is None:
         print("Neither verbose nor writing site stats - boring!")

--- a/tests/fixture/confs-stdlocal/migstats
+++ b/tests/fixture/confs-stdlocal/migstats
@@ -4,6 +4,6 @@
 
 # We default to include disk use for gluster and lustre mounts and write
 # reports in various file formats
-su - mig -c "PYTHONPATH=/home/mig mig/server/usagestats.py -t 'ext4 xfs fuse.glusterfs lustre' -s AUTO -o 'txt json pickle csv'"
+su - mig -c "PYTHONPATH=/home/mig mig/server/usagestats.py -q -t 'ext4 xfs fuse.glusterfs lustre' -s AUTO -o 'txt json pickle csv'"
 
 exit 0

--- a/tests/fixture/confs-stdlocal/migstats
+++ b/tests/fixture/confs-stdlocal/migstats
@@ -4,6 +4,6 @@
 
 # We default to include disk use for gluster and lustre mounts and write
 # reports in various file formats
-su - mig -c "PYTHONPATH=/home/mig mig/server/usagestats.py -t 'fuse.glusterfs lustre' -s AUTO -o 'txt json pickle csv'"
+su - mig -c "PYTHONPATH=/home/mig mig/server/usagestats.py -t 'ext4 xfs fuse.glusterfs lustre' -s AUTO -o 'txt json pickle csv'"
 
 exit 0


### PR DESCRIPTION
Out of general interest and to avoid `df` error when no network file systems are in use.
Admins should only receive email from cron about warnings and failures. 