### PR TITLE
Add recurring handling of user, resource and vgrid map refresh to janitor

### DIFF
--- a/mig/lib/janitor.py
+++ b/mig/lib/janitor.py
@@ -43,6 +43,8 @@ from mig.shared.fileio import delete_file, listdir
 from mig.shared.pwcrypto import verify_reset_token
 from mig.shared.serial import load
 from mig.shared.userdb import default_db_path, load_user_dict
+from mig.shared.vgridaccess import get_resource_map, get_user_map, \
+    get_vgrid_map, last_refresh, RESOURCES, USERS, VGRIDS
 
 REMIND_REQ_DAYS = 5
 EXPIRE_REQ_DAYS = 30
@@ -493,7 +495,17 @@ def handle_cache_updates(configuration, now=None):
         now = time.time()
     handled = 0
     _logger.debug("handle pending cache updates")
-    # TODO: actually handle vgrid/user/resource/... cache updates
+    # NOTE: we use get_X_map here to throttle down and only refresh when needed
+    user_map = get_user_map(configuration, caching=False)
+    if last_refresh[USERS] > now:
+        handled += 1
+    if configuration.site_enable_resources:
+        resource_map = get_resource_map(configuration, caching=False)
+        if last_refresh[RESOURCES] > now:
+            handled += 1
+    vgrid_map = get_vgrid_map(configuration, caching=False)
+    if last_refresh[VGRIDS] > now:
+        handled += 1
     if handled > 0:
         _logger.info("handled %d pending cache updates" % handled)
     else:

--- a/mig/shared/functionality/resman.py
+++ b/mig/shared/functionality/resman.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # resman - manage resources
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2025  The MiG Project lead by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -41,7 +42,7 @@ from mig.shared.init import initialize_main_variables, find_entry
 from mig.shared.modified import pending_resources_update, pending_vgrids_update
 from mig.shared.resource import anon_to_real_res_map
 from mig.shared.vgridaccess import user_visible_res_confs, get_resource_map, \
-    OWNERS, CONF
+    load_resource_map, CONF, OWNERS
 
 list_operations = ['showlist', 'list']
 show_operations = ['show', 'showlist']
@@ -155,7 +156,11 @@ to open resource management.
         logger.info("get vgrid and resource map with caching %s" % caching)
         visible_res_confs = user_visible_res_confs(configuration, client_id,
                                                    caching)
-        res_map = get_resource_map(configuration, caching)
+        # NOTE: prevent refresh if janitor is enabled as it handles all updates
+        if configuration.site_enable_janitor:
+            (res_map, _) = load_resource_map(configuration, caching=caching)
+        else:
+            res_map = get_resource_map(configuration, caching)
         anon_map = anon_to_real_res_map(configuration.resource_home)
 
         # NOTE: use simple pending check if caching to avoid lock during update

--- a/mig/shared/functionality/vgridman.py
+++ b/mig/shared/functionality/vgridman.py
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -40,7 +41,8 @@ from mig.shared.init import initialize_main_variables, find_entry
 from mig.shared.modified import pending_vgrids_update
 from mig.shared.useradm import get_full_user_map
 from mig.shared.vgrid import vgrid_create_allowed
-from mig.shared.vgridaccess import get_vgrid_map, VGRIDS, OWNERS, MEMBERS, SETTINGS
+from mig.shared.vgridaccess import get_vgrid_map, load_vgrid_map, MEMBERS, \
+    OWNERS, SETTINGS, VGRIDS
 
 list_operations = ['showlist', 'list']
 show_operations = ['show', 'showlist']
@@ -185,7 +187,11 @@ resources.''' % label})
 
     if operation in list_operations:
         logger.info("get vgrid map with caching %s" % caching)
-        vgrid_map = get_vgrid_map(configuration, caching=caching)
+        # NOTE: prevent refresh if janitor is enabled as it handles all updates
+        if configuration.site_enable_janitor:
+            (vgrid_map, _) = load_vgrid_map(configuration, caching=caching)
+        else:
+            vgrid_map = get_vgrid_map(configuration, caching=caching)
         # NOTE: use simple pending check if caching to avoid lock during update
         if caching:
             pending_updates = pending_vgrids_update(configuration)


### PR DESCRIPTION
Add recurring handling of user, resource and vgrid map refresh to janitor service. Effectively centralizes the updates in a single long-running process rather than the fragile concurrent client-initiated refreshes, since they tend to result in clients hammering the site during refresh and may leave cache inconsistent if client hits HTTP time-out in the middle of a refresh (#121).

Runs in the main thread so far, but we may need to consider a background thread/process for the refresh if it turns out to delay other janitor tasks too much.

Removes client-initiated refresh triggers in `vgridman` and `resman` backends if janitor is enabled.

Could perhaps use improved user-facing information e.g. about when the current (cached) view was generated on `vgridman` and `resman` pages to help clarify when any recent changes are not yet fully processed and showing.