### PR TITLE
Eliminate deprecated `logger.warn` calls for `logger.warning`

### DIFF
--- a/mig/shared/functionality/mkdir.py
+++ b/mig/shared/functionality/mkdir.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # mkdir - create directory in user home
-# Copyright (C) 2003-2020  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -175,8 +175,8 @@ CSRF-filtered POST requests to prevent unintended updates'''
                 # partial match:
                 # ../*/* is technically allowed to match own files.
 
-                logger.warn('%s tried to %s %s restricted path! (%s)'
-                            % (client_id, op_name, abs_path, pattern))
+                logger.warning('%s tried to %s %s restricted path! (%s)'
+                               % (client_id, op_name, abs_path, pattern))
                 continue
             match.append(abs_path)
 

--- a/mig/shared/functionality/rangefileaccess.py
+++ b/mig/shared/functionality/rangefileaccess.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # rangefileaccess - read or write byte range inside file
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -363,8 +363,8 @@ def main(client_id, user_arguments_dict, environ=None):
                 # partial match:
                 # ../*/* is technically allowed to match own files.
 
-                logger.warn('%s tried to %s %s restricted path! (%s)'
-                            % (client_id, op_name, abs_path, pattern))
+                logger.warning('%s tried to %s %s restricted path! (%s)'
+                               % (client_id, op_name, abs_path, pattern))
                 continue
             match.append(abs_path)
 

--- a/mig/shared/map.py
+++ b/mig/shared/map.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# map.py - Collection of map related functions
+# --- BEGIN_HEADER ---
 #
-# Copyright (C) 2003-2019  The MiG Project lead by Brian Vinter
+# map.py - Collection of map related functions
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -22,6 +23,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 """A shared collection of map helper functions"""
+
 from __future__ import absolute_import
 
 import os
@@ -50,7 +52,7 @@ def load_system_map(configuration, kind, do_lock):
         map_stamp = os.path.getmtime(map_path)
 
     except IOError:
-        configuration.logger.warn("No %s map to load" % kind)
+        configuration.logger.warning("No %s map to load" % kind)
         entity_map = {}
         map_stamp = -1
     if do_lock:

--- a/mig/shared/pwcrypto.py
+++ b/mig/shared/pwcrypto.py
@@ -3,9 +3,8 @@
 #
 # --- BEGIN_HEADER ---
 #
-#
 # pwcrypto - helpers for password and crypto including for encryption and hashing
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -721,8 +720,8 @@ def verify_reset_token(configuration, user_dict, token, auth_type,
     try:
         assure_reset_supported(configuration, user_dict, auth_type)
     except ValueError as vae:
-        _logger.warn("verify %s reset token %s failed: %s" % (auth_type, token,
-                                                              vae))
+        _logger.warning("verify %s reset token %s failed: %s" % (auth_type,
+                                                                 token, vae))
         return False
 
     token_stamp, token_hash = parse_reset_token(configuration, token,

--- a/mig/shared/vgridaccess.py
+++ b/mig/shared/vgridaccess.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # vgridaccess - user access in VGrids
-# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -107,7 +107,7 @@ def load_entity_map(configuration, kind, do_lock, caching):
         _logger.info("after %s map load from %s" % (kind, map_path))
         map_stamp = os.path.getmtime(map_path)
     except IOError:
-        _logger.warn("No %s map to load" % kind)
+        _logger.warning("No %s map to load" % kind)
         entity_map = {}
         map_stamp = -1
     if do_lock:
@@ -1204,8 +1204,8 @@ def fill_placeholder_cache(configuration, cache, vgrid_list):
             continue
         for parent in [os.path.join(*parts[:i]) for i in range(1, len(parts))]:
             cache[parent] = parent
-            #_logger.debug("found parent %r for %r in cache" % (parent, name))
-    #_logger.debug("filled placeholder cache: %s" % cache)
+            # _logger.debug("found parent %r for %r in cache" % (parent, name))
+    # _logger.debug("filled placeholder cache: %s" % cache)
     return cache
 
 
@@ -1413,16 +1413,16 @@ if "__main__" == __name__:
     user_access_stores = user_allowed_res_stores(conf, user_id)
     print("%s can access resources: %s" %
           (user_id, ', '.join(list(user_access_confs))))
-    #(user_id, ', '.join([i for (i, j) in user_access_confs.items() if j]))
+    # (user_id, ', '.join([i for (i, j) in user_access_confs.items() if j]))
     print("%s can access exes: %s" %
           (user_id, ', '.join(list(user_access_exes))))
-    #(user_id, ', '.join([i for (i, j) in user_access_exes.items() if j]))
+    # (user_id, ', '.join([i for (i, j) in user_access_exes.items() if j]))
     print("%s can access stores: %s" %
           (user_id, ', '.join(list(user_access_stores))))
-    #(user_id, ', '.join([i for (i, j) in user_access_stores.items() if j]))
+    # (user_id, ', '.join([i for (i, j) in user_access_stores.items() if j]))
     user_owned_confs = user_owned_res_confs(conf, user_id)
-    #user_owned_exes = user_owned_res_exes(conf, user_id)
-    #user_owned_stores = user_owned_res_stores(conf, user_id)
+    # user_owned_exes = user_owned_res_exes(conf, user_id)
+    # user_owned_stores = user_owned_res_stores(conf, user_id)
     print("%s owns: %s" %
           (user_id, ', '.join(list(user_owned_confs))))
     user_visible_confs = user_visible_res_confs(conf, user_id)

--- a/mig/shared/workflows.py
+++ b/mig/shared/workflows.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# workflows.py - Collection of workflows related functions
+# --- BEGIN_HEADER ---
 #
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# workflows.py - Collection of workflows related functions
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -3396,7 +3397,7 @@ def __create_task_parameter_file(configuration, vgrid, pattern,
     except Exception as err:
         msg = "Failed to create the task parameter " \
               "file: %s, data: %s, err: %s" % (path, parameter_dict, err)
-        _logger.warn(msg)
+        _logger.warning(msg)
         return (False, msg)
 
     return (True, '')
@@ -3610,7 +3611,7 @@ def get_workflow_trigger(configuration, vgrid, rule_id=None, recursive=False):
     if not status:
         msg = "Failed to find triggers in vgrid '%s', err '%s'" % (vgrid,
                                                                    triggers)
-        _logger.warn(msg)
+        _logger.warning(msg)
         return (False, msg)
 
     if rule_id:


### PR DESCRIPTION
Adjust deprecated `logger.warn(MSG)` calls to recommended `logger.warning(MSG)` form. Forcing vgridcache update etc. warns about it now.