### PR TITLE
Add additional unit tests for the `peers_prefilter` helper from PR321.

### DIFF
--- a/tests/test_mig_shared_accountreq.py
+++ b/tests/test_mig_shared_accountreq.py
@@ -164,8 +164,6 @@ class MigSharedAccountreq__peers(MigTestCase):
                                                         user)
             self.assertFalse(check)
 
-            print("check %r: %s" % (addr, check))
-
     def test_peers_prefilter_email_accept(self):
         accept = ['john.doe@science.ku.dk', 'abc123@ku.dk',
                   'john.doe@a.b.c.ku.dk']
@@ -177,7 +175,7 @@ class MigSharedAccountreq__peers(MigTestCase):
                                                        user)
             self.assertTrue(check)
 
-    def test_signup_prefilter_email_reject(self):
+    def test_peers_prefilter_email_reject(self):
         reject = ['john@doe.org', 'a@b.c.org', 'a@ku.dk.com',
                   'a@sci.ku.dk.org']
         self.configuration.site_peers_prefilter = [

--- a/tests/test_mig_shared_accountreq.py
+++ b/tests/test_mig_shared_accountreq.py
@@ -143,27 +143,49 @@ class MigSharedAccountreq__peers(MigTestCase):
         self.assertTrue(success)
 
     def test_signup_prefilter_email_accept(self):
-        accept = ['john@doe.org', 'a@b.c.org', 'a@ku.dk.com', 'a@sci.ku.dk.org',
-                  'a@diku.dk', 'a@nbi.dk']
+        accept = ['john@doe.org', 'a@b.c.org', 'a@ku.dk.com',
+                  'a@sci.ku.dk.org', 'a@diku.dk', 'a@nbi.dk']
         self.configuration.site_signup_prefilter = [
             ('email', r'^.+(?<!(@|\.)ku\.dk)$')]
         for addr in accept:
             user = {'email': addr}
-            check = accountreq.signup_prefilter_allowed(
-                self.configuration, user)
-            print("check %r: %s" % (addr, check))
+            check = accountreq.signup_prefilter_allowed(self.configuration,
+                                                        user)
             self.assertTrue(check)
 
     def test_signup_prefilter_email_reject(self):
-        reject = ['john.doe@science.ku.dk',
-                  'abc123@ku.dk', 'john.doe@a.b.c.ku.dk']
+        reject = ['john.doe@science.ku.dk', 'abc123@ku.dk',
+                  'john.doe@a.b.c.ku.dk']
         self.configuration.site_signup_prefilter = [
             ('email', r'.+(?<!(@|\.)ku\.dk)$')]
         for addr in reject:
             user = {'email': addr}
-            check = accountreq.signup_prefilter_allowed(
-                self.configuration, user)
+            check = accountreq.signup_prefilter_allowed(self.configuration,
+                                                        user)
+            self.assertFalse(check)
+
             print("check %r: %s" % (addr, check))
+
+    def test_peers_prefilter_email_accept(self):
+        accept = ['john.doe@science.ku.dk', 'abc123@ku.dk',
+                  'john.doe@a.b.c.ku.dk']
+        self.configuration.site_peers_prefilter = [
+            ('peers_email', r'^.+@([a-z0-9]+\.)*ku\.dk$')]
+        for addr in accept:
+            user = {'peers_email': addr}
+            check = accountreq.peers_prefilter_allowed(self.configuration,
+                                                       user)
+            self.assertTrue(check)
+
+    def test_signup_prefilter_email_reject(self):
+        reject = ['john@doe.org', 'a@b.c.org', 'a@ku.dk.com',
+                  'a@sci.ku.dk.org']
+        self.configuration.site_peers_prefilter = [
+            ('peers_email', r'^.+@([a-z0-9]+\.)*ku\.dk$')]
+        for addr in reject:
+            user = {'peers_email': addr}
+            check = accountreq.peers_prefilter_allowed(self.configuration,
+                                                       user)
             self.assertFalse(check)
 
 


### PR DESCRIPTION
Cleaned up a bit in PR #326 code to remove debug messages and to sync.