### PR TITLE
Use C89 prior variable init to remove last critical c-extension lint error

### DIFF
--- a/mig/src/libpam-mig/libpam_mig.c
+++ b/mig/src/libpam-mig/libpam_mig.c
@@ -236,8 +236,9 @@ static int converse(pam_handle_t * pamh, int nargs,
 /* this function frees PAM response structures */
 static void free_pam_response(struct pam_response *resp, int nargs)
 {
+    int i;
     if (resp != NULL) {
-        for (int i = 0; i < nargs; i++) {
+        for (i = 0; i < nargs; i++) {
             if (resp[i].resp != NULL) {
                 free(resp[i].resp);
                 resp[i].resp = NULL;


### PR DESCRIPTION
Change one for-loop to use C89-style prior variable init to remove last critical splint error and make lint action pass.
Not ideal if it prevents eventual move to C99 standards, but AFAICT we do use C89 variable declarations in all other locations. So it's no big deal at the moment and does add consistency.