### PR TITLE
Avoid accessing the configuration on import in the arcwrapper code.

### DIFF
--- a/mig/shared/arcwrapper.py
+++ b/mig/shared/arcwrapper.py
@@ -51,31 +51,49 @@ from mig.shared.safeeval import subprocess_popen, subprocess_pipe
 
 # MiG utilities:
 from mig.shared.conf import get_configuration_object
-config = get_configuration_object()
-logger = config.logger
-
-# Avoid massive log spam when unconditionally importing arcwrapper in other
-# modules like jobstatus and jobscriptgenerator
-if not config.arc_clusters:
-    raise Exception('ignoring arcwrapper import without ARC enabled!')
 
 # to make this succeed:
 # install nordugrid-arc-client and nordugrid-arc-python
 # set LD_LIBRARY_PATH="$NORDUGRID_LOCATION/lib:$GLOBUS_LOCATION/lib
 #     PYTHONPATH="$NORDUGRID_LOCATION/lib/python2.4/site-packages"
+
+_acrlib_import_error = None
+
 try:
     import arclib
 except:
-    logger.error('problems importing arclib... trying workaround')
+    _acrlib_import_error = 'problems importing arclib... trying workaround'
+
     try:
-        logger.debug('Current sys.path is %s' % sys.path)
         sys.path.append(os.environ['NORDUGRID_LOCATION']
                         + '/lib/python2.4/site-packages')
         import arclib
     except:
-        raise Exception('arclib not found - no problem unless using ARC')
+        _acrlib_import_error = 'unable to import a working arclib'
 
 # (trivially inheriting) exception class of our own
+
+
+if _acrlib_import_error:
+    # the code statically relies on definitions in the library which, if it
+    # was not loaded, will not exist. Make this code importable in the absence
+    # of the library by siply defining wrappers and attempt to construct the
+    # Ui object that we use error instead.
+
+    from types import SimpleNamespace
+
+    class Certificate(SimpleNamespace):
+        pass
+
+    class ARCLibError(RuntimeError):
+        def what(self):
+            return self.__str__()
+
+    arclib = SimpleNamespace(
+        ARCLibError=ARCLibError,
+        Certificate=Certificate,
+        URL=lambda _: None,
+    )
 
 
 class ARCWrapperError(arclib.ARCLibError):
@@ -259,8 +277,14 @@ class Ui(object):
     # hard-wired: expected proxy name
     proxy_name = '.proxy.pem'
 
-    def __init__(self, userdir, require_user_proxy=False):
+    def __init__(self, configuration, userdir, require_user_proxy=False):
         """Class constructor"""
+
+        if _acrlib_import_error:
+            raise ARCWrapperError(_acrlib_import_error)
+
+        if not config.arc_clusters:
+            raise ARCWrapperError('ignoring arcwrapper import without ARC enabled!')
 
         # would be nice to hold the Ui instance and have the resources
         # set up on instantiation. but several problems arise:

--- a/mig/shared/functionality/arcresources.py
+++ b/mig/shared/functionality/arcresources.py
@@ -221,7 +221,7 @@ Please contact the %s site support (%s) if you think it should be enabled.
                                'No ARC support!'})
         return (output_objects, returnvalues.ERROR)
     try:
-        session = arcwrapper.Ui(user_dir)
+        session = arcwrapper.Ui(configration, user_dir)
         queues = session.getQueues()
 
     except arcwrapper.NoProxyError as err:

--- a/mig/shared/functionality/autocreate.py
+++ b/mig/shared/functionality/autocreate.py
@@ -202,7 +202,7 @@ def handle_proxy(proxy_string, client_id, config):
     # provide information about the uploaded proxy
 
     try:
-        session_ui = arcwrapper.Ui(proxy_dir)
+        session_ui = arcwrapper.Ui(configuration, proxy_dir)
         proxy = session_ui.getProxy()
         if proxy.IsExpired():
 

--- a/mig/shared/functionality/jobstatus.py
+++ b/mig/shared/functionality/jobstatus.py
@@ -261,7 +261,7 @@ contact the site admins.''' % configuration.short_title})
                 and job_dict['STATUS'] == 'EXECUTING':
             try:
                 home = os.path.join(configuration.user_home, client_dir)
-                arcsession = arcwrapper.Ui(home)
+                arcsession = arcwrapper.Ui(configuration, home)
                 arcstatus = arcsession.jobStatus(job_dict['EXE'])
                 job_obj['status'] = arcstatus['status']
             except arcwrapper.ARCWrapperError as err:

--- a/mig/shared/functionality/settings.py
+++ b/mig/shared/functionality/settings.py
@@ -2227,7 +2227,7 @@ value="%(default_authpassword)s" />
         # provide information about the available proxy, offer upload
         try:
             home_dir = os.path.normpath(base_dir)
-            session_Ui = arcwrapper.Ui(home_dir, require_user_proxy=True)
+            session_Ui = arcwrapper.Ui(configuration, home_dir, require_user_proxy=True)
             proxy = session_Ui.getProxy()
             if proxy.IsExpired():
                 # can rarely happen, constructor will throw exception
@@ -2247,6 +2247,9 @@ value="%(default_authpassword)s" />
             output_objects.append({'object_type': 'warning',
                                    'text': 'No proxy certificate to load: %s'
                                    % err.what()})
+        except arcwrapper.ARCWrapperError as err:
+            output_objects.append({'object_type': 'error_text',
+                        'text': err.what()})
 
         output_objects = output_objects + arcwrapper.askProxy()
 

--- a/mig/shared/gridscript.py
+++ b/mig/shared/gridscript.py
@@ -598,7 +598,7 @@ def clean_arc_job(
     # clean up in ARC
     try:
         userdir = os.path.join(configuration.user_home, client_dir)
-        arcsession = arcwrapper.Ui(userdir)
+        arcsession = arcwrapper.Ui(configuration, userdir)
     except Exception as err:
         logger.error('Error cleaning up ARC job: %s' % err)
         logger.debug('Job was: %s' % job_dict)

--- a/mig/shared/mrslparser.py
+++ b/mig/shared/mrslparser.py
@@ -307,7 +307,7 @@ environment '%s', therefore the job can not be run on any resources.""" %
         logger.debug('Received job for ARC.')
         user_home = os.path.join(configuration.user_home, client_dir)
         try:
-            session = arcwrapper.Ui(user_home)
+            session = arcwrapper.Ui(configuration, user_home)
             timeleft = session.getProxy().getTimeleft()
             req_time = int(global_dict.get('CPUTIME', '0'))
             logger.debug('CPU time (%s), proxy lifetime (%s)'


### PR DESCRIPTION
This code is written to load a configuration object at its outer most level, meaning that any import causes trying to load a configuration which could well not exist. Worse, there are some places that unconditionally import this. As things stand there would be no way to test this and no way to pass a particular configuration to it.

Looking into this, all the uses of this code start by attempting to instantiate a class exposed by this code. This lead to the following idea: allow import to succeed but unilaterally error when trying to instantiate the object this relies on. All paths doing so already have error handling. This commit does that, leading to a rather minimal change which makes the configuration an argument to the constructor.