### PR TITLE
Allow site admins to sign up for X509 or local oid access to existing account

### DIFF
--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -1393,10 +1393,17 @@ def auto_add_user_allowed_with_peer(configuration, user_dict):
                                    configuration.auto_add_user_with_peer)
 
 
-def signup_prefilter_allowed(configuration, user_dict):
+def signup_prefilter_allowed(configuration, user_dict, allow_dn_list=None):
     """Check if user with user_dict is potentially allowed to sign up in forms
     soleley based on optional configuration prefilter.
+    If a list of user distinguished_name values is passed as the allow_dn_list
+    those users will unconditionally be allowed through the filter. This is
+    mainly useful in relation to allowing registered site admins to sign up for
+    X509 certificates or migoid(c) access for an existing extoid(c) account.
     """
+    if allow_dn_list and user_dict.get('distinguished_name', None) in \
+            allow_dn_list:
+        return True
     for (key, val) in configuration.site_signup_prefilter:
         if not re.match(val, user_dict.get(key, 'NO SUCH FIELD')):
             return False

--- a/mig/shared/functionality/reqcertaction.py
+++ b/mig/shared/functionality/reqcertaction.py
@@ -231,7 +231,9 @@ You may also read more about the Peers system in the site documentation.
     user_dict = canonical_user(configuration, raw_user, raw_user.keys())
     fill_distinguished_name(user_dict)
 
-    if not signup_prefilter_allowed(configuration, raw_user):
+    # NOTE: allow registered site admins to request alternative login access
+    if not signup_prefilter_allowed(configuration, raw_user,
+                                    configuration.admin_list):
         output_objects.append({'object_type': 'error_text', 'text':
                                '''Invalid sign up request:
 Please read and follow the sign up help and instructions on the request page!

--- a/mig/shared/functionality/reqoidaction.py
+++ b/mig/shared/functionality/reqoidaction.py
@@ -245,7 +245,9 @@ You may also read more about the Peers system in the site documentation.
     user_dict = canonical_user(configuration, raw_user, raw_user.keys())
     fill_distinguished_name(user_dict)
 
-    if not signup_prefilter_allowed(configuration, raw_user):
+    # NOTE: allow registered site admins to request alternative login access
+    if not signup_prefilter_allowed(configuration, raw_user,
+                                    configuration.admin_list):
         output_objects.append({'object_type': 'error_text', 'text':
                                '''Invalid sign up request:
 Please read and follow the sign up help and instructions on the request page!

--- a/tests/test_mig_shared_accountreq.py
+++ b/tests/test_mig_shared_accountreq.py
@@ -36,7 +36,8 @@ import unittest
 from tests.support import MigTestCase, testmain, fixturefile, ensure_dirs_exist
 
 import mig.shared.accountreq as accountreq
-from mig.shared.base import canonical_user, fill_distinguished_name
+from mig.shared.base import canonical_user, distinguished_name_to_user, \
+    fill_distinguished_name, get_client_id
 from mig.shared.defaults import keyword_auto
 
 
@@ -142,6 +143,12 @@ class MigSharedAccountreq__peers(MigTestCase):
 
         self.assertTrue(success)
 
+
+class MigSharedAccountreq__prefilters(MigTestCase):
+    """Unit tests for prefilter helper functions within the accountreq module"""
+
+    TEST_ADMIN_DN = '/C=DK/ST=NA/L=NA/O=DIKU/OU=NA/CN=Test Admin/emailAddress=siteadm@di.ku.dk'
+
     def test_signup_prefilter_email_accept(self):
         accept = ['john@doe.org', 'a@b.c.org', 'a@ku.dk.com',
                   'a@sci.ku.dk.org', 'a@diku.dk', 'a@nbi.dk']
@@ -163,6 +170,17 @@ class MigSharedAccountreq__peers(MigTestCase):
             check = accountreq.signup_prefilter_allowed(self.configuration,
                                                         user)
             self.assertFalse(check)
+
+    def test_signup_prefilter_email_accept_site_admins(self):
+        user = distinguished_name_to_user(self.TEST_ADMIN_DN)
+        admin_list = [get_client_id(user)]
+        self.configuration.site_signup_prefilter = [
+            ('email', r'^.+(?<!(@|\.)ku\.dk)$')]
+        check = accountreq.signup_prefilter_allowed(self.configuration, user)
+        self.assertFalse(check)
+        check = accountreq.signup_prefilter_allowed(self.configuration, user,
+                                                    admin_list)
+        self.assertTrue(check)
 
     def test_peers_prefilter_email_accept(self):
         accept = ['john.doe@science.ku.dk', 'abc123@ku.dk',


### PR DESCRIPTION
Implement basic white-list support in `signup_prefilter_allowed` and use it to let registered site admins in configuration `admin_list` through the filter. Allows admins to sign up for alternative X509 or migoid(c) access to existing extoid(c) accounts.
Refactor `accountreq` unit tests to fit class name and add a test to cover the new white-list.