### PR TITLE
migerrors cronjob: Only check logfiles for enabled services

### DIFF
--- a/mig/install/migerrors-template.sh.cronjob
+++ b/mig/install/migerrors-template.sh.cronjob
@@ -25,17 +25,23 @@ TODAY=$(date +'%Y-%m-%d')
 YESTERDAY=$(date --date=yesterday +%'Y-%m-%d')
 # Number of lines to allow from each log 
 MAXLINES=1000
+# Which services are enabled ?
+ENABLE_FTPS="__ENABLE_FTPS__"
+ENABLE_SFTP="__ENABLE_SFTP__"
+ENABLE_SFTP_SUBSYS="__ENABLE_SFTP_SUBSYS__"
+ENABLE_DAVS="__ENABLE_DAVS__"
 {
-grep -H "Internal Server Error" $LOGDIR/webdavs.out | tail -n $MAXLINES
-grep -H -A 12 "Traceback" $LOGDIR/webdavs.out | tail -n $MAXLINES
+[ "$ENABLE_DAVS" == "True" ] && grep -H "Internal Server Error" $LOGDIR/webdavs.out | tail -n $MAXLINES
+[ "$ENABLE_DAVS" == "True" ] && grep -H -A 12 "Traceback" $LOGDIR/webdavs.out | tail -n $MAXLINES
 
-grep -H " ERROR " $LOGDIR/ftps.log | \
+[ "$ENABLE_FTPS" == "True" ] && grep -H " ERROR " $LOGDIR/ftps.log | \
         grep -E -v "ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|: Invalid path characters" | tail -n $MAXLINES
 
-grep -H " ERROR " $LOGDIR/sftp*.log | \
+[[ "$ENABLE_SFTP" == "True" || "$ENABLE_SFTP_SUBSYS" == True ]]  \
+        && grep -H " ERROR " $LOGDIR/sftp*.log | \
 	grep -E -v "Password authentication failed for|Socket exception: Connection reset by peer|Error reading SSH protocol banner|check_banner|list_folder on missing path|chmod (292|365) rejected on path|symlink rejected on path|ERROR mkdir .* failed: \[Errno 17\] File exists|ERROR rmdir .* failed: \[Errno 39\] Directory not empty|ERROR open .* failed: \[Errno 21\] Is a directory|ERROR open for modify on read-only path|ERROR open existing file on missing path |ERROR Exception.*: Incompatible ssh|ERROR Exception.*: Incompatible version |Exception.*: Invalid SSH banner|ERROR Exception.*: no moduli available|ERROR Exception.*: Expecting packet from \(20,\), got 0|ERROR Socket exception: Connection timed out|ERROR Exception.*: Key-exchange timed out|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|ERROR Exception.*: Client kex .* is out of range|ERROR Exception.*: Expecting packet from .*|get_fs_path failed: Invalid path characters|ERROR $" | tail -n $MAXLINES
 
-grep -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES
+[ "$ENABLE_DAVS" == "True" ] && grep -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES
 
 grep -H " ERROR " $LOGDIR/chkchroot.log | grep -E -v " from ${SECSCANIP} "| \
         grep -E -v "__CRACK_WEB_REGEX__" | \

--- a/tests/fixture/confs-stdlocal/migerrors
+++ b/tests/fixture/confs-stdlocal/migerrors
@@ -25,17 +25,22 @@ TODAY=$(date +'%Y-%m-%d')
 YESTERDAY=$(date --date=yesterday +%'Y-%m-%d')
 # Number of lines to allow from each log 
 MAXLINES=1000
+ENABLE_FTPS="True"
+ENABLE_SFTP="True"
+ENABLE_SFTP_SUBSYS="True"
+ENABLE_DAVS="True"
 {
-grep -H "Internal Server Error" $LOGDIR/webdavs.out | tail -n $MAXLINES
-grep -H -A 12 "Traceback" $LOGDIR/webdavs.out | tail -n $MAXLINES
+[ "$ENABLE_DAVS" == "True" ] && grep -H "Internal Server Error" $LOGDIR/webdavs.out | tail -n $MAXLINES
+[ "$ENABLE_DAVS" == "True" ] && grep -H -A 12 "Traceback" $LOGDIR/webdavs.out | tail -n $MAXLINES
 
-grep -H " ERROR " $LOGDIR/ftps.log | \
+[ "$ENABLE_FTPS" == "True" ] && grep -H " ERROR " $LOGDIR/ftps.log | \
         grep -E -v "ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|: Invalid path characters" | tail -n $MAXLINES
 
-grep -H " ERROR " $LOGDIR/sftp*.log | \
+[[ "$ENABLE_SFTP" == "True" || "$ENABLE_SFTP_SUBSYS" == True ]] \ 
+    && grep -H " ERROR " $LOGDIR/sftp*.log | \
 	grep -E -v "Password authentication failed for|Socket exception: Connection reset by peer|Error reading SSH protocol banner|check_banner|list_folder on missing path|chmod (292|365) rejected on path|symlink rejected on path|ERROR mkdir .* failed: \[Errno 17\] File exists|ERROR rmdir .* failed: \[Errno 39\] Directory not empty|ERROR open .* failed: \[Errno 21\] Is a directory|ERROR open for modify on read-only path|ERROR open existing file on missing path |ERROR Exception.*: Incompatible ssh|ERROR Exception.*: Incompatible version |Exception.*: Invalid SSH banner|ERROR Exception.*: no moduli available|ERROR Exception.*: Expecting packet from \(20,\), got 0|ERROR Socket exception: Connection timed out|ERROR Exception.*: Key-exchange timed out|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|ERROR Exception.*: Client kex .* is out of range|ERROR Exception.*: Expecting packet from .*|get_fs_path failed: Invalid path characters|ERROR $" | tail -n $MAXLINES
 
-grep -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES
+[ "$ENABLE_DAVS" == "True" ] && grep -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES
 
 grep -H " ERROR " $LOGDIR/chkchroot.log | grep -E -v " from ${SECSCANIP} "| \
         grep -E -v "((HNAP1|GponForm|provisioning|provision|prov|polycom|yealink|CertProv|phpmyadmin|admin|cfg|wp|wordpress|cms|blog|old|new|test|dev|tmp|temp|remote|mgmt|properties|authenticate|tmui|ddem|a2billing|vtigercrm|secure|rpc|recordings|dana-na)(/.*|)|.*(Login|login|logon|configuration|header|admin|index)\.(php|jsp|asp)|(api/v1/pods|Telerik.Web.UI.WebResource.axd))" | \

--- a/tests/fixture/confs-stdlocal/migerrors
+++ b/tests/fixture/confs-stdlocal/migerrors
@@ -25,10 +25,11 @@ TODAY=$(date +'%Y-%m-%d')
 YESTERDAY=$(date --date=yesterday +%'Y-%m-%d')
 # Number of lines to allow from each log 
 MAXLINES=1000
-ENABLE_FTPS="True"
-ENABLE_SFTP="True"
-ENABLE_SFTP_SUBSYS="True"
-ENABLE_DAVS="True"
+# Which services are enabled ?
+ENABLE_FTPS="False"
+ENABLE_SFTP="False"
+ENABLE_SFTP_SUBSYS="False"
+ENABLE_DAVS="False"
 {
 [ "$ENABLE_DAVS" == "True" ] && grep -H "Internal Server Error" $LOGDIR/webdavs.out | tail -n $MAXLINES
 [ "$ENABLE_DAVS" == "True" ] && grep -H -A 12 "Traceback" $LOGDIR/webdavs.out | tail -n $MAXLINES
@@ -36,8 +37,8 @@ ENABLE_DAVS="True"
 [ "$ENABLE_FTPS" == "True" ] && grep -H " ERROR " $LOGDIR/ftps.log | \
         grep -E -v "ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|: Invalid path characters" | tail -n $MAXLINES
 
-[[ "$ENABLE_SFTP" == "True" || "$ENABLE_SFTP_SUBSYS" == True ]] \ 
-    && grep -H " ERROR " $LOGDIR/sftp*.log | \
+[[ "$ENABLE_SFTP" == "True" || "$ENABLE_SFTP_SUBSYS" == True ]]  \
+        && grep -H " ERROR " $LOGDIR/sftp*.log | \
 	grep -E -v "Password authentication failed for|Socket exception: Connection reset by peer|Error reading SSH protocol banner|check_banner|list_folder on missing path|chmod (292|365) rejected on path|symlink rejected on path|ERROR mkdir .* failed: \[Errno 17\] File exists|ERROR rmdir .* failed: \[Errno 39\] Directory not empty|ERROR open .* failed: \[Errno 21\] Is a directory|ERROR open for modify on read-only path|ERROR open existing file on missing path |ERROR Exception.*: Incompatible ssh|ERROR Exception.*: Incompatible version |Exception.*: Invalid SSH banner|ERROR Exception.*: no moduli available|ERROR Exception.*: Expecting packet from \(20,\), got 0|ERROR Socket exception: Connection timed out|ERROR Exception.*: Key-exchange timed out|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|ERROR Exception.*: Client kex .* is out of range|ERROR Exception.*: Expecting packet from .*|get_fs_path failed: Invalid path characters|ERROR $" | tail -n $MAXLINES
 
 [ "$ENABLE_DAVS" == "True" ] && grep -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES


### PR DESCRIPTION
The migerrors cronjob currently throw errors if log files are missing for disabled services.

Check if a specific services is enabled before trying to grep it's log file.