### PR TITLE
Address a lint warning in PAM / NSS about regcomp return value check

### DIFF
--- a/mig/src/include/auth/migauth.h
+++ b/mig/src/include/auth/migauth.h
@@ -416,7 +416,8 @@ static int validate_username(const char *username)
     }
 
     regex_res = regcomp(&validator, username_regex, REG_EXTENDED | REG_NOSUB);
-    if (regex_res) {
+    if (regex_res != 0) {
+        /* Failure in regex compilation */
         if (regex_res == REG_ESPACE) {
             WRITELOGMESSAGE(LOG_ERR,
                             "Memory error in username validation: %s\n",


### PR DESCRIPTION
Address a lint warning in PAM / NSS that regcomp int return value is used as bool. Non-zero value means error according to `man regcomp`.