### PR TITLE
Port old paramiko scan noise log silencer to recent platforms and versions

### DIFF
--- a/mig/src/paramiko/Makefile
+++ b/mig/src/paramiko/Makefile
@@ -1,0 +1,15 @@
+# Makefile for paramiko
+
+
+# PLATFORM is expected overridden on command line to be e.g. 'el9' for RHEL/Rocky 9
+PLATFORM = UNKNOWN
+
+PATCH = /usr/bin/patch
+PARAMIKO_VERSION = $(shell python -c 'import paramiko; print(paramiko.__version__)')
+SILENCE = ${CURDIR}/silence-scan-noise_python-paramiko-${PARAMIKO_VERSION}.${PLATFORM}_transport.py.diff
+
+patch:	
+	if [ -e ${SILENCE} ]; then cd / && ${PATCH} --batch -p 1 < ${SILENCE}; fi
+
+unpatch:
+	if [ -e ${SILENCE} ]; then cd / && ${PATCH} --batch -R -p 1 < ${SILENCE}; fi

--- a/mig/src/paramiko/silence-scan-noise_python-paramiko-2.12.0.el9_transport.py.diff
+++ b/mig/src/paramiko/silence-scan-noise_python-paramiko-2.12.0.el9_transport.py.diff
@@ -1,0 +1,13 @@
+--- /usr/lib/python3.9/site-packages/paramiko/transport.py	2025-08-25 14:12:00.801675759 +0200
++++ /usr/lib/python3.9/site-packages/paramiko/transport.py.quieter	2025-08-25 14:10:06.584651532 +0200
+@@ -2187,9 +2187,7 @@
+                         "server" if self.server_mode else "client", e
+                     ),
+                 )
+-                self._log(ERROR, util.tb_strings())
++                # NOTE: we degraded this noisy traceback from ERROR to INFO
++                #       It is usually just ssh vulnerability scans failing.
++                self._log(INFO, util.tb_strings())
+                 self.saved_exception = e
+             except EOFError as e:
+                 self._log(DEBUG, "EOF in transport thread")

--- a/mig/src/paramiko/silence-scan-noise_python-paramiko-2.12.0.noble_transport.py.diff
+++ b/mig/src/paramiko/silence-scan-noise_python-paramiko-2.12.0.noble_transport.py.diff
@@ -1,13 +1,13 @@
---- /usr/lib/python3.9/site-packages/paramiko/transport.py	2025-08-25 14:12:00.801675759 +0200
-+++ /usr/lib/python3.9/site-packages/paramiko/transport.py.quieter	2025-08-25 14:10:06.584651532 +0200
-@@ -2187,9 +2187,7 @@
+--- /usr/lib/python3/dist-packages/paramiko/transport.py	2025-08-25 17:31:40.448077885 +0200
++++ /usr/lib/python3/dist-packages/paramiko/transport.py.quieter	2025-08-25 17:34:45.580822927 +0200
+@@ -2236,7 +2236,9 @@
                          "server" if self.server_mode else "client", e
                      ),
                  )
+-                self._log(ERROR, util.tb_strings())
 +                # NOTE: we degraded this noisy traceback from ERROR to INFO
 +                #       It is usually just ssh vulnerability scans failing.
 +                self._log(INFO, util.tb_strings())
--                self._log(ERROR, util.tb_strings())
                  self.saved_exception = e
              except EOFError as e:
                  self._log(DEBUG, "EOF in transport thread")

--- a/mig/src/paramiko/silence-scan-noise_python-paramiko-4.0.0.el9_transport.py.diff
+++ b/mig/src/paramiko/silence-scan-noise_python-paramiko-4.0.0.el9_transport.py.diff
@@ -1,0 +1,13 @@
+--- /usr/lib/python3.9/site-packages/paramiko/transport.py      2025-08-07 15:09:40.000000000 +0200
++++ /usr/lib/python3.9/site-packages/paramiko/transport.py.quieter      2025-08-25 13:34:22.303856548 +0200
+@@ -2279,7 +2279,9 @@
+                         "server" if self.server_mode else "client", e
+                     ),
+                 )
+-                self._log(ERROR, util.tb_strings())
++                # NOTE: we degraded this noisy traceback from ERROR to INFO
++                #       It is usually just ssh vulnerability scans failing.
++                self._log(INFO, util.tb_strings())
+                 self.saved_exception = e
+             except EOFError as e:
+                 self._log(DEBUG, "EOF in transport thread")


### PR DESCRIPTION
Port the old paramiko quiter patches to the 4.0.0 version we use in Rocky9 with our default pip upgraded paramiko.

Can be applied with
```
cd /
patch -p 1 < /path/to/mig/src/paramiko/silence-scan-noise_python-paramiko-4.0.0.el9_transport.py.diff
```
to avoid the
```
Ignoring potentially dangerous file name /usr/lib/python3.9/site-packages/paramiko/transport.py
``` 
and resulting manual path to patch prompt.

Included a similar version of the old 2.12.0 patch just against rocky 9 python version so that we can also patch the default non-upgraded paramiko there and a similar sample for Ubuntu 24.04 (noble) for local testing.

Added a `Makefile` to support e.g. simple `make patch PLATFORM=el9` and `make unpatch PLATFORM=el9` to handle automatic patching and reverse patch of the installed paramiko in a sane way on RHEL/Rocky 9. Similar results just replacing with `PLATFORM=noble` on Ubuntu 24.04.
