### PR TITLE
Silence migimportdoi and migindexdoi cronjobs unless freeze is enabled and DOI integration configured

### DIFF
--- a/mig/install/migimportdoi-template.sh.cronjob
+++ b/mig/install/migimportdoi-template.sh.cronjob
@@ -2,12 +2,38 @@
 #
 # run importdoi as mig user
 
+# Force bash to handle uninitialized variables and errors
+# https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+# NOTE: 'set -eE' exits on failure, which is good when we handle all errors
+set -eEuo pipefail
+
 # Add any custom domains to lookup DOIs for here and format according to
 # https://support.datacite.org/docs/api-queries
 # where we simply filter on our own FQDN in the registered DOI url.
 doi_fqdn="url:__PUBLIC_ALIAS_FQDN__" 
 
 # No more edits below
-su - mig -c "PYTHONPATH=__MIG_BASE__ mig/server/importdoi.py $doi_fqdn"
+check_enabled() {
+    su - mig -c "PYTHONPATH=__MIG_BASE__ __MIG_CODE__/server/chkenabled.py $1" >& /dev/null
+}
+check_set() {
+    VALUE=$(su - mig -c "PYTHONPATH=__MIG_BASE__ __MIG_CODE__/server/readconfval.py $1")
+    if [ -z "$VALUE" ]; then
+         #echo "DEBUG: $1 not set in MiGserver conf - skipping"
+         return 1
+    fi
+    return 0
+}
+
+if ! check_enabled "freeze" ; then
+    #echo "DEBUG: nothing to do with freeze disabled"
+    exit 0
+fi
+if ! check_set "site_freeze_doi_url" ; then
+    #echo "DEBUG: nothing to do with freeze doi url disabled"
+    exit 0
+fi
+
+su - mig -c "PYTHONPATH=__MIG_BASE__ __MIG_CODE__/server/importdoi.py $doi_fqdn"
 
 exit 0

--- a/mig/install/migindexdoi-template.sh.cronjob
+++ b/mig/install/migindexdoi-template.sh.cronjob
@@ -2,7 +2,34 @@
 #
 # run indexdoi as mig user
 
+# Force bash to handle uninitialized variables and errors
+# https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+# NOTE: 'set -eE' exits on failure, which is good when we handle all errors
+set -eEuo pipefail
+
+
 # No more edits below
-su - mig -c "PYTHONPATH=__MIG_BASE__ mig/server/indexdoi.py"
+check_enabled() {
+    su - mig -c "PYTHONPATH=__MIG_BASE__ __MIG_CODE__/server/chkenabled.py $1" >& /dev/null
+}
+check_set() {
+    VALUE=$(su - mig -c "PYTHONPATH=__MIG_BASE__ __MIG_CODE__/server/readconfval.py $1")
+    if [ -z "$VALUE" ]; then
+         #echo "DEBUG: $1 not set in MiGserver conf - skipping"
+         return 1
+    fi
+    return 0
+}
+
+if ! check_enabled "freeze" ; then
+    #echo "DEBUG: nothing to do with freeze disabled"
+    exit 0
+fi
+if ! check_set "site_freeze_doi_url" ; then
+    #echo "DEBUG: nothing to do with freeze doi url disabled"
+    exit 0
+fi
+
+su - mig -c "PYTHONPATH=__MIG_BASE__ __MIG_CODE__/server/indexdoi.py"
 
 exit 0

--- a/tests/fixture/confs-stdlocal/migimportdoi
+++ b/tests/fixture/confs-stdlocal/migimportdoi
@@ -2,12 +2,38 @@
 #
 # run importdoi as mig user
 
+# Force bash to handle uninitialized variables and errors
+# https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+# NOTE: 'set -eE' exits on failure, which is good when we handle all errors
+set -eEuo pipefail
+
 # Add any custom domains to lookup DOIs for here and format according to
 # https://support.datacite.org/docs/api-queries
 # where we simply filter on our own FQDN in the registered DOI url.
 doi_fqdn="url:" 
 
 # No more edits below
-su - mig -c "PYTHONPATH=/home/mig mig/server/importdoi.py $doi_fqdn"
+check_enabled() {
+    su - mig -c "PYTHONPATH=/home/mig /home/mig/mig/server/chkenabled.py $1" >& /dev/null
+}
+check_set() {
+    VALUE=$(su - mig -c "PYTHONPATH=/home/mig /home/mig/mig/server/readconfval.py $1")
+    if [ -z "$VALUE" ]; then
+         #echo "DEBUG: $1 not set in MiGserver conf - skipping"
+         return 1
+    fi
+    return 0
+}
+
+if ! check_enabled "freeze" ; then
+    #echo "DEBUG: nothing to do with freeze disabled"
+    exit 0
+fi
+if ! check_set "site_freeze_doi_url" ; then
+    #echo "DEBUG: nothing to do with freeze doi url disabled"
+    exit 0
+fi
+
+su - mig -c "PYTHONPATH=/home/mig /home/mig/mig/server/importdoi.py $doi_fqdn"
 
 exit 0

--- a/tests/fixture/confs-stdlocal/migindexdoi
+++ b/tests/fixture/confs-stdlocal/migindexdoi
@@ -2,7 +2,34 @@
 #
 # run indexdoi as mig user
 
+# Force bash to handle uninitialized variables and errors
+# https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+# NOTE: 'set -eE' exits on failure, which is good when we handle all errors
+set -eEuo pipefail
+
+
 # No more edits below
-su - mig -c "PYTHONPATH=/home/mig mig/server/indexdoi.py"
+check_enabled() {
+    su - mig -c "PYTHONPATH=/home/mig /home/mig/mig/server/chkenabled.py $1" >& /dev/null
+}
+check_set() {
+    VALUE=$(su - mig -c "PYTHONPATH=/home/mig /home/mig/mig/server/readconfval.py $1")
+    if [ -z "$VALUE" ]; then
+         #echo "DEBUG: $1 not set in MiGserver conf - skipping"
+         return 1
+    fi
+    return 0
+}
+
+if ! check_enabled "freeze" ; then
+    #echo "DEBUG: nothing to do with freeze disabled"
+    exit 0
+fi
+if ! check_set "site_freeze_doi_url" ; then
+    #echo "DEBUG: nothing to do with freeze doi url disabled"
+    exit 0
+fi
+
+su - mig -c "PYTHONPATH=/home/mig /home/mig/mig/server/indexdoi.py"
 
 exit 0


### PR DESCRIPTION
Adjust `migimportdoi` and `migindexdoi` cronjob to bail out if freeze or DOI integration is not configured.
Changed to absolute path in `importdoi.py` and `indexdoi.py` call.
Add bash flags to catch and fail hard on errors while at it. 
Synced updates to unit test fixture.