### PR TITLE
Arrange the requisite explicit environ in tested functionality files.

### DIFF
--- a/mig/shared/functionality/datatransfer.py
+++ b/mig/shared/functionality/datatransfer.py
@@ -126,6 +126,7 @@ def _main(configuration, logger, environ, op_name='', output_objects=None, clien
         client_id,
         configuration,
         allow_rejects=False,
+        environ=environ,
     )
     if not validate_status:
         # NOTE: 'accepted' is a non-sensitive error string here

--- a/tests/test_mig_shared_functionality_cat.py
+++ b/tests/test_mig_shared_functionality_cat.py
@@ -184,7 +184,7 @@ class MigSharedFunctionalityCat(MigTestCase):
     @unittest.skipIf(PY2, "Python 3 only")
     def test_main_passes_environ(self):
         try:
-            result = realmain(self.TEST_CLIENT_ID, {}, None)
+            result = realmain(self.TEST_CLIENT_ID, {}, self.test_environ)
         except Exception as unexpectedexc:
             raise AssertionError(
                 "saw unexpected exception: %s" % (unexpectedexc,))

--- a/tests/test_mig_shared_functionality_datatransfer.py
+++ b/tests/test_mig_shared_functionality_datatransfer.py
@@ -80,7 +80,7 @@ class MigSharedFunctionalityDataTransfer(MigTestCase):
     def test_default_disabled_site_transfer(self):
         self.assertFalse(self.configuration.site_enable_transfers)
 
-        result = realmain(self.TEST_CLIENT_ID, {})
+        result = realmain(self.TEST_CLIENT_ID, {}, self.test_environ)
         (output_objects, status) = result
         self.assertEqual(status, returnvalues.OK)
 


### PR DESCRIPTION
At some point the couple of tests we have for functionality files started to fail. The way these tests were achieved was a minimal change was made to the mainline code itself to allow passing in a controlled series of arguments, which the test file then uses to exercise the codepaths.

Make sure this works fully across cat and datatransfer, with the following being required:
* in datatransfer, the populated environment was not being passed into the certificate validate method - do so thereby aligning it with cat
* the tests for both cat and datatransfer were not passing the test populated environment in all cases - unclear exactly how that worked previously (sense if that we added or tightened a check somewhere) but get this value passed down