### PR TITLE
Expose the actual `enable_janitor` option in generateconfs.

### DIFF
--- a/mig/install/generateconfs.py
+++ b/mig/install/generateconfs.py
@@ -285,6 +285,7 @@ def main(argv, _generate_confs=generate_confs, _print=print):
         'enable_seafile',
         'enable_duplicati',
         'enable_crontab',
+        'enable_janitor',
         'enable_notify',
         'enable_imnotify',
         'enable_dev_accounts',


### PR DESCRIPTION
which should also allow docker-migrid PR128 to succeed.