### PR TITLE
More migration to `mig/lib/` for code, `bin/` for scripts and tools  and `sbin/` for services.

### DIFF
--- a/bin/addheader.py
+++ b/bin/addheader.py
@@ -19,9 +19,8 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
-# USA.
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # --- END_HEADER ---
 #
@@ -92,9 +91,8 @@ LICENSE_TEXT += """#
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
-# USA."""
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA."""
 
 
 def check_header(path, var_dict, preamble_lines=100):

--- a/bin/checkcloud.py
+++ b/bin/checkcloud.py
@@ -1,0 +1,1 @@
+../mig/server/checkcloud.py

--- a/bin/checktwofactor.py
+++ b/bin/checktwofactor.py
@@ -1,0 +1,1 @@
+../mig/server/checktwofactor.py

--- a/bin/chkenabled.py
+++ b/bin/chkenabled.py
@@ -1,0 +1,1 @@
+../mig/server/chkenabled.py

--- a/bin/cleansessions.py
+++ b/bin/cleansessions.py
@@ -1,0 +1,1 @@
+../mig/server/cleansessions.py

--- a/bin/createresource.py
+++ b/bin/createresource.py
@@ -1,0 +1,1 @@
+../mig/server/createresource.py

--- a/bin/createuser.py
+++ b/bin/createuser.py
@@ -1,0 +1,1 @@
+../mig/server/createuser.py

--- a/bin/deleteuser.py
+++ b/bin/deleteuser.py
@@ -1,0 +1,1 @@
+../mig/server/deleteuser.py

--- a/bin/editgdpuser.py
+++ b/bin/editgdpuser.py
@@ -1,0 +1,1 @@
+../mig/server/editgdpuser.py

--- a/bin/editmeta.py
+++ b/bin/editmeta.py
@@ -1,0 +1,1 @@
+../mig/server/editmeta.py

--- a/bin/edituser.py
+++ b/bin/edituser.py
@@ -1,0 +1,1 @@
+../mig/server/edituser.py

--- a/bin/genoiddiscovery.py
+++ b/bin/genoiddiscovery.py
@@ -1,0 +1,1 @@
+../mig/server/genoiddiscovery.py

--- a/bin/importdoi.py
+++ b/bin/importdoi.py
@@ -1,0 +1,1 @@
+../mig/server/importdoi.py

--- a/bin/importusers.py
+++ b/bin/importusers.py
@@ -1,0 +1,1 @@
+../mig/server/importusers.py

--- a/bin/indexdoi.py
+++ b/bin/indexdoi.py
@@ -1,0 +1,1 @@
+../mig/server/indexdoi.py

--- a/bin/managecloud.py
+++ b/bin/managecloud.py
@@ -1,0 +1,1 @@
+../mig/server/managecloud.py

--- a/bin/notifyexpire.py
+++ b/bin/notifyexpire.py
@@ -1,0 +1,1 @@
+../mig/server/notifyexpire.py

--- a/bin/notifymigoid.py
+++ b/bin/notifymigoid.py
@@ -1,0 +1,1 @@
+../mig/server/notifymigoid.py

--- a/bin/notifypassword.py
+++ b/bin/notifypassword.py
@@ -1,0 +1,1 @@
+../mig/server/notifypassword.py

--- a/bin/refreshusers.py
+++ b/bin/refreshusers.py
@@ -1,0 +1,1 @@
+../mig/server/refreshusers.py

--- a/bin/rejectuser.py
+++ b/bin/rejectuser.py
@@ -1,0 +1,1 @@
+../mig/server/rejectuser.py

--- a/bin/reqacceptpeer.py
+++ b/bin/reqacceptpeer.py
@@ -1,0 +1,1 @@
+../mig/server/reqacceptpeer.py

--- a/bin/reset2fakey.py
+++ b/bin/reset2fakey.py
@@ -1,0 +1,1 @@
+../mig/server/reset2fakey.py

--- a/bin/sftpfailinfo.py
+++ b/bin/sftpfailinfo.py
@@ -1,0 +1,1 @@
+../mig/server/sftpfailinfo.py

--- a/bin/usagestats.py
+++ b/bin/usagestats.py
@@ -1,0 +1,1 @@
+../mig/server/usagestats.py

--- a/bin/verifyarchives.py
+++ b/bin/verifyarchives.py
@@ -1,0 +1,1 @@
+../mig/server/verifyarchives.py

--- a/mig/cgi-bin/__init__.py
+++ b/mig/cgi-bin/__init__.py
@@ -3,8 +3,8 @@
 #
 # --- BEGIN_HEADER ---
 #
-# __init__ - [insert a few words of module description on this line]
-# Copyright (C) 2003-2009  The MiG Project lead by Brian Vinter
+# __init__ - package init
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -19,13 +19,22 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # -- END_HEADER ---
 #
 
-# This file is needed to tell python that this dir is a package
-# so that other modules can call, say, import shared.editing
-# Please refer to http://www.network-theory.co.uk/docs/pytut/tut_51.html
-# for details.
+"""This file is needed to tell python that this dir is a package
+so that all modules can call, say, import mig.shared.base
+Please refer e.g. to
+https://docs.python.org/3/tutorial/modules.html#packages
+and
+https://www.python.org/dev/peps/pep-0008/#imports
+for details
+"""
+
+__dummy = True
+
+# above line is only to make python tidy behave and not
+# move module doc string inside header

--- a/mig/lib/README
+++ b/mig/lib/README
@@ -4,7 +4,11 @@ efforts.
 That also means that any code placed here MUST comply with the project style
 guides, be lint clean, documented and have decent unit test coverage.
 
-You may want to use autopep8, pylint, ruff or any available make lint targets
-to help verify.
-The black code formatter and isort may also come in handy. You can see usage
-hints in `.github/workflows/python-stylecheck.yml`.
+You may want to use autopep8, pylint, flake8, ruff or 'make lint' targets once
+available to help verify.
+The black code formatter and isort may also come in handy. To apply them on
+the code in $TARGET file please run:
+black --line-length=80 $TARGET
+isort --line-length=80 -m=HANGING_INDENT $TARGET
+in that order on code files to preserve our existing hanging indent imports
+instead of the exotic black import style with parentheses.

--- a/mig/lib/__init__.py
+++ b/mig/lib/__init__.py
@@ -26,7 +26,7 @@
 #
 
 """This file is needed to tell python that this dir is a package
-so that all modules can call, say, import mig.shared.base
+so that all modules can call, say, import mig.lib.daemon
 Please refer e.g. to
 https://docs.python.org/3/tutorial/modules.html#packages
 and

--- a/mig/server/__init__.py
+++ b/mig/server/__init__.py
@@ -3,8 +3,8 @@
 #
 # --- BEGIN_HEADER ---
 #
-# __init__ - package marker
-# Copyright (C) 2003-2020  The MiG Project lead by Brian Vinter
+# __init__ - package init
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -19,15 +19,16 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # -- END_HEADER ---
 #
 
 """This file is needed to tell python that this dir is a package
-so that other modules can call, say, import mig.server.jobscriptgenerator
-Please refer to http://www.network-theory.co.uk/docs/pytut/tut_51.html
+so that all modules can call, say, import mig.shared.base
+Please refer e.g. to
+https://docs.python.org/3/tutorial/modules.html#packages
 and
 https://www.python.org/dev/peps/pep-0008/#imports
 for details

--- a/mig/shared/__init__.py
+++ b/mig/shared/__init__.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # --- BEGIN_HEADER ---
 #
-# __init__ - [insert a few words of module description on this line]
-# Copyright (C) 2003-2009  The MiG Project lead by Brian Vinter
+# __init__ - package init
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -19,15 +19,18 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # -- END_HEADER ---
 #
 
 """This file is needed to tell python that this dir is a package
-so that other modules can call, say, import shared.editing
-Please refer to http://www.network-theory.co.uk/docs/pytut/tut_51.html
+so that all modules can call, say, import mig.shared.base
+Please refer e.g. to
+https://docs.python.org/3/tutorial/modules.html#packages
+and
+https://www.python.org/dev/peps/pep-0008/#imports
 for details
 """
 

--- a/mig/shared/functionality/__init__.py
+++ b/mig/shared/functionality/__init__.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # --- BEGIN_HEADER ---
 #
-# __init__ - [insert a few words of module description on this line]
-# Copyright (C) 2003-2009  The MiG Project lead by Brian Vinter
+# __init__ - package init
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -19,13 +19,22 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # -- END_HEADER ---
 #
 
-# This file is needed to tell python that this dir is a package
-# so that other modules can call, say, import shared.editing
-# Please refer to http://www.network-theory.co.uk/docs/pytut/tut_51.html
-# for details.
+"""This file is needed to tell python that this dir is a package
+so that all modules can call, say, import mig.shared.base
+Please refer e.g. to
+https://docs.python.org/3/tutorial/modules.html#packages
+and
+https://www.python.org/dev/peps/pep-0008/#imports
+for details
+"""
+
+__dummy = True
+
+# above line is only to make python tidy behave and not
+# move module doc string inside header

--- a/mig/shared/gdp/__init__.py
+++ b/mig/shared/gdp/__init__.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # --- BEGIN_HEADER ---
 #
-# __init__ - [insert a few words of module description on this line]
-# Copyright (C) 2010-2020  The MiG Project lead by Brian Vinter
+# __init__ - package init
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -19,16 +19,18 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # -- END_HEADER ---
 #
 
-
 """This file is needed to tell python that this dir is a package
-so that other modules can call, say, import shared.editing
-Please refer to http://www.network-theory.co.uk/docs/pytut/tut_51.html
+so that all modules can call, say, import mig.shared.base
+Please refer e.g. to
+https://docs.python.org/3/tutorial/modules.html#packages
+and
+https://www.python.org/dev/peps/pep-0008/#imports
 for details
 """
 
@@ -36,4 +38,3 @@ __dummy = True
 
 # above line is only to make python tidy behave and not
 # move module doc string inside header
-

--- a/mig/shared/griddaemons/__init__.py
+++ b/mig/shared/griddaemons/__init__.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # --- BEGIN_HEADER ---
 #
-# __init__ - [insert a few words of module description on this line]
-# Copyright (C) 2010-2020  The MiG Project lead by Brian Vinter
+# __init__ - package init
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -19,15 +19,18 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # -- END_HEADER ---
 #
 
 """This file is needed to tell python that this dir is a package
-so that other modules can call, say, import shared.editing
-Please refer to http://www.network-theory.co.uk/docs/pytut/tut_51.html
+so that all modules can call, say, import mig.shared.base
+Please refer e.g. to
+https://docs.python.org/3/tutorial/modules.html#packages
+and
+https://www.python.org/dev/peps/pep-0008/#imports
 for details
 """
 
@@ -35,4 +38,3 @@ __dummy = True
 
 # above line is only to make python tidy behave and not
 # move module doc string inside header
-

--- a/mig/src/pylustrequota/pylustrequota/__init__.py
+++ b/mig/src/pylustrequota/pylustrequota/__init__.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # --- BEGIN_HEADER ---
 #
 # __init__ - luste quota python extensions
-# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -19,8 +19,8 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # -- END_HEADER ---
 #

--- a/mig/unittest/__init__.py
+++ b/mig/unittest/__init__.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# __init__ - package init
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# -- END_HEADER ---
+#
+
+"""This file is needed to tell python that this dir is a package
+so that all modules can call, say, import mig.shared.base
+Please refer e.g. to
+https://docs.python.org/3/tutorial/modules.html#packages
+and
+https://www.python.org/dev/peps/pep-0008/#imports
+for details
+"""
+
+__dummy = True
+
+# above line is only to make python tidy behave and not
+# move module doc string inside header

--- a/mig/user/__init__.py
+++ b/mig/user/__init__.py
@@ -3,8 +3,8 @@
 #
 # --- BEGIN_HEADER ---
 #
-# __init__ - package marker
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# __init__ - package init
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -19,15 +19,16 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # -- END_HEADER ---
 #
 
 """This file is needed to tell python that this dir is a package
-so that other modules can call, say, import mig.server.jobscriptgenerator
-Please refer to http://www.network-theory.co.uk/docs/pytut/tut_51.html
+so that all modules can call, say, import mig.shared.base
+Please refer e.g. to
+https://docs.python.org/3/tutorial/modules.html#packages
 and
 https://www.python.org/dev/peps/pep-0008/#imports
 for details

--- a/mig/user/selenium/__init__.py
+++ b/mig/user/selenium/__init__.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # --- BEGIN_HEADER ---
 #
-# __init__ - package marker
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# __init__ - package init
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -19,15 +19,16 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # -- END_HEADER ---
 #
 
 """This file is needed to tell python that this dir is a package
-so that other modules can call, say, import mig.server.jobscriptgenerator
-Please refer to http://www.network-theory.co.uk/docs/pytut/tut_51.html
+so that all modules can call, say, import mig.shared.base
+Please refer e.g. to
+https://docs.python.org/3/tutorial/modules.html#packages
 and
 https://www.python.org/dev/peps/pep-0008/#imports
 for details

--- a/sbin/README
+++ b/sbin/README
@@ -1,14 +1,14 @@
 = Modernization and Clean Up =
-We are cleaning up and moving various scripts and tools into a more logical
-location and will as a start just link to the existing paths in this folder so
-that one can use them as
-/path/to/bin/X
+We are cleaning up and moving various daemons into a more logical location and
+will as a start just link to the existing paths in this folder so that one can
+use them as
+/path/to/sbin/X
 Long term we will likely move them there instead and perhaps only preserve
 symlinks to still support the original paths for a while.
 
-Some scripts and tools may still expect certain relative paths to e.g. the
-MiGserver.conf file but you can always override it with something like: 
-MIG_CONF=/path/to/my/MiGserver.conf /path/to/bin/searchusers.py
+Some daemons may still expect certain relative paths to e.g. the MiGserver.conf
+file but you can always override it with something like: 
+MIG_CONF=/path/to/my/MiGserver.conf /path/to/sbin/grid_janitor
 
 The clean up also means that any code placed here MUST comply with the project
 style guides, be lint clean, documented and have decent unit test coverage.

--- a/sbin/chksidroot.py
+++ b/sbin/chksidroot.py
@@ -1,0 +1,1 @@
+../mig/server/chksidroot.py

--- a/sbin/chkuserroot.py
+++ b/sbin/chkuserroot.py
@@ -1,0 +1,1 @@
+../mig/server/chkuserroot.py

--- a/sbin/grid_cron.py
+++ b/sbin/grid_cron.py
@@ -1,0 +1,1 @@
+../mig/server/grid_cron.py

--- a/sbin/grid_events.py
+++ b/sbin/grid_events.py
@@ -1,0 +1,1 @@
+../mig/server/grid_events.py

--- a/sbin/grid_ftps.py
+++ b/sbin/grid_ftps.py
@@ -1,0 +1,1 @@
+../mig/server/grid_ftps.py

--- a/sbin/grid_imnotify.py
+++ b/sbin/grid_imnotify.py
@@ -1,0 +1,1 @@
+../mig/server/grid_imnotify.py

--- a/sbin/grid_imnotify_stdout.py
+++ b/sbin/grid_imnotify_stdout.py
@@ -1,0 +1,1 @@
+../mig/server/grid_imnotify_stdout.py

--- a/sbin/grid_monitor.py
+++ b/sbin/grid_monitor.py
@@ -1,0 +1,1 @@
+../mig/server/grid_monitor.py

--- a/sbin/grid_notify.py
+++ b/sbin/grid_notify.py
@@ -1,0 +1,1 @@
+../mig/server/grid_notify.py

--- a/sbin/grid_openid.py
+++ b/sbin/grid_openid.py
@@ -1,0 +1,1 @@
+../mig/server/grid_openid.py

--- a/sbin/grid_script.py
+++ b/sbin/grid_script.py
@@ -1,0 +1,1 @@
+../mig/server/grid_script.py

--- a/sbin/grid_sftp.py
+++ b/sbin/grid_sftp.py
@@ -1,0 +1,1 @@
+../mig/server/grid_sftp.py

--- a/sbin/grid_sshmux.py
+++ b/sbin/grid_sshmux.py
@@ -1,0 +1,1 @@
+../mig/server/grid_sshmux.py

--- a/sbin/grid_transfers.py
+++ b/sbin/grid_transfers.py
@@ -1,0 +1,1 @@
+../mig/server/grid_transfers.py

--- a/sbin/grid_vmproxy.py
+++ b/sbin/grid_vmproxy.py
@@ -1,0 +1,1 @@
+../mig/server/grid_vmproxy.py

--- a/sbin/grid_webdavs.py
+++ b/sbin/grid_webdavs.py
@@ -1,0 +1,1 @@
+../mig/server/grid_webdavs.py

--- a/sbin/sftp_subsys.py
+++ b/sbin/sftp_subsys.py
@@ -1,0 +1,1 @@
+../mig/server/sftp_subsys.py


### PR DESCRIPTION
More migration to `mig/lib/` for code, `bin/` for scripts and tools  and `sbin/` for services.

Added symlinks in `bin/` and `sbin/` to most scripts, tools and services pending migration. We want to gradually replace those links by migrating the link source to the new location and cleaning them up in the process as described in the included README files. Same applies for the modules in `mig/shared/` which should gradualy be migrated to `mig/lib/`.

Synced all active `__init__.py` files for consistency and working links.

Tweaked `addheader.py` helper to avoid exceeding our 80-char line length limit.