### PR TITLE
Add a coarse filter on allowed peers values in external account requests

### DIFF
--- a/mig/install/MiGserver-template.conf
+++ b/mig/install/MiGserver-template.conf
@@ -762,9 +762,9 @@ password_legacy_policy = __PASSWORD_LEGACY_POLICY__
 # Optional additional guard against simple passwords with the cracklib library
 password_cracklib = __ENABLE_CRACKLIB__
 # Optional prefilter on users who may potenially invite peers as site users.
-# Used as a coarse filter to reject clearly invalid user requests early.
-# Space separated list of user field and regexp-filter pattern pairs separated
-# by colons.
+# Used as a coarse filter to reject clearly invalid user requests early by only
+# filtering on form values (peers_full_name and peers_email). Space separated
+# list of user field and regexp-filter pattern pairs separated by colons.
 peers_prefilter = __PEERS_PREFILTER__
 # Optional limit on users who may invite peers as site users. Space separated
 # list of user field and regexp-filter pattern pairs separated by colons.

--- a/mig/install/MiGserver-template.conf
+++ b/mig/install/MiGserver-template.conf
@@ -761,6 +761,11 @@ password_policy = __PASSWORD_POLICY__
 password_legacy_policy = __PASSWORD_LEGACY_POLICY__
 # Optional additional guard against simple passwords with the cracklib library
 password_cracklib = __ENABLE_CRACKLIB__
+# Optional prefilter on users who may potenially invite peers as site users.
+# Used as a coarse filter to reject clearly invalid user requests early.
+# Space separated list of user field and regexp-filter pattern pairs separated
+# by colons.
+peers_prefilter = __PEERS_PREFILTER__
 # Optional limit on users who may invite peers as site users. Space separated
 # list of user field and regexp-filter pattern pairs separated by colons.
 peers_permit = __PEERS_PERMIT__

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -1173,6 +1173,15 @@ def list_country_codes(configuration):
     return country_list
 
 
+def prefilter_potential_peers(peers_list, configuration):
+    """Return entries from peers_list that fit local prefilter policy"""
+    potential_peers = []
+    for peer_dict in peers_list:
+        if peers_prefilter_allowed(configuration, peer_dict):
+            potential_peers.append(peer_dict)
+    return potential_peers
+
+
 def forced_org_email_match(org, email, configuration):
     """Check that email and organization follow the required policy"""
 
@@ -1321,6 +1330,16 @@ def auto_add_user_allowed_with_peer(configuration, user_dict):
 
     return __auto_add_user_allowed(configuration, user_dict,
                                    configuration.auto_add_user_with_peer)
+
+def peers_prefilter_allowed(configuration, user_dict):
+    """Check if user with user_dict is potentially allowed to manage peers
+    soleley based on optional configuration prefilter.
+    Please use peers_permit_allowed too before actually allowing user as peer.
+    """
+    for (key, val) in configuration.site_peers_prefilter:
+        if not re.match(val, user_dict.get(key, 'NO SUCH FIELD')):
+            return False
+    return True
 
 
 def peers_permit_allowed(configuration, user_dict):

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -529,7 +529,7 @@ _CONFIGURATION_DEFAULTS = {
     'site_signup_methods': ['extcert'],
     'site_login_methods': ['extcert'],
     'site_signup_hint': "",
-    'site_peers_prefilter': [('email', '.*')],
+    'site_peers_prefilter': [('peers_email', '.*')],
     'site_peers_permit': [('distinguished_name', '.*')],
     'site_peers_notice': "",
     # TODO: switch to CSRF_FULL when rpc and scripts are ready?

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -529,6 +529,7 @@ _CONFIGURATION_DEFAULTS = {
     'site_signup_methods': ['extcert'],
     'site_login_methods': ['extcert'],
     'site_signup_hint': "",
+    'site_peers_prefilter': [('email', '.*')],
     'site_peers_permit': [('distinguished_name', '.*')],
     'site_peers_notice': "",
     # TODO: switch to CSRF_FULL when rpc and scripts are ready?
@@ -2138,6 +2139,9 @@ location.""" % self.config_file)
             self.site_login_methods = self.site_signup_methods
         if config.has_option('SITE', 'signup_hint'):
             self.site_signup_hint = config.get('SITE', 'signup_hint').strip()
+        if config.has_option('SITE', 'peers_prefilter'):
+            req = config.get('SITE', 'peers_prefilter').split()
+            self.site_peers_prefilter = [i.split(':', 2) for i in req]
         if config.has_option('SITE', 'peers_permit'):
             req = config.get('SITE', 'peers_permit').split()
             self.site_peers_permit = [i.split(':', 2) for i in req]

--- a/mig/shared/functionality/reqcertaction.py
+++ b/mig/shared/functionality/reqcertaction.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # reqcertaction - handle certificate account requests and send email to admins
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -37,7 +37,7 @@ import tempfile
 
 from mig.shared import returnvalues
 from mig.shared.accountreq import existing_country_code, forced_org_email_match, \
-    user_manage_commands, save_account_request
+    prefilter_potential_peers, user_manage_commands, save_account_request
 from mig.shared.accountstate import default_account_expire
 from mig.shared.base import client_id_dir, canonical_user, mask_creds, \
     generate_https_urls, fill_distinguished_name
@@ -187,6 +187,21 @@ line with the ISO-3166 standard.
         output_objects.append(
             {'object_type': 'link',
              'destination': 'javascript:history.back();',
+             'class': 'genericbutton', 'text': "Try again"})
+        return (output_objects, returnvalues.CLIENT_ERROR)
+
+    peers_list = []
+    for (peer_name, peer_email) in zip(peers_full_name_list, peers_email_list):
+        peers_list.append({'full_name': peer_name, 'email': peer_email})
+    valid_peers = prefilter_potential_peers(peers_list, configuration)
+    if not valid_peers:
+        output_objects.append({'object_type': 'error_text', 'text':
+                               '''Invalid peers specification:
+Please read and follow the sign up help and instructions on the request page!
+You may also read more about the Peers system in the site documentation.
+'''})
+        output_objects.append(
+            {'object_type': 'link', 'destination': 'javascript:history.back();',
              'class': 'genericbutton', 'text': "Try again"})
         return (output_objects, returnvalues.CLIENT_ERROR)
 

--- a/mig/shared/functionality/reqcertaction.py
+++ b/mig/shared/functionality/reqcertaction.py
@@ -192,7 +192,8 @@ line with the ISO-3166 standard.
 
     peers_list = []
     for (peer_name, peer_email) in zip(peers_full_name_list, peers_email_list):
-        peers_list.append({'full_name': peer_name, 'email': peer_email})
+        peers_list.append({'peers_full_name': peer_name,
+                           'peers_email': peer_email})
     valid_peers = prefilter_potential_peers(peers_list, configuration)
     if not valid_peers:
         output_objects.append({'object_type': 'error_text', 'text':

--- a/mig/shared/functionality/reqoidaction.py
+++ b/mig/shared/functionality/reqoidaction.py
@@ -200,7 +200,8 @@ line with the ISO-3166 standard.
 
     peers_list = []
     for (peer_name, peer_email) in zip(peers_full_name_list, peers_email_list):
-        peers_list.append({'full_name': peer_name, 'email': peer_email})
+        peers_list.append({'peers_full_name': peer_name,
+                           'peers_email': peer_email})
     valid_peers = prefilter_potential_peers(peers_list, configuration)
     if not valid_peers:
         output_objects.append({'object_type': 'error_text', 'text':

--- a/mig/shared/functionality/reqoidaction.py
+++ b/mig/shared/functionality/reqoidaction.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # reqoidaction - handle OpenID account requests and send email to admins
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -37,7 +37,7 @@ import tempfile
 
 from mig.shared import returnvalues
 from mig.shared.accountreq import existing_country_code, forced_org_email_match, \
-    user_manage_commands, save_account_request
+    prefilter_potential_peers, user_manage_commands, save_account_request
 from mig.shared.accountstate import default_account_expire
 from mig.shared.base import client_id_dir, canonical_user, mask_creds, \
     force_utf8, force_unicode, force_native_str, force_native_str_rec, \
@@ -195,6 +195,21 @@ line with the ISO-3166 standard.
         output_objects.append(
             {'object_type': 'link',
              'destination': 'javascript:history.back();',
+             'class': 'genericbutton', 'text': "Try again"})
+        return (output_objects, returnvalues.CLIENT_ERROR)
+
+    peers_list = []
+    for (peer_name, peer_email) in zip(peers_full_name_list, peers_email_list):
+        peers_list.append({'full_name': peer_name, 'email': peer_email})
+    valid_peers = prefilter_potential_peers(peers_list, configuration)
+    if not valid_peers:
+        output_objects.append({'object_type': 'error_text', 'text':
+                               '''Invalid peers specification:
+Please read and follow the sign up help and instructions on the request page!
+You may also read more about the Peers system in the site documentation.
+'''})
+        output_objects.append(
+            {'object_type': 'link', 'destination': 'javascript:history.back();',
              'class': 'genericbutton', 'text': "Try again"})
         return (output_objects, returnvalues.CLIENT_ERROR)
 

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -447,6 +447,7 @@ def generate_confs(
     daemon_pubkey_from_dns=False,
     daemon_show_address='',
     alias_field='',
+    peers_prefilter='email:.*',
     peers_permit='distinguished_name:.*',
     vgrid_creators='distinguished_name:.*',
     vgrid_managers='distinguished_name:.*',
@@ -771,6 +772,7 @@ def _generate_confs_prepare(
     daemon_pubkey_from_dns,
     daemon_show_address,
     alias_field,
+    peers_prefilter,
     peers_permit,
     vgrid_creators,
     vgrid_managers,
@@ -1056,6 +1058,7 @@ def _generate_confs_prepare(
     user_dict['__SEAFILE_RO_ACCESS__'] = "%s" % seafile_ro_access
     user_dict['__PUBLIC_USE_HTTPS__'] = "%s" % public_use_https
     user_dict['__ALIAS_FIELD__'] = alias_field
+    user_dict['__PEERS_PREFILTER__'] = peers_prefilter
     user_dict['__PEERS_PERMIT__'] = peers_permit
     user_dict['__VGRID_CREATORS__'] = vgrid_creators
     user_dict['__VGRID_MANAGERS__'] = vgrid_managers

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -84,6 +84,7 @@ def abspath(path, start):
         return path
     return os.path.normpath(os.path.join(start, path))
 
+
 def transform_str_to_dict(input_str):
     """
     Transforms a string input into a Python literal or container.
@@ -447,7 +448,7 @@ def generate_confs(
     daemon_pubkey_from_dns=False,
     daemon_show_address='',
     alias_field='',
-    peers_prefilter='email:.*',
+    peers_prefilter='peers_email:.*',
     peers_permit='distinguished_name:.*',
     vgrid_creators='distinguished_name:.*',
     vgrid_managers='distinguished_name:.*',
@@ -1519,7 +1520,8 @@ cert, oid and sid based https!
         jupyter_openids, jupyter_oidcs, jupyter_rewrites = [], [], []
         services = user_dict['__JUPYTER_SERVICES__'].split()
 
-        jupyter_services_proxy_configs = transform_str_to_dict(jupyter_services_proxy_config)
+        jupyter_services_proxy_configs = transform_str_to_dict(
+            jupyter_services_proxy_config)
         if not isinstance(jupyter_services_proxy_configs, dict):
             print('Error: jupyter_services_proxy_config '
                   'could not be interpreted correctly. Double check that your '
@@ -1623,7 +1625,8 @@ cert, oid and sid based https!
                 ws_host = host.replace(
                     "https://", "wss://").replace("http://", "ws://")
                 member_def = "Define JUPYTER_%s %s" % (name_index, host)
-                ws_member_def = "Define WS_JUPYTER_%s %s" % (name_index, ws_host)
+                ws_member_def = "Define WS_JUPYTER_%s %s" % (name_index,
+                                                             ws_host)
 
                 # No user supplied port, assign based on url prefix
                 if len(host.split(":")) < 3:
@@ -1641,7 +1644,8 @@ cert, oid and sid based https!
 
                 jupyter_defs.extend([member_def, ws_member_def])
 
-            service_proxy_config_kwargs = jupyter_services_proxy_configs.get(name, {})
+            service_proxy_config_kwargs = jupyter_services_proxy_configs.get(
+                name, {})
             # Get proxy template and append to template conf
             proxy_template = gen_balancer_proxy_template(
                 url, def_name, name, hosts, ws_hosts,

--- a/tests/fixture/confs-stdlocal/MiGserver.conf
+++ b/tests/fixture/confs-stdlocal/MiGserver.conf
@@ -761,6 +761,11 @@ password_policy = MEDIUM
 password_legacy_policy = 
 # Optional additional guard against simple passwords with the cracklib library
 password_cracklib = False
+# Optional prefilter on users who may potenially invite peers as site users.
+# Used as a coarse filter to reject clearly invalid user requests early.
+# Space separated list of user field and regexp-filter pattern pairs separated
+# by colons.
+peers_prefilter = email:.*
 # Optional limit on users who may invite peers as site users. Space separated
 # list of user field and regexp-filter pattern pairs separated by colons.
 peers_permit = distinguished_name:.*

--- a/tests/fixture/confs-stdlocal/MiGserver.conf
+++ b/tests/fixture/confs-stdlocal/MiGserver.conf
@@ -762,10 +762,10 @@ password_legacy_policy =
 # Optional additional guard against simple passwords with the cracklib library
 password_cracklib = False
 # Optional prefilter on users who may potenially invite peers as site users.
-# Used as a coarse filter to reject clearly invalid user requests early.
-# Space separated list of user field and regexp-filter pattern pairs separated
-# by colons.
-peers_prefilter = email:.*
+# Used as a coarse filter to reject clearly invalid user requests early by only
+# filtering on form values (peers_full_name and peers_email). Space separated
+# list of user field and regexp-filter pattern pairs separated by colons.
+peers_prefilter = peers_email:.*
 # Optional limit on users who may invite peers as site users. Space separated
 # list of user field and regexp-filter pattern pairs separated by colons.
 peers_permit = distinguished_name:.*

--- a/tests/fixture/mig_shared_configuration--new.json
+++ b/tests/fixture/mig_shared_configuration--new.json
@@ -181,6 +181,12 @@
       ".*"
     ]
   ],
+  "site_peers_prefilter": [
+    [
+      "email",
+      ".*"
+    ]
+  ],
   "site_prefer_python3": false,
   "site_signup_hint": "",
   "site_signup_methods": [

--- a/tests/fixture/mig_shared_configuration--new.json
+++ b/tests/fixture/mig_shared_configuration--new.json
@@ -183,7 +183,7 @@
   ],
   "site_peers_prefilter": [
     [
-      "email",
+      "peers_email",
       ".*"
     ]
   ],

--- a/tests/fixture/mig_shared_configuration--new.json.ini
+++ b/tests/fixture/mig_shared_configuration--new.json.ini
@@ -2,6 +2,7 @@
 auto_add_user_permit = array_of_tuples
 auto_add_user_with_peer = array_of_tuples
 site_cloud_access = array_of_tuples
+site_peers_prefilter = array_of_tuples
 site_peers_permit = array_of_tuples
 site_vgrid_creators = array_of_tuples
 site_vgrid_managers = array_of_tuples


### PR DESCRIPTION
Add a coarse filter on allowed peers values in external account requests.

~Should be extended with one or more basic unit tests of the new `accountreq` helpers~.