### PR TITLE
Integrate QR code on sharelink invite form for easy direct visual sharing

### DIFF
--- a/mig/shared/functionality/sharelink.py
+++ b/mig/shared/functionality/sharelink.py
@@ -46,7 +46,7 @@ from mig.shared.pwcrypto import make_hash
 from mig.shared.sharelinks import build_sharelinkitem_object, load_share_links, \
     create_share_link, update_share_link, delete_share_link, \
     create_share_link_form, invite_share_link_form, \
-    invite_share_link_message, generate_sharelink_id
+    invite_share_link_message, show_share_link_qr, generate_sharelink_id
 from mig.shared.validstring import valid_user_path
 from mig.shared.vgrid import in_vgrid_share, vgrid_is_owner, vgrid_settings, \
     vgrid_add_sharelinks, vgrid_remove_sharelinks
@@ -111,8 +111,13 @@ def main(client_id, user_arguments_dict):
                                                     [table_spec],
                                                     {'width': 600})
     title_entry['script']['advanced'] += add_import
+    title_entry['script']['advanced'] += '''
+<script type="text/javascript" src="/images/js/qrious.js"></script>
+    '''
     title_entry['script']['init'] += add_init
     title_entry['script']['ready'] += add_ready
+    title_entry['script']['ready'] += show_share_link_qr(configuration,
+                                                         share_id)
     output_objects.append({'object_type': 'html_form',
                            'text': man_base_html(configuration)})
 

--- a/mig/shared/sharelinks.py
+++ b/mig/shared/sharelinks.py
@@ -347,9 +347,15 @@ def invite_share_link_form(configuration, client_id, share_dict, output_format,
         <h4>Send Share Link Invitations</h4>
         <p>
         After creating a share link you can manually give the link to anyone
-        you want to share the data with and/or use this form to send
-        invitations on email. Please note that abuse of this service to send
-        out spam mail is strictly prohibited and will be sanctioned.
+        you want to share the data with. Either by handing them the URL<br/>
+        %(share_url)s<br/>
+        or by letting them scan this QR code:
+        </p>
+        <canvas id="sharelink_qr"><!-- filled by script --></canvas>
+        <p>
+        Alternatively you can use this form to send invitations on email.
+        Please note that abuse of this service to send out spam mail is
+        strictly prohibited and will be sanctioned.
         </p>
         <table>
         <tr><td colspan=2>
@@ -389,6 +395,19 @@ def invite_share_link_form(configuration, client_id, share_dict, output_format,
 ''' % fill_helpers
     return html
 
+def show_share_link_qr(configuration, share_id):
+    """Generate QR code for sharelinks"""
+    fill_helpers = {}
+    fill_helpers['share_url'] = "%s/sharelink/%s" % \
+                                (configuration.migserver_https_sid_url,
+                                 share_id)
+    return '''
+         var qr = new QRious({
+                       element: document.getElementById("sharelink_qr"),
+                       value: "%(share_url)s",
+                       size: 200
+                             });
+    ''' % fill_helpers
 
 def load_share_links(configuration, client_id):
     """Find all share links owned by user"""


### PR DESCRIPTION
Integrate QR code on sharelink invite form for easy direct visual sharing. Just reuse the existing qrious js helper to visualize the share URL.