### PR TITLE
Add `signup_prefilter` to ease filtering of unwanted manual sign ups

### DIFF
--- a/mig/install/MiGserver-template.conf
+++ b/mig/install/MiGserver-template.conf
@@ -757,6 +757,12 @@ password_policy = __PASSWORD_POLICY__
 password_legacy_policy = __PASSWORD_LEGACY_POLICY__
 # Optional additional guard against simple passwords with the cracklib library
 password_cracklib = __ENABLE_CRACKLIB__
+# Optional prefilter on users who may sign up as site users with sign up forms.
+# Used as a coarse filter to reject invalid user requests early by only
+# filtering on form values (organization, email). E.g. to avoid internal users
+# signing up as externals. Space separated list of user field and regexp-filter
+# pattern pairs separated by colons.
+signup_prefilter = __SIGNUP_PREFILTER__
 # Optional prefilter on users who may potenially invite peers as site users.
 # Used as a coarse filter to reject clearly invalid user requests early by only
 # filtering on form values (peers_full_name and peers_email). Space separated

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -1182,51 +1182,6 @@ def prefilter_potential_peers(peers_list, configuration):
     return potential_peers
 
 
-def forced_org_email_match(org, email, configuration):
-    """Check that email and organization follow the required policy"""
-
-    logger = configuration.logger
-    # Policy regexps: prioritized order with most general last
-    force_org_email = [('DIKU', ['^[a-zA-Z0-9_.+-]+@diku.dk$',
-                                 '^[a-zA-Z0-9_.+-]+@di.ku.dk$']),
-                       ('NBI', ['^[a-zA-Z0-9_.+-]+@nbi.ku.dk$',
-                                '^[a-zA-Z0-9_.+-]+@nbi.dk$',
-                                '^[a-zA-Z0-9_.+-]+@fys.ku.dk$']),
-                       ('IMF', ['^[a-zA-Z0-9_.+-]+@math.ku.dk$']),
-                       # Keep this KU catch-all last and do not generalize it!
-                       ('KU', ['^[a-zA-Z0-9_.+-]+@(alumni.|)ku.dk$']),
-                       ]
-    force_org_email_dict = dict(force_org_email)
-    is_forced_email = False
-    is_forced_org = False
-    if org.upper() in force_org_email_dict:
-        is_forced_org = True
-        # Consistent casing
-        org = org.upper()
-    email_hit = '__BOGUS__'
-    for (forced_org, forced_email_list) in force_org_email:
-        for forced_email in forced_email_list:
-            # Consistent casing
-            if re.match(forced_email, email.lower()):
-                is_forced_email = True
-                email_hit = forced_email
-                logger.debug('email match on %s vs %s' % (email, forced_email))
-                break
-
-        # Use first hit to avoid catch-all overriding specific hits
-        if is_forced_email or is_forced_org and org == forced_org:
-            break
-    if is_forced_org != is_forced_email or \
-            not email_hit in force_org_email_dict.get(org, ['__BOGUS__']):
-        logger.error('Illegal email and organization combination: %s' %
-                     ([email, org, is_forced_org, is_forced_email,
-                       email_hit, force_org_email_dict.get(org,
-                                                           ['__BOGUS__'])]))
-        return False
-    else:
-        return True
-
-
 def save_account_request(configuration, req_dict):
     """Save req_dict account request as pickle in configured user_pending
     location.
@@ -1330,6 +1285,17 @@ def auto_add_user_allowed_with_peer(configuration, user_dict):
 
     return __auto_add_user_allowed(configuration, user_dict,
                                    configuration.auto_add_user_with_peer)
+
+
+def signup_prefilter_allowed(configuration, user_dict):
+    """Check if user with user_dict is potentially allowed to sign up in forms
+    soleley based on optional configuration prefilter.
+    """
+    for (key, val) in configuration.site_signup_prefilter:
+        if not re.match(val, user_dict.get(key, 'NO SUCH FIELD')):
+            return False
+    return True
+
 
 def peers_prefilter_allowed(configuration, user_dict):
     """Check if user with user_dict is potentially allowed to manage peers

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -526,6 +526,7 @@ _CONFIGURATION_DEFAULTS = {
     'site_signup_methods': ['extcert'],
     'site_login_methods': ['extcert'],
     'site_signup_hint': "",
+    'site_signup_prefilter': [('email', '.*')],
     'site_peers_prefilter': [('peers_email', '.*')],
     'site_peers_permit': [('distinguished_name', '.*')],
     'site_peers_notice': "",
@@ -2131,6 +2132,9 @@ location.""" % self.config_file)
             self.site_login_methods = self.site_signup_methods
         if config.has_option('SITE', 'signup_hint'):
             self.site_signup_hint = config.get('SITE', 'signup_hint').strip()
+        if config.has_option('SITE', 'signup_prefilter'):
+            req = config.get('SITE', 'signup_prefilter').split()
+            self.site_signup_prefilter = [i.split(':', 2) for i in req]
         if config.has_option('SITE', 'peers_prefilter'):
             req = config.get('SITE', 'peers_prefilter').split()
             self.site_peers_prefilter = [i.split(':', 2) for i in req]

--- a/mig/shared/functionality/reqcertaction.py
+++ b/mig/shared/functionality/reqcertaction.py
@@ -29,15 +29,16 @@
 
 from __future__ import absolute_import
 
-# TODO: this backend is horribly KU/UCPH-specific, should move that to conf
+# TODO: this backend is somewhat KU/UCPH-specific, should move that to conf
 
 import os
 import time
 import tempfile
 
 from mig.shared import returnvalues
-from mig.shared.accountreq import existing_country_code, forced_org_email_match, \
-    prefilter_potential_peers, user_manage_commands, save_account_request
+from mig.shared.accountreq import existing_country_code, \
+    prefilter_potential_peers, save_account_request, signup_prefilter_allowed, \
+    user_manage_commands
 from mig.shared.accountstate import default_account_expire
 from mig.shared.base import client_id_dir, canonical_user, mask_creds, \
     generate_https_urls, fill_distinguished_name
@@ -111,6 +112,7 @@ Please contact the %s site support (%s) if you think it should be enabled.
     country = accepted['country'][-1].strip()
     state = accepted['state'][-1].strip()
     org = accepted['org'][-1].strip()
+    # NOTE: safeinput thoroughly checks that emails are on valid form
     email = accepted['email'][-1].strip()
     password = accepted['password'][-1]
     verifypassword = accepted['verifypassword'][-1]
@@ -206,23 +208,6 @@ You may also read more about the Peers system in the site documentation.
              'class': 'genericbutton', 'text': "Try again"})
         return (output_objects, returnvalues.CLIENT_ERROR)
 
-    # TODO: move this check to conf?
-
-    if not forced_org_email_match(org, email, configuration):
-        output_objects.append({'object_type': 'error_text', 'text':
-                               '''Illegal email and organization combination:
-Please read and follow the instructions in red on the request page!
-If you are a student with only a @*.ku.dk address please just use KU as
-organization. As long as you state that you want the account for course
-purposes in the comment field, you will be given access to the necessary
-resources anyway.
-'''})
-        output_objects.append(
-            {'object_type': 'link',
-             'destination': 'javascript:history.back();',
-             'class': 'genericbutton', 'text': "Try again"})
-        return (output_objects, returnvalues.CLIENT_ERROR)
-
     raw_user = {
         'full_name': cert_name,
         'organization': org,
@@ -246,6 +231,19 @@ resources anyway.
     # Title name, lowercase email, uppercase country and state, etc.
     user_dict = canonical_user(configuration, raw_user, raw_user.keys())
     fill_distinguished_name(user_dict)
+
+    if not signup_prefilter_allowed(configuration, raw_user):
+        output_objects.append({'object_type': 'error_text', 'text':
+                               '''Invalid sign up request:
+Please read and follow the sign up help and instructions on the request page!
+Namely, make sure to use the correct sign up based on your organizational
+affiliation. You may also read more about sign up in the site documentation.
+'''})
+        output_objects.append(
+            {'object_type': 'link', 'destination': 'javascript:history.back();',
+             'class': 'genericbutton', 'text': "Try again"})
+        return (output_objects, returnvalues.CLIENT_ERROR)
+
     user_id = user_dict['distinguished_name']
     user_dict['authorized'] = (user_id == client_id)
     if configuration.user_openid_providers and configuration.user_openid_alias:
@@ -285,7 +283,7 @@ User certificate requests are not supported on this site!"""})
     helper_commands = user_manage_commands(configuration, mig_user, req_path,
                                            user_id, user_dict, 'cert')
     user_dict.update(helper_commands)
-    user_dict['site'] = configuration.short_title
+    user_dict['site'] = short_title
     user_dict['vgrid_label'] = configuration.site_vgrid_label
     user_dict['vgridman_links'] = generate_https_urls(
         configuration, '%(auto_base)s/%(auto_bin)s/vgridman.py', {})

--- a/mig/shared/functionality/reqoidaction.py
+++ b/mig/shared/functionality/reqoidaction.py
@@ -29,15 +29,16 @@
 
 from __future__ import absolute_import
 
-# TODO: this backend is horribly KU/UCPH-specific, should move that to conf
+# TODO: this backend is somewhat KU/UCPH-specific, should move that to conf
 
 import os
 import time
 import tempfile
 
 from mig.shared import returnvalues
-from mig.shared.accountreq import existing_country_code, forced_org_email_match, \
-    prefilter_potential_peers, user_manage_commands, save_account_request
+from mig.shared.accountreq import existing_country_code, \
+    prefilter_potential_peers, save_account_request, signup_prefilter_allowed, \
+    user_manage_commands
 from mig.shared.accountstate import default_account_expire
 from mig.shared.base import client_id_dir, canonical_user, mask_creds, \
     force_utf8, force_unicode, force_native_str, force_native_str_rec, \
@@ -214,22 +215,6 @@ You may also read more about the Peers system in the site documentation.
              'class': 'genericbutton', 'text': "Try again"})
         return (output_objects, returnvalues.CLIENT_ERROR)
 
-    # TODO: move this check to conf?
-
-    if not forced_org_email_match(org, email, configuration):
-        output_objects.append({'object_type': 'error_text', 'text':
-                               '''Illegal email and organization combination:
-Please read and follow the instructions in red on the request page!
-If you are a student with only a @*.ku.dk address please just use KU as
-organization. As long as you state that you want the account for course
-purposes in the comment field, you will be given access to the necessary
-resources anyway.
-'''})
-        output_objects.append(
-            {'object_type': 'link', 'destination': 'javascript:history.back();',
-             'class': 'genericbutton', 'text': "Try again"})
-        return (output_objects, returnvalues.CLIENT_ERROR)
-
     # NOTE: we save password on scrambled form only if explicitly requested
     if passwordrecovery:
         logger.info('saving %s scrambled password to enable recovery' % email)
@@ -261,6 +246,19 @@ resources anyway.
     # Title name, lowercase email, uppercase country and state, etc.
     user_dict = canonical_user(configuration, raw_user, raw_user.keys())
     fill_distinguished_name(user_dict)
+
+    if not signup_prefilter_allowed(configuration, raw_user):
+        output_objects.append({'object_type': 'error_text', 'text':
+                               '''Invalid sign up request:
+Please read and follow the sign up help and instructions on the request page!
+Namely, make sure to use the correct sign up based on your organizational
+affiliation. You may also read more about sign up in the site documentation.
+'''})
+        output_objects.append(
+            {'object_type': 'link', 'destination': 'javascript:history.back();',
+             'class': 'genericbutton', 'text': "Try again"})
+        return (output_objects, returnvalues.CLIENT_ERROR)
+
     user_id = user_dict['distinguished_name']
     user_dict['authorized'] = (user_id == client_id)
     if configuration.user_openid_providers and configuration.user_openid_alias:

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -447,6 +447,7 @@ def generate_confs(
     daemon_pubkey_from_dns=False,
     daemon_show_address='',
     alias_field='',
+    signup_prefilter='email:.*',
     peers_prefilter='peers_email:.*',
     peers_permit='distinguished_name:.*',
     vgrid_creators='distinguished_name:.*',
@@ -771,6 +772,7 @@ def _generate_confs_prepare(
     daemon_pubkey_from_dns,
     daemon_show_address,
     alias_field,
+    signup_prefilter,
     peers_prefilter,
     peers_permit,
     vgrid_creators,
@@ -1056,6 +1058,7 @@ def _generate_confs_prepare(
     user_dict['__SEAFILE_RO_ACCESS__'] = "%s" % seafile_ro_access
     user_dict['__PUBLIC_USE_HTTPS__'] = "%s" % public_use_https
     user_dict['__ALIAS_FIELD__'] = alias_field
+    user_dict['__SIGNUP_PREFILTER__'] = signup_prefilter
     user_dict['__PEERS_PREFILTER__'] = peers_prefilter
     user_dict['__PEERS_PERMIT__'] = peers_permit
     user_dict['__VGRID_CREATORS__'] = vgrid_creators

--- a/tests/fixture/confs-stdlocal/MiGserver.conf
+++ b/tests/fixture/confs-stdlocal/MiGserver.conf
@@ -757,6 +757,12 @@ password_policy = MEDIUM
 password_legacy_policy = 
 # Optional additional guard against simple passwords with the cracklib library
 password_cracklib = False
+# Optional prefilter on users who may sign up as site users with sign up forms.
+# Used as a coarse filter to reject invalid user requests early by only
+# filtering on form values (organization, email). E.g. to avoid internal users
+# signing up as externals. Space separated list of user field and regexp-filter
+# pattern pairs separated by colons.
+signup_prefilter = email:.*
 # Optional prefilter on users who may potenially invite peers as site users.
 # Used as a coarse filter to reject clearly invalid user requests early by only
 # filtering on form values (peers_full_name and peers_email). Space separated

--- a/tests/fixture/mig_shared_configuration--new.json
+++ b/tests/fixture/mig_shared_configuration--new.json
@@ -191,6 +191,12 @@
   "site_signup_methods": [
     "extcert"
   ],
+  "site_signup_prefilter": [
+    [
+      "email",
+      ".*"
+    ]
+  ],
   "site_skin": "",
   "site_vgrid_creators": [
     [

--- a/tests/fixture/mig_shared_configuration--new.json.ini
+++ b/tests/fixture/mig_shared_configuration--new.json.ini
@@ -2,6 +2,7 @@
 auto_add_user_permit = array_of_tuples
 auto_add_user_with_peer = array_of_tuples
 site_cloud_access = array_of_tuples
+site_signup_prefilter = array_of_tuples
 site_peers_prefilter = array_of_tuples
 site_peers_permit = array_of_tuples
 site_vgrid_creators = array_of_tuples


### PR DESCRIPTION
Add `signup_prefilter` similar to `peers_prefilter` to ease filtering of unwanted account requests like e.g. internal users signing up as external users. Eliminated the old obsolete `forced_org_email_match` checks, which can now be implemented better with a `signup_prefilter` on email and optionally organization.
Minor polish and sync of reqcert and reqoid for consistency.