### PR TITLE
Rework password checks in account renewal to rely on early_validation_checks

### DIFF
--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -51,7 +51,7 @@ from mig.shared.defaults import peers_fields, peers_filename, \
     gdp_distinguished_field
 from mig.shared.fileio import delete_file, make_temp_file
 from mig.shared.notification import notify_user
-from mig.shared.pwcrypto import check_hash
+from mig.shared.pwcrypto import check_hash, check_scramble
 # Expose some helper variables for functionality backends
 from mig.shared.safeinput import name_extras, password_extras, \
     password_min_len, password_max_len, valid_password_chars, \
@@ -1231,24 +1231,31 @@ to invite you instead if that is easier"""
 
     client_id = get_user_id(configuration, raw_request)
     db_path = default_db_path(configuration)
-    user_dict = load_user_dict(configuration, client_id, db_path)
+    user_dict = load_user_dict(logger, client_id, db_path)
     if user_dict:
-        # Renewal or password change
+        # Renewal or password change - check against existing pw and status
+        scrambled = user_dict.get('password', None)
+        hashed = user_dict.get('password_hash', None)
+        account_status = user_dict.get('status', 'active')
         authorized = raw_request.get('authorized', None)
         reset_token = raw_request.get('reset_token', None)
-        account_status = raw_request.get('status', 'active')
-        if not authorized and not reset_token:
-            hashed = user_dict.get('password_hash', None)
-            if not check_hash(configuration, service, username, password,
-                              hashed):
-                logger.warning('illegal password change in request from %r' %
-                               client_id)
-                raw_request['invalid'].append(illegal_pw_change)
-        elif account_status not in ('temporal', 'active', 'inactive'):
+        if hashed:
+            raw_request['pw_changed'] = check_hash(configuration, service,
+                                                   username, password, hashed)
+        elif scrambled:
+            raw_request['pw_changed'] = check_scramble(
+                configuration, service, username, password, scrambled,
+                salt=configuration.site_password_salt)
+
+        if account_status not in ('temporal', 'active', 'inactive'):
             logger.warning('existing account for %r is %s and not renewable'
                            % (client_id, account_status))
             raw_request['invalid'].append(renewal_blocked)
-        else:
+        if raw_request['pw_changed'] and not authorized and not reset_token:
+            logger.warning('illegal password change in request from %r' %
+                           client_id)
+            raw_request['invalid'].append(illegal_pw_change)
+        if not raw_request.get('invalid', []):
             logger.debug('account renewal from %r looks alright' % client_id)
     elif existing_user_collision(configuration, raw_request, client_id):
         # TODO: drop and rely solely on live check in janitor to avoid races?

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -1240,18 +1240,21 @@ to invite you instead if that is easier"""
         authorized = raw_request.get('authorized', None)
         reset_token = raw_request.get('reset_token', None)
         if hashed:
-            raw_request['pw_changed'] = check_hash(configuration, service,
-                                                   username, password, hashed)
+            raw_request['pw_match'] = check_hash(configuration, service,
+                                                 username, password, hashed)
         elif scrambled:
-            raw_request['pw_changed'] = check_scramble(
+            raw_request['pw_match'] = check_scramble(
                 configuration, service, username, password, scrambled,
                 salt=configuration.site_password_salt)
+        else:
+            logger.debug('account for %r has no passwords set' % client_id)
+            raw_request['pw_match'] = True
 
         if account_status not in ('temporal', 'active', 'inactive'):
             logger.warning('existing account for %r is %s and not renewable'
                            % (client_id, account_status))
             raw_request['invalid'].append(renewal_blocked)
-        if raw_request['pw_changed'] and not authorized and not reset_token:
+        if not raw_request['pw_match'] and not authorized and not reset_token:
             logger.warning('illegal password change in request from %r' %
                            client_id)
             raw_request['invalid'].append(illegal_pw_change)

--- a/mig/shared/useradm.py
+++ b/mig/shared/useradm.py
@@ -1829,6 +1829,9 @@ def get_any_oid_user_dn(configuration, raw_login,
             distinguished_name = lookup_client_id(configuration, user_id)
         elif configuration.site_user_id_format == X509_USER_ID_FORMAT:
             distinguished_name = client_dir_id(native_dir)
+        else:
+            raise ValueError("invalid user ID format requested: %s" %
+                             configuration.site_user_id_format)
         _logger.debug('found full ID %s from %s link'
                       % (distinguished_name, raw_login))
         return distinguished_name

--- a/mig/shared/useradm.py
+++ b/mig/shared/useradm.py
@@ -459,7 +459,7 @@ def verify_user_peers(configuration, db_path, client_id, user, now, verify_peer,
 
 
 def create_user_in_db(configuration, db_path, client_id, user, now, authorized,
-                      reset_token, reset_auth_type, pw_changed,
+                      reset_token, reset_auth_type, pw_match,
                       accepted_peer_list, force, verbose, ask_renew,
                       default_renew, do_lock, from_edit_user, ask_change_pw,
                       auto_create_db, create_backup):
@@ -571,12 +571,12 @@ def create_user_in_db(configuration, db_path, client_id, user, now, authorized,
             # existing password should be left alone on renewal.
             # The password_hash field is not guaranteed to exist and it varies
             # depending on the current random seed and assigned salt. So we use
-            # check_password during submit and save result in pw_changed.
+            # check_password during submit and save result in pw_match.
             if not user['password']:
                 user['password'] = user['old_password']
             if not user.get('password_hash', ''):
                 user['password_hash'] = user['old_password_hash']
-            if pw_changed:
+            if not pw_match:
                 # Allow password change if it's directly authorized with login
                 # or authorized through a simple reset challenge (reset_token).
                 if not authorized and reset_token:
@@ -1062,11 +1062,11 @@ def create_user(user, conf_path, db_path, force=False, verbose=False,
         reset_auth_type = user.get('auth', ['UNKNOWN'])[-1]
         # Always remove any reset_token fields before DB insert
         del user['reset_token']
-    pw_changed = False
-    if 'pw_changed' in user:
-        pw_changed = user['pw_changed']
-        # Always remove any pw_changed fields before DB insert
-        del user['pw_changed']
+    pw_match = True
+    if 'pw_match' in user:
+        pw_match = user['pw_match']
+        # Always remove any pw_match fields before DB insert
+        del user['pw_match']
 
     _logger.info('trying to create or renew user %r' % client_id)
     if verbose:
@@ -1095,7 +1095,7 @@ def create_user(user, conf_path, db_path, force=False, verbose=False,
 
     created = create_user_in_db(configuration, db_path, client_id, user, now,
                                 authorized, reset_token, reset_auth_type,
-                                pw_changed, accepted_peer_list, force, verbose,
+                                pw_match, accepted_peer_list, force, verbose,
                                 ask_renew, default_renew, do_lock,
                                 from_edit_user, ask_change_pw, auto_create_db,
                                 create_backup)

--- a/mig/shared/useradm.py
+++ b/mig/shared/useradm.py
@@ -459,10 +459,10 @@ def verify_user_peers(configuration, db_path, client_id, user, now, verify_peer,
 
 
 def create_user_in_db(configuration, db_path, client_id, user, now, authorized,
-                      reset_token, reset_auth_type, accepted_peer_list, force,
-                      verbose, ask_renew, default_renew, do_lock,
-                      from_edit_user, ask_change_pw, auto_create_db,
-                      create_backup):
+                      reset_token, reset_auth_type, pw_changed,
+                      accepted_peer_list, force, verbose, ask_renew,
+                      default_renew, do_lock, from_edit_user, ask_change_pw,
+                      auto_create_db, create_backup):
     """Handle all the parts of user creation or renewal relating to the user
     datatbase.
     """
@@ -569,14 +569,14 @@ def create_user_in_db(configuration, db_path, client_id, user, now, authorized,
             # password alone.
             # External OpenID users do not provide a password so again any
             # existing password should be left alone on renewal.
-            # The password_hash field is not guaranteed to exist.
+            # The password_hash field is not guaranteed to exist and it varies
+            # depending on the current random seed and assigned salt. So we use
+            # check_password during submit and save result in pw_changed.
             if not user['password']:
                 user['password'] = user['old_password']
             if not user.get('password_hash', ''):
                 user['password_hash'] = user['old_password_hash']
-            password_changed = (user['old_password'] != user['password'] or
-                                user['old_password_hash'] != user['password_hash'])
-            if password_changed:
+            if pw_changed:
                 # Allow password change if it's directly authorized with login
                 # or authorized through a simple reset challenge (reset_token).
                 if not authorized and reset_token:
@@ -1062,6 +1062,11 @@ def create_user(user, conf_path, db_path, force=False, verbose=False,
         reset_auth_type = user.get('auth', ['UNKNOWN'])[-1]
         # Always remove any reset_token fields before DB insert
         del user['reset_token']
+    pw_changed = False
+    if 'pw_changed' in user:
+        pw_changed = user['pw_changed']
+        # Always remove any pw_changed fields before DB insert
+        del user['pw_changed']
 
     _logger.info('trying to create or renew user %r' % client_id)
     if verbose:
@@ -1090,9 +1095,10 @@ def create_user(user, conf_path, db_path, force=False, verbose=False,
 
     created = create_user_in_db(configuration, db_path, client_id, user, now,
                                 authorized, reset_token, reset_auth_type,
-                                accepted_peer_list, force, verbose, ask_renew,
-                                default_renew, do_lock, from_edit_user,
-                                ask_change_pw, auto_create_db, create_backup)
+                                pw_changed, accepted_peer_list, force, verbose,
+                                ask_renew, default_renew, do_lock,
+                                from_edit_user, ask_change_pw, auto_create_db,
+                                create_backup)
     # Mark user updated for all logins
     update_account_expire_cache(configuration, created)
     update_account_status_cache(configuration, created)

--- a/tests/test_mig_shared_accountreq.py
+++ b/tests/test_mig_shared_accountreq.py
@@ -144,31 +144,64 @@ class MigSharedAccountreq__peers(MigTestCase):
         self.assertTrue(success)
 
 
-class MigSharedAccountreq__prefilters(MigTestCase):
-    """Unit tests for prefilter helper functions within the accountreq module"""
+class MigSharedAccountreq__filters(MigTestCase):
+    """Unit tests for filter related functions within the accountreq module"""
 
+    TEST_SERVICE = 'migoid'
+    TEST_INTERNAL_DN = '/C=DK/ST=NA/L=NA/O=Local Org/OU=NA/CN=Test Name/emailAddress=test@local.org'
+    TEST_EXTERNAL_DN = '/C=DK/ST=NA/L=NA/O=External Org/OU=NA/CN=Test User/emailAddress=test@external.org'
+    TEST_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com'
     TEST_ADMIN_DN = '/C=DK/ST=NA/L=NA/O=DIKU/OU=NA/CN=Test Admin/emailAddress=siteadm@di.ku.dk'
 
-    def test_signup_prefilter_email_accept(self):
-        accept = ['john@doe.org', 'a@b.c.org', 'a@ku.dk.com',
-                  'a@sci.ku.dk.org', 'a@diku.dk', 'a@nbi.dk']
+    TEST_INT_PW = 'PW74deb6609F109f504d'
+    TEST_EXT_PW = 'PW174db6509F109e1531'
+    TEST_USER_PW = 'foobar'
+    TEST_INT_PW_HASH = 'PBKDF2$sha256$10000$MDAwMDAwMDAwMDAw$epib2rEg/HYTQZFnCp7hmIGZ6rzHnViy'
+    TEST_EXT_PW_HASH = 'PBKDF2$sha256$10000$MDAwMDAwMDAwMDAw$TQZFnCp7hmIGZ6ep2rEg/HYrzHnVyiib'
+    TEST_USER_PW_HASH = 'PBKDF2$sha256$10000$/TkhLk4yMGf6XhaY$7HUeQ9iwCkE4YMQAaCd+ZdrN+y8EzkJH'
+
+    TEST_INTERNAL_EMAILS = ['john.doe@science.ku.dk', 'abc123@ku.dk',
+                            'john.doe@a.b.c.ku.dk']
+    TEST_EXTERNAL_EMAILS = ['john@doe.org', 'a@b.c.org', 'a@ku.dk.com',
+                            'a@sci.ku.dk.org', 'a@diku.dk', 'a@nbi.dk']
+    TEST_EXTERNAL_EMAIL_PATTERN = r'^.+(?<!(@|\.)ku\.dk)$'
+    TEST_INTERNAL_EMAIL_PATTERN = r'^.+@([a-z0-9]+\.)*ku\.dk$'
+    INT_USER, EXT_USER, TEST_USER = {}, {}, {}
+
+    def _provide_configuration(self):
+        return 'testconfig'
+
+    def before_each(self):
+        ensure_dirs_exist(self.configuration.user_cache)
+        ensure_dirs_exist(self.configuration.user_pending)
+        ensure_dirs_exist(self.configuration.user_settings)
+        ensure_dirs_exist(self.configuration.mrsl_files_dir)
+        ensure_dirs_exist(self.configuration.resource_pending)
+        self.INT_USER = distinguished_name_to_user(self.TEST_INTERNAL_DN)
+        self.INT_USER['password_hash'] = self.TEST_INT_PW_HASH
+        self.EXT_USER = distinguished_name_to_user(self.TEST_EXTERNAL_DN)
+        self.EXT_USER['peers_email'] = self.INT_USER['email']
+        self.EXT_USER['peers_full_name'] = self.INT_USER['full_name']
+        self.EXT_USER['password_hash'] = self.TEST_EXT_PW_HASH
+        self.TEST_USER = distinguished_name_to_user(self.TEST_USER_DN)
+        self.EXT_USER['password_hash'] = self.TEST_USER_PW_HASH
         self.configuration.site_signup_prefilter = [
-            ('email', r'^.+(?<!(@|\.)ku\.dk)$')]
-        for addr in accept:
-            user = {'email': addr}
+            ('email', self.TEST_EXTERNAL_EMAIL_PATTERN), ]
+        self.configuration.site_peers_prefilter = [
+            ('peers_email', self.TEST_INTERNAL_EMAIL_PATTERN), ]
+
+    def test_signup_prefilter_email_accept(self):
+        for addr in self.TEST_EXTERNAL_EMAILS:
+            self.EXT_USER['email'] = addr
             check = accountreq.signup_prefilter_allowed(self.configuration,
-                                                        user)
+                                                        self.EXT_USER)
             self.assertTrue(check)
 
     def test_signup_prefilter_email_reject(self):
-        reject = ['john.doe@science.ku.dk', 'abc123@ku.dk',
-                  'john.doe@a.b.c.ku.dk']
-        self.configuration.site_signup_prefilter = [
-            ('email', r'.+(?<!(@|\.)ku\.dk)$')]
-        for addr in reject:
-            user = {'email': addr}
+        for addr in self.TEST_INTERNAL_EMAILS:
+            self.EXT_USER['email'] = addr
             check = accountreq.signup_prefilter_allowed(self.configuration,
-                                                        user)
+                                                        self.EXT_USER)
             self.assertFalse(check)
 
     def test_signup_prefilter_email_accept_site_admins(self):
@@ -183,115 +216,136 @@ class MigSharedAccountreq__prefilters(MigTestCase):
         self.assertTrue(check)
 
     def test_peers_prefilter_email_accept(self):
-        accept = ['john.doe@science.ku.dk', 'abc123@ku.dk',
-                  'john.doe@a.b.c.ku.dk']
-        self.configuration.site_peers_prefilter = [
-            ('peers_email', r'^.+@([a-z0-9]+\.)*ku\.dk$')]
-        for addr in accept:
-            user = {'peers_email': addr}
+        for addr in self.TEST_INTERNAL_EMAILS:
+            self.EXT_USER['peers_email'] = addr
             check = accountreq.peers_prefilter_allowed(self.configuration,
-                                                       user)
+                                                       self.EXT_USER)
             self.assertTrue(check)
 
     def test_peers_prefilter_email_reject(self):
-        reject = ['john@doe.org', 'a@b.c.org', 'a@ku.dk.com',
-                  'a@sci.ku.dk.org']
-        self.configuration.site_peers_prefilter = [
-            ('peers_email', r'^.+@([a-z0-9]+\.)*ku\.dk$')]
-        for addr in reject:
-            user = {'peers_email': addr}
+        for addr in self.TEST_EXTERNAL_EMAILS:
+            self.EXT_USER['peers_email'] = addr
             check = accountreq.peers_prefilter_allowed(self.configuration,
-                                                       user)
+                                                       self.EXT_USER)
             self.assertFalse(check)
 
     def test_early_validation_checks_valid_new_simple(self):
-        service = 'migoid'
-        full_name = 'Valid Test Name'
-        email = 'john@doe.org'
-        dummy_pw = 'PW74deb6609F109f504d'
-        dummy_pw_hash = 'DUMMYPWHASH'
-        user = {'full_name': full_name, 'organization': 'Test Org',
-                'organizational_unit': '', 'email': email,
-                'password_hash': dummy_pw_hash, 'comment': ''}
-        fill_distinguished_name(user)
-        checked = accountreq.early_validation_checks(self.configuration, user,
-                                                     service, email, dummy_pw)
-        print("DEBUG: early checks on valid simple req: %s" % checked)
+        checked = accountreq.early_validation_checks(self.configuration,
+                                                     self.EXT_USER,
+                                                     self.TEST_SERVICE,
+                                                     self.EXT_USER['email'],
+                                                     self.TEST_EXT_PW)
+        # print("DEBUG: early checks on valid simple req: %s" % checked)
         self.assertEqual(checked['invalid'], [], "early validation failed")
 
     def test_early_validation_checks_valid_new_peers(self):
         self.configuration.site_enable_peers = True
         self.configuration.site_peers_explicit_fields = ['full_name', 'email']
-        self.configuration.site_peers_prefilter = [
-            ('peers_email', r'^.+@([a-z0-9]+\.)*ku\.dk$')]
-        service = 'migoid'
-        full_name = 'Valid Test Name'
-        email = 'john@doe.org'
-        peers_full_name = 'Valid Peer Name'
-        dummy_pw = 'PW74deb6609F109f504d'
-        dummy_pw_hash = 'DUMMYPWHASH'
-        accept = ['john.doe@science.ku.dk', 'abc123@ku.dk',
-                  'john.doe@a.b.c.ku.dk']
-        self.configuration.site_peers_prefilter = [
-            ('peers_email', r'^.+@([a-z0-9]+\.)*ku\.dk$')]
-        user = {'full_name': full_name, 'organization': 'Test Org',
-                'organizational_unit': '', 'email': email,
-                'password_hash': dummy_pw_hash, 'comment': '',
-                'peers_full_name': [peers_full_name], 'peers_email': []}
-        fill_distinguished_name(user)
-        for addr in accept:
-            user['peers_email'] = [addr]
-            username = user['email']
+        for addr in self.TEST_INTERNAL_EMAILS:
+            self.EXT_USER['peers_email'] = addr
             checked = accountreq.early_validation_checks(self.configuration,
-                                                         user, service,
-                                                         username, dummy_pw)
-            print("DEBUG: early checks on valid peers req: %s" % checked)
+                                                         self.EXT_USER,
+                                                         self.TEST_SERVICE,
+                                                         self.EXT_USER['email'],
+                                                         self.TEST_EXT_PW)
+            # print("DEBUG: early checks on valid peers req: %s" % checked)
             self.assertEqual(checked['invalid'], [], "early validation failed")
 
-    # TODO: add test valid renew
+    def test_early_validation_checks_valid_renew_existing(self):
+        test_int_client_dir = self._provision_test_user(self,
+                                                        self.TEST_INTERNAL_DN)
+        test_int_client_dir_name = os.path.basename(test_int_client_dir)
+        test_client_dir = self._provision_test_user(self, self.TEST_USER_DN)
+        test_client_dir_name = os.path.basename(test_client_dir)
+        self.TEST_USER['peers_email'] = self.INT_USER['email']
+        # TODO: sync password with saved hash and disable auth here
+        self.TEST_USER['authorized'] = True
+        checked = accountreq.early_validation_checks(self.configuration,
+                                                     self.TEST_USER,
+                                                     self.TEST_SERVICE,
+                                                     self.TEST_USER['email'],
+                                                     self.TEST_USER_PW)
+        # print("DEBUG: early checks on valid renew req: %s" % checked)
+        self.assertEqual(checked['invalid'], [], "early validation failed")
+
+    def test_early_validation_checks_valid_renew_authorized(self):
+        test_int_client_dir = self._provision_test_user(self,
+                                                        self.TEST_INTERNAL_DN)
+        test_int_client_dir_name = os.path.basename(test_int_client_dir)
+        test_client_dir = self._provision_test_user(self, self.TEST_USER_DN)
+        test_client_dir_name = os.path.basename(test_client_dir)
+        self.TEST_USER['peers_email'] = self.INT_USER['email']
+        # Make sure password change is allowed if needed
+        self.TEST_USER['authorized'] = True
+        checked = accountreq.early_validation_checks(self.configuration,
+                                                     self.TEST_USER,
+                                                     self.TEST_SERVICE,
+                                                     self.TEST_USER['email'],
+                                                     self.TEST_USER_PW)
+        # print("DEBUG: early checks on valid renew req: %s" % checked)
+        self.assertEqual(checked['invalid'], [], "early validation failed")
 
     def test_early_validation_checks_invalid_new_simple(self):
-        service = 'migoid'
-        full_name = 'InvalidTestName'
-        email = 'john@doe.org'
-        dummy_pw = 'PW74deb6609F109f504d'
-        dummy_pw_hash = 'DUMMYPWHASH'
-        user = {'full_name': full_name, 'organization': 'Test Org',
-                'organizational_unit': '', 'email': email,
-                'password_hash': dummy_pw_hash, 'comment': ''}
-        fill_distinguished_name(user)
-        checked = accountreq.early_validation_checks(self.configuration, user,
-                                                     service, email, dummy_pw)
-        print("DEBUG: early checks on invalid simple req: %s" % checked)
+        self.EXT_USER['full_name'] = 'InvalidNameWithoutSpace'
+        checked = accountreq.early_validation_checks(self.configuration,
+                                                     self.EXT_USER,
+                                                     self.TEST_SERVICE,
+                                                     self.EXT_USER['email'],
+                                                     self.TEST_INT_PW)
+        # print("DEBUG: early checks on invalid simple req: %s" % checked)
         self.assertTrue(checked['invalid'], "early validation failed")
 
     def test_early_validation_checks_invalid_new_peers(self):
         self.configuration.site_enable_peers = True
-        self.configuration.site_peers_explicit_fields = ['email']
-        self.configuration.site_peers_prefilter = [
-            ('peers_email', r'^.+@([a-z0-9]+\.)*ku\.dk$')]
-        service = 'migoid'
-        full_name = 'Valid Test Name'
-        email = 'john@doe.org'
-        peers_full_name = 'Valid Peer Name'
-        dummy_pw = 'PW74deb6609F109f504d'
-        dummy_pw_hash = 'DUMMYPWHASH'
-        user = {'full_name': full_name, 'organization': 'Test Org',
-                'organizational_unit': '', 'email': email,
-                'password_hash': dummy_pw_hash, 'comment': '',
-                'peers_full_name': [peers_full_name], 'peers_email': []}
-        fill_distinguished_name(user)
-        reject = ['', 'john@doe.org', 'a@b.c.org', 'a@ku.dk.com',
-                  'a@sci.ku.dk.org']
-        for addr in reject:
-            user['peers_email'] = addr
-            username = user['email']
-            checked = accountreq.early_validation_checks(self.configuration, user,
-                                                         service, email, dummy_pw)
-            print("DEBUG: early checks on invalid peers req: %s" % checked)
-            self.assertTrue(checked['invalid'], "early validation failed")
+        self.configuration.site_peers_explicit_fields = ['full_name', 'email']
+        self.EXT_USER['peers_full_name'] = self.INT_USER['full_name']
+        self.EXT_USER['peers_email'] = ''
+        checked = accountreq.early_validation_checks(self.configuration,
+                                                     self.EXT_USER,
+                                                     self.TEST_SERVICE,
+                                                     self.EXT_USER['email'],
+                                                     self.TEST_EXT_PW)
+        # print("DEBUG: early checks on invalid peers req: %s" % checked)
+        self.assertTrue(checked['invalid'], "early validation failed")
 
-    # TODO: add test invalid renew
+    def test_early_validation_checks_invalid_renew_collision(self):
+        test_client_dir = self._provision_test_user(self,
+                                                    self.TEST_USER_DN)
+        test_client_dir_name = os.path.basename(test_client_dir)
+        self.TEST_USER['organization'] = 'Invalid Changed Org'
+        del self.TEST_USER['distinguished_name']
+        self.TEST_USER = fill_distinguished_name(self.TEST_USER)
+        checked = accountreq.early_validation_checks(self.configuration,
+                                                     self.TEST_USER,
+                                                     self.TEST_SERVICE,
+                                                     self.TEST_USER['email'],
+                                                     self.TEST_USER_PW)
+        # print("DEBUG: early checks on invalid renew collision req: %s" % checked)
+        self.assertTrue(checked['invalid'], "early validation failed")
+
+    def test_early_validation_checks_invalid_renew_pw_change(self):
+        test_client_dir = self._provision_test_user(self, self.TEST_USER_DN)
+        test_client_dir_name = os.path.basename(test_client_dir)
+        checked = accountreq.early_validation_checks(self.configuration,
+                                                     self.TEST_USER,
+                                                     self.TEST_SERVICE,
+                                                     self.TEST_USER['email'],
+                                                     self.TEST_USER_PW + 'N3w')
+        # print("DEBUG: early checks on invalid renew pw change req: %s" % checked)
+        self.assertTrue(checked['invalid'], "early validation failed")
+
+    def test_early_validation_checks_invalid_renew_suspended(self):
+        test_client_dir = self._provision_test_user(self, self.TEST_USER_DN)
+        test_client_dir_name = os.path.basename(test_client_dir)
+        # TODO: change existing user status to suspended! (currently fails on pw)
+        self.TEST_USER['status'] = 'temporal'
+        checked = accountreq.early_validation_checks(self.configuration,
+                                                     self.TEST_USER,
+                                                     self.TEST_SERVICE,
+                                                     self.TEST_USER['email'],
+                                                     self.TEST_USER_PW)
+        # print("DEBUG: early checks on invalid renew suspended req: %s" % checked)
+        self.assertTrue(checked['invalid'], "early validation failed")
 
 
 if __name__ == '__main__':

--- a/tests/test_mig_shared_accountreq.py
+++ b/tests/test_mig_shared_accountreq.py
@@ -204,6 +204,95 @@ class MigSharedAccountreq__prefilters(MigTestCase):
                                                        user)
             self.assertFalse(check)
 
+    def test_early_validation_checks_valid_new_simple(self):
+        service = 'migoid'
+        full_name = 'Valid Test Name'
+        email = 'john@doe.org'
+        dummy_pw = 'PW74deb6609F109f504d'
+        dummy_pw_hash = 'DUMMYPWHASH'
+        user = {'full_name': full_name, 'organization': 'Test Org',
+                'organizational_unit': '', 'email': email,
+                'password_hash': dummy_pw_hash, 'comment': ''}
+        fill_distinguished_name(user)
+        checked = accountreq.early_validation_checks(self.configuration, user,
+                                                     service, email, dummy_pw)
+        print("DEBUG: early checks on valid simple req: %s" % checked)
+        self.assertEqual(checked['invalid'], [], "early validation failed")
+
+    def test_early_validation_checks_valid_new_peers(self):
+        self.configuration.site_enable_peers = True
+        self.configuration.site_peers_explicit_fields = ['full_name', 'email']
+        self.configuration.site_peers_prefilter = [
+            ('peers_email', r'^.+@([a-z0-9]+\.)*ku\.dk$')]
+        service = 'migoid'
+        full_name = 'Valid Test Name'
+        email = 'john@doe.org'
+        peers_full_name = 'Valid Peer Name'
+        dummy_pw = 'PW74deb6609F109f504d'
+        dummy_pw_hash = 'DUMMYPWHASH'
+        accept = ['john.doe@science.ku.dk', 'abc123@ku.dk',
+                  'john.doe@a.b.c.ku.dk']
+        self.configuration.site_peers_prefilter = [
+            ('peers_email', r'^.+@([a-z0-9]+\.)*ku\.dk$')]
+        user = {'full_name': full_name, 'organization': 'Test Org',
+                'organizational_unit': '', 'email': email,
+                'password_hash': dummy_pw_hash, 'comment': '',
+                'peers_full_name': [peers_full_name], 'peers_email': []}
+        fill_distinguished_name(user)
+        for addr in accept:
+            user['peers_email'] = [addr]
+            username = user['email']
+            checked = accountreq.early_validation_checks(self.configuration,
+                                                         user, service,
+                                                         username, dummy_pw)
+            print("DEBUG: early checks on valid peers req: %s" % checked)
+            self.assertEqual(checked['invalid'], [], "early validation failed")
+
+    # TODO: add test valid renew
+
+    def test_early_validation_checks_invalid_new_simple(self):
+        service = 'migoid'
+        full_name = 'InvalidTestName'
+        email = 'john@doe.org'
+        dummy_pw = 'PW74deb6609F109f504d'
+        dummy_pw_hash = 'DUMMYPWHASH'
+        user = {'full_name': full_name, 'organization': 'Test Org',
+                'organizational_unit': '', 'email': email,
+                'password_hash': dummy_pw_hash, 'comment': ''}
+        fill_distinguished_name(user)
+        checked = accountreq.early_validation_checks(self.configuration, user,
+                                                     service, email, dummy_pw)
+        print("DEBUG: early checks on invalid simple req: %s" % checked)
+        self.assertTrue(checked['invalid'], "early validation failed")
+
+    def test_early_validation_checks_invalid_new_peers(self):
+        self.configuration.site_enable_peers = True
+        self.configuration.site_peers_explicit_fields = ['email']
+        self.configuration.site_peers_prefilter = [
+            ('peers_email', r'^.+@([a-z0-9]+\.)*ku\.dk$')]
+        service = 'migoid'
+        full_name = 'Valid Test Name'
+        email = 'john@doe.org'
+        peers_full_name = 'Valid Peer Name'
+        dummy_pw = 'PW74deb6609F109f504d'
+        dummy_pw_hash = 'DUMMYPWHASH'
+        user = {'full_name': full_name, 'organization': 'Test Org',
+                'organizational_unit': '', 'email': email,
+                'password_hash': dummy_pw_hash, 'comment': '',
+                'peers_full_name': [peers_full_name], 'peers_email': []}
+        fill_distinguished_name(user)
+        reject = ['', 'john@doe.org', 'a@b.c.org', 'a@ku.dk.com',
+                  'a@sci.ku.dk.org']
+        for addr in reject:
+            user['peers_email'] = addr
+            username = user['email']
+            checked = accountreq.early_validation_checks(self.configuration, user,
+                                                         service, email, dummy_pw)
+            print("DEBUG: early checks on invalid peers req: %s" % checked)
+            self.assertTrue(checked['invalid'], "early validation failed")
+
+    # TODO: add test invalid renew
+
 
 if __name__ == '__main__':
     testmain()


### PR DESCRIPTION
Rework password checks in account renewal to rely on `check_hash` / `check_scramble` calls in the recently introduced `early_validation_checks` during account request submission where original password is still available.

Fix a use of `load_account_dict` using configuration where logger is expected.

Add unit tests to cover a number of `early_validation_checks` cases. 
NOTE: there are still a few tests pending improvements marked with TODO e.g. to better test account access renewal with legal and illegal password change. Tagged the PR with _follow-up_ as we want the fix to land ASAP and the included unit tests are _sufficient_ along with practical deployment tests.