### PR TITLE
Improved coverage and fixed string checks for basic functionality of several of the pwcrypto helpers

### DIFF
--- a/mig/shared/pwcrypto.py
+++ b/mig/shared/pwcrypto.py
@@ -40,6 +40,7 @@ from string import ascii_lowercase, ascii_uppercase, digits
 import datetime
 import hashlib
 import time
+import sys
 
 from mig.shared.base import force_utf8, force_native_str, mask_creds, string_snippet
 from mig.shared.defaults import keyword_auto, RESET_TOKEN_TTL
@@ -1027,7 +1028,8 @@ def generate_random_password(configuration, tries=42):
     raise ValueError("Failed to generate suitable password!")
 
 
-if __name__ == "__main__":
+def main(_exit=sys.exit, _print=print):
+    """Run module self-tests"""
     from mig.shared.conf import get_configuration_object
     configuration = get_configuration_object()
     dummy_user = {'distinguished_name': 'Test User', 'password_hash': ''}
@@ -1057,6 +1059,8 @@ if __name__ == "__main__":
         hashed = make_hash(pw)
         snippet = string_snippet(hashed)
         dummy_user['password_hash'] = hashed
+        if 'migoid' not in configuration.site_login_methods:
+            configuration.site_login_methods.append('migoid')
         token = generate_reset_token(configuration, dummy_user, 'migoid')
         print("Password %r gives hash %r, snippet %r and reset token %r" %
               (pw, hashed, snippet, token))
@@ -1112,3 +1116,7 @@ if __name__ == "__main__":
         except Exception as exc:
             print(
                 "Failed to handle aesgcm static encrypt/decrypt %s : %s" % (pw, exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mig_shared_pwcrypto.py
+++ b/tests/test_mig_shared_pwcrypto.py
@@ -89,7 +89,7 @@ DUMMY_AESGCM_KEY = b'48797271554677786167464ED6F23EC6'
 DUMMY_AESGCM_STATIC_IV = b'\xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9'
 DUMMY_AESGCM_AAD_PREFIX = b'\xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9\xa88\xee\xbc[\xb1\xa9'
 DUMMY_AESGCM_AAD = b' \xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9\xa88\xee\xbc[\xb1\xa920500101'
-# NOTE: we avoid any percent expansion values of actual date here freeze AAD
+# NOTE: we avoid any percent expansion values of actual date here to freeze AAD
 DUMMY_FIXED_TIMESTAMP = '20500101'
 
 

--- a/tests/test_mig_shared_pwcrypto.py
+++ b/tests/test_mig_shared_pwcrypto.py
@@ -37,8 +37,8 @@ from tests.support import MigTestCase, FakeConfiguration, \
 
 from mig.shared.defaults import POLICY_NONE, POLICY_WEAK, POLICY_MEDIUM, \
     POLICY_HIGH, POLICY_MODERN, POLICY_CUSTOM, PASSWORD_POLICIES
+from mig.shared.pwcrypto import main as pwcrypto_main
 from mig.shared.pwcrypto import *
-
 
 DUMMY_USER = "dummy-user"
 DUMMY_ID = "dummy-id"
@@ -47,6 +47,7 @@ DUMMY_WEAK_PW = 'foobar'
 DUMMY_MEDIUM_PW = 'QZFnCp7h'
 DUMMY_HIGH_PW = 'QZFnp7I-GZ'
 DUMMY_MODERN_PW = 'QZFnCp7hmI1G'
+DUMMY_GENERATED_PW = '7hmI1GnCpQZF'
 DUMMY_WEAK_PW_MD5 = "3858f62230ac3c915f300c664312c63f"
 DUMMY_WEAK_PW_SHA256 = \
     "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"
@@ -63,8 +64,15 @@ DUMMY_MODERN_PW_PBKDF2 = \
     "PBKDF2$sha256$10000$MDAwMDAwMDAwMDAw$B22uw6C7C4VFiYAe4Vf10n58FHrn1pjX"
 DUMMY_MODERN_PW_DIGEST = \
     "DIGEST$custom$CONFSALT$64756D6D792D7265616C6D3A64756D6D792D7520DE71261F96A2FE48A67DD0877F2A2C"
+DUMMY_MODERN_DIGEST_SCRAMBLE = "53BB031C1F96A2FE48A67DD0877F2A2C"
 DUMMY_MODERN_PW_SCRAMBLE = "53BB031C1F96A2FE48A67DD0877F2A2C"
+DUMMY_MODERN_PW_AESGCM_SIV_ENCRYPTED = b'xRsT1qHmiM3xqDjuvFuxqQ==.g4-Gt83uRrdvVWwXNHdk5guAy3dbosnmjJQ6rg==.ICAgIG1pZ3JpZCBhdXRoZW50aWNhdGVkMjAyNTEwMTM='
 DUMMY_MODERN_PW_RESET_TOKEN = b'gAAAAABo63hYqeHE7Db93pMxWn1sWzj2Z-6td2UhA5gKYa4KV096ndV-AO0pp6hrR9jXKcwWAouLCMiNC0BRudeCAYHoBii15lTRbP9b7JzvJjeusbidjRxqcJg0om6bbtSK1Rz_RBTq_jhdAk4v-7PccWlZ15dVJ4j-X3X4zSsBWIOR5y6Y-bA='
+DUMMY_METHOD = 'dummy-method'
+DUMMY_OPERATION = 'dummy-operation'
+DUMMY_ARGS = {'dummy-key': 'dummy-val'}
+DUMMY_CSRF_TOKEN = '351cc47e0cd5c155fa4c4d3d0a6f1ee8f20eeb293ba13d59ede9d2a789687d3d'
+DUMMY_CSRF_TRUST_TOKEN = '466c0bacd045a060a201c4e08c749c2e19743613422e0381ab0a57706c9fa2b8'
 DUMMY_HOME_DIR = 'dummy_user_home'
 DUMMY_SETTINGS_DIR = 'dummy_user_settings'
 # TODO: adjust password reset token helpers to handle configured services
@@ -72,7 +80,15 @@ DUMMY_SETTINGS_DIR = 'dummy_user_settings'
 # DUMMY_SERVICE = 'dummy-svc'
 DUMMY_SERVICE = 'migoid'
 DUMMY_REALM = 'dummy-realm'
+DUMMY_PATH = 'dummy-path'
+DUMMY_PATH_MD5 = 'd19033877452e8c217d3cddebbc37419'
 DUMMY_SALT = b'53BB031C4ECCE4900BD64AB8EA361B6B'
+DUMMY_ENTROPY = b'\xd2\x93\xdc\xb9v,\x87d\x1e\xa1\xde\xcb\xfev\xd8N\xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9'
+DUMMY_FERNET_KEY = 'NDg3OTcyNzE1NTQ2Nzc3ODYxNjc0NjRFRDZGMjNFQzY='
+DUMMY_AESGCM_KEY = b'48797271554677786167464ED6F23EC6'
+DUMMY_AESGCM_STATIC_IV = b'\xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9'
+DUMMY_AESGCM_AAD_PREFIX = b'\xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9\xa88\xee\xbc[\xb1\xa9'
+DUMMY_AESGCM_AAD = b' \xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9\xa88\xee\xbc[\xb1\xa920251013'
 
 
 class MigSharedPwCrypto(MigTestCase):
@@ -95,6 +111,7 @@ class MigSharedPwCrypto(MigTestCase):
             site_password_salt=DUMMY_SALT,
             site_digest_salt=DUMMY_SALT,
             site_login_methods=[DUMMY_SERVICE],
+            site_signup_methods=[DUMMY_SERVICE],
         )
 
     def test_best_crypt_salt(self):
@@ -118,6 +135,89 @@ class MigSharedPwCrypto(MigTestCase):
             pass
         self.assertTrue(actual is None, "best crypt salt failed to err")
 
+    def test_password_requirements(self):
+        """Test parse password policy for default MODERN and legacy MEDIUM"""
+        expected = (12, 1, [])
+        result = password_requirements(self.dummy_conf.site_password_policy)
+        self.assertEqual(expected[0], result[0], "failed pw req chars")
+        self.assertEqual(expected[1], result[1], "failed pw req classes")
+        self.assertEqual(expected[2], result[2], "failed pw req errors")
+        expected = (8, 3, [])
+        result = password_requirements(
+            self.dummy_conf.site_password_legacy_policy)
+        self.assertEqual(expected[0], result[0], "failed legacy pw req chars")
+        self.assertEqual(expected[1], result[1],
+                         "failed legacy pw req classes")
+        self.assertEqual(expected[2], result[2], "failed legacy pw req errors")
+
+    def test_parse_password_policy(self):
+        """Test parse password policy for default MODERN and legacy MEDIUM"""
+        expected = (12, 1)
+        result = parse_password_policy(self.dummy_conf)
+        self.assertEqual(expected[0], result[0], "failed parse policy chars")
+        self.assertEqual(expected[1], result[1], "failed parse policy classes")
+        expected = (8, 3)
+        result = parse_password_policy(self.dummy_conf, use_legacy=True)
+        self.assertEqual(expected[0], result[0], "failed parse policy chars")
+        self.assertEqual(expected[1], result[1], "failed parse policy classes")
+
+    def test_assure_password_strength(self):
+        """Test assure password strength"""
+        try:
+            allow_weak = assure_password_strength(self.dummy_conf,
+                                                  DUMMY_WEAK_PW)
+        except ValueError as vae:
+            allow_weak = False
+        self.assertFalse(allow_weak, "allowed weak pw")
+        try:
+            allow_weak = assure_password_strength(self.dummy_conf,
+                                                  DUMMY_WEAK_PW,
+                                                  allow_legacy=True)
+        except ValueError as vae:
+            allow_weak = False
+        self.assertFalse(allow_weak, "allowed weak pw with legacy")
+        # NOTE: only allow medium with legacy
+        try:
+            allow_medium = assure_password_strength(self.dummy_conf,
+                                                    DUMMY_MEDIUM_PW)
+        except ValueError as vae:
+            allow_medium = False
+        self.assertFalse(allow_medium, "allowed medium pw without legacy")
+        try:
+            allow_medium = assure_password_strength(self.dummy_conf,
+                                                    DUMMY_MEDIUM_PW,
+                                                    allow_legacy=True)
+        except ValueError as vae:
+            allow_medium = False
+        self.assertTrue(allow_medium, "refused medium pw with legacy")
+        # NOTE: only allow high with legacy - not long enough for modern
+        try:
+            allow_high = assure_password_strength(self.dummy_conf,
+                                                  DUMMY_HIGH_PW)
+        except ValueError as vae:
+            allow_high = False
+        self.assertFalse(allow_high, "allowed high pw without legacy")
+        try:
+            allow_high = assure_password_strength(self.dummy_conf,
+                                                  DUMMY_HIGH_PW,
+                                                  allow_legacy=True)
+        except ValueError as vae:
+            allow_high = False
+        self.assertTrue(allow_high, "refused high pw with legacy")
+        try:
+            allow_modern = assure_password_strength(self.dummy_conf,
+                                                    DUMMY_MODERN_PW)
+        except ValueError as vae:
+            allow_modern = False
+        self.assertTrue(allow_modern, "refused modern pw")
+        try:
+            allow_modern = assure_password_strength(self.dummy_conf,
+                                                    DUMMY_MODERN_PW,
+                                                    allow_legacy=True)
+        except ValueError as vae:
+            allow_modern = False
+        self.assertTrue(allow_modern, "refused modern pw with legacy")
+
     def test_valid_login_password(self):
         """Test valid login password checker which assures password strength"""
         allow_weak = valid_login_password(self.dummy_conf, DUMMY_WEAK_PW)
@@ -138,6 +238,18 @@ class MigSharedPwCrypto(MigTestCase):
         first = make_simple_hash(DUMMY_MODERN_PW)
         second = make_simple_hash(DUMMY_MODERN_PW)
         self.assertEqual(first, second, "simple hashing is not constant")
+
+    def test_make_path_hash_fixed(self):
+        """Test basic hashing of a fixed path string to be constant"""
+        expected = DUMMY_PATH_MD5
+        actual = make_path_hash(self.dummy_conf, DUMMY_PATH)
+        self.assertEqual(actual, expected, "mismatch path hash string")
+
+    def test_make_path_hash_constant_string(self):
+        """Test basic hashing of a fixed path string to be constant"""
+        first = make_path_hash(self.dummy_conf, DUMMY_PATH)
+        second = make_path_hash(self.dummy_conf, DUMMY_PATH)
+        self.assertEqual(first, second, "path hashing is not constant")
 
     def test_make_safe_hash_fixed(self):
         """Test basic hashing of a fixed string to be constant"""
@@ -268,6 +380,18 @@ class MigSharedPwCrypto(MigTestCase):
                             DUMMY_MODERN_PW, second)
         self.assertTrue(result, "mismatch in 2nd random password hash check")
 
+    def test_scramble_digest_fixed(self):
+        """Test basic scramble of a fixed string to be constant"""
+        expected = DUMMY_MODERN_DIGEST_SCRAMBLE
+        actual = scramble_digest(DUMMY_SALT, DUMMY_MODERN_PW)
+        self.assertEqual(actual, expected, "mismatch scramble digest string")
+
+    def test_unscramble_digest_fixed(self):
+        """Test basic unscramble of a fixed string to be constant"""
+        expected = DUMMY_MODERN_PW
+        actual = unscramble_digest(DUMMY_SALT, DUMMY_MODERN_DIGEST_SCRAMBLE)
+        self.assertEqual(actual, expected, "mismatch unscramble digest string")
+
     def test_make_digest_fixed(self):
         """Test basic digest of a fixed string"""
         expected = DUMMY_MODERN_PW_DIGEST
@@ -345,6 +469,13 @@ class MigSharedPwCrypto(MigTestCase):
         second = make_scramble(DUMMY_MODERN_PW, DUMMY_SALT)
         self.assertEqual(first, second, "basic scramble is not constant")
 
+    def test_prepare_fernet_key(self):
+        """Test basic fernet secret key preparation on a fixed string.
+        """
+        expected = DUMMY_FERNET_KEY
+        result = prepare_fernet_key(self.dummy_conf)
+        self.assertEqual(expected, result, "failed prepare fernet key")
+
     def test_fernet_encrypt_decrypt(self):
         """Test basic fernet password encrypt and decrypt on a random string"""
         random_pw = generate_random_password(self.dummy_conf)
@@ -352,12 +483,54 @@ class MigSharedPwCrypto(MigTestCase):
         result = fernet_decrypt_password(self.dummy_conf, expected)
         self.assertEqual(random_pw, result, "failed fernet enc+dec")
 
+    def test_prepare_aesgcm_key(self):
+        """Test basic aesgcm secret key preparation on a fixed string.
+        """
+        expected = DUMMY_AESGCM_KEY
+        result = prepare_aesgcm_key(self.dummy_conf)
+        self.assertEqual(expected, result, "failed prepare aesgcm key")
+
     def test_aesgcm_encrypt_decrypt(self):
         """Test basic aesgcm password encrypt and decrypt on a random string"""
         random_pw = generate_random_password(self.dummy_conf)
         expected = aesgcm_encrypt_password(self.dummy_conf, random_pw)
         result = aesgcm_decrypt_password(self.dummy_conf, expected)
         self.assertEqual(random_pw, result, "failed aesgcm enc+dec")
+
+    def test_prepare_aesgcm_static_iv_fixed(self):
+        """Test basic aesgcm initialization vector preparation on a fixed
+        entropy value.
+        """
+        expected = DUMMY_AESGCM_STATIC_IV
+        result = prepare_aesgcm_iv(self.dummy_conf, iv_entropy=DUMMY_ENTROPY)
+        self.assertEqual(expected, result, "failed prepare aesgcm static iv")
+
+    def test_prepare_aesgcm_aad_fixed(self):
+        """Test basic aesgcm additional auth dat preparation on a fixed
+        entropy value.
+        """
+        expected = DUMMY_AESGCM_AAD
+        result = prepare_aesgcm_aad(self.dummy_conf, DUMMY_AESGCM_AAD_PREFIX)
+        self.assertEqual(expected, result, "failed prepare aesgcm aad")
+
+    def test_aesgcm_encrypt_static_iv_fixed(self):
+        """Test basic aesgcm password encrypt on a fixed string with a fixed
+        initialization vector.
+        """
+        expected = DUMMY_MODERN_PW_AESGCM_SIV_ENCRYPTED
+        result = aesgcm_encrypt_password(self.dummy_conf, DUMMY_MODERN_PW,
+                                         init_vector=DUMMY_AESGCM_STATIC_IV)
+        self.assertEqual(expected, result, "failed fixed aesgcm static iv enc")
+
+    def test_aesgcm_decrypt_static_iv_fixed(self):
+        """Test basic aesgcm password decrypt on a fixed string with a fixed
+        initialization vector.
+        """
+        expected = DUMMY_MODERN_PW
+        result = aesgcm_decrypt_password(self.dummy_conf,
+                                         DUMMY_MODERN_PW_AESGCM_SIV_ENCRYPTED,
+                                         init_vector=DUMMY_AESGCM_STATIC_IV)
+        self.assertEqual(expected, result, "failed fixed aesgcm static iv den")
 
     def test_aesgcm_encrypt_decrypt_static_iv(self):
         """Test basic aesgcm password encrypt and decrypt on a random string
@@ -412,6 +585,15 @@ class MigSharedPwCrypto(MigTestCase):
                                random_pw, encrypted, algo='aesgcm_static')
         self.assertTrue(result, "mismatch in aesgcm_static encrypt check")
 
+    def test_assure_reset_supported(self):
+        """Test basic password reset token check for a fixed user and auth"""
+        dummy_user = {'distinguished_name': DUMMY_USER}
+        dummy_user['password_hash'] = DUMMY_MODERN_PW_PBKDF2
+        result = assure_reset_supported(self.dummy_conf, dummy_user,
+                                        DUMMY_SERVICE)
+        self.assertTrue(result, "failed assure reset supported")
+
+    # TODO: adjust API to allow enabling the next test
     @unittest.skipIf(True, "requires constant random seed")
     def test_generate_reset_token_fixed(self):
         """Test basic password reset token generate for a fixed string"""
@@ -424,16 +606,19 @@ class MigSharedPwCrypto(MigTestCase):
         self.assertEqual(expected, result,
                          "failed generate password reset token")
 
+    # TODO: adjust API to allow enabling the next test
     @unittest.skipIf(True, "requires constant random seed")
     def test_parse_reset_token_fixed(self):
         """Test basic password reset token parse for a fixed string"""
         timestamp = 42
-        result = parse_reset_token(self.dummy_conf, DUMMY_MODERN_PW_RESET_TOKEN,
+        result = parse_reset_token(self.dummy_conf,
+                                   DUMMY_MODERN_PW_RESET_TOKEN,
                                    DUMMY_SERVICE)
         self.assertEqual(result[0], timestamp, "failed parse token time")
         self.assertEqual(result[1], DUMMY_MODERN_PW_PBKDF2,
                          "failed parse token hash")
 
+    # TODO: adjust API to allow enabling the next test
     @unittest.skipIf(True, "requires constant random seed")
     def test_verify_reset_token_fixed(self):
         """Test basic password reset token verify for a fixed string"""
@@ -478,7 +663,55 @@ class MigSharedPwCrypto(MigTestCase):
                                     DUMMY_SERVICE, timestamp)
         self.assertFalse(result, "failed password reset token expiry check")
 
-   # TODO: migrate remaining inline checks from module here instead
+    def test_make_csrf_token_fixed(self):
+        """Test basic csrf token generate for a fixed method, operation and
+        client id.
+        """
+        expected = DUMMY_CSRF_TOKEN
+        result = make_csrf_token(self.dummy_conf, DUMMY_METHOD,
+                                 DUMMY_OPERATION, DUMMY_ID)
+        self.assertEqual(expected, result, "failed make csrf token")
+
+    def test_make_csrf_trust_token_fixed(self):
+        """Test basic csrf trust token generate for a fixed method, operation,
+        client id and args.
+        """
+        expected = DUMMY_CSRF_TRUST_TOKEN
+        result = make_csrf_trust_token(self.dummy_conf, DUMMY_METHOD,
+                                       DUMMY_OPERATION, DUMMY_ARGS, DUMMY_ID)
+        self.assertEqual(expected, result, "failed make csrf trust token")
+
+    def test_generate_random_password(self):
+        """Test basic generate password"""
+        result = generate_random_password(self.dummy_conf)
+        self.assertTrue(result, "failed generate password")
+        self.assertTrue(len(result) == 12, "failed generate password length")
+
+    # TODO: adjust API to allow enabling the next test
+    @unittest.skipIf(True, "requires constant random seed")
+    def test_generate_random_password_fixed_seed(self):
+        """Test basic generate password is constant with fixed random seed"""
+        expected = DUMMY_GENERATED_PW
+        result = generate_random_password(self.dummy_conf)
+        self.assertEqual(expected, result,
+                         "failed generate password with fixed seed")
+
+    # TODO: migrate remaining inline checks from module here instead
+    def test_existing_main(self):
+        def raise_on_error_exit(exit_code):
+            if exit_code != 0:
+                if raise_on_error_exit.last_print is not None:
+                    identifying_message = raise_on_error_exit.last_print
+                else:
+                    identifying_message = 'unknown'
+                raise AssertionError(
+                    'failure in unittest/testcore: %s' % (identifying_message,))
+        raise_on_error_exit.last_print = None
+
+        def record_last_print(value):
+            raise_on_error_exit.last_print = value
+
+        pwcrypto_main(_exit=raise_on_error_exit, _print=record_last_print)
 
 
 if __name__ == '__main__':

--- a/tests/test_mig_shared_pwcrypto.py
+++ b/tests/test_mig_shared_pwcrypto.py
@@ -66,7 +66,7 @@ DUMMY_MODERN_PW_DIGEST = \
     "DIGEST$custom$CONFSALT$64756D6D792D7265616C6D3A64756D6D792D7520DE71261F96A2FE48A67DD0877F2A2C"
 DUMMY_MODERN_DIGEST_SCRAMBLE = "53BB031C1F96A2FE48A67DD0877F2A2C"
 DUMMY_MODERN_PW_SCRAMBLE = "53BB031C1F96A2FE48A67DD0877F2A2C"
-DUMMY_MODERN_PW_AESGCM_SIV_ENCRYPTED = b'xRsT1qHmiM3xqDjuvFuxqQ==.g4-Gt83uRrdvVWwXiN0a29_PLwkqySS0Pb7MmA==.ICAgIG1pZ3JpZCBhdXRoZW50aWNhdGVkMjAyNTEwMTY='
+DUMMY_MODERN_PW_AESGCM_SIV_ENCRYPTED = b'xRsT1qHmiM3xqDjuvFuxqQ==.g4-Gt83uRrdvVWwX0SF1iMza3NyKJbp2sEYVkw==.ICAgIG1pZ3JpZCBhdXRoZW50aWNhdGVkMjA1MDAxMDE='
 DUMMY_MODERN_PW_RESET_TOKEN = b'gAAAAABo63hYqeHE7Db93pMxWn1sWzj2Z-6td2UhA5gKYa4KV096ndV-AO0pp6hrR9jXKcwWAouLCMiNC0BRudeCAYHoBii15lTRbP9b7JzvJjeusbidjRxqcJg0om6bbtSK1Rz_RBTq_jhdAk4v-7PccWlZ15dVJ4j-X3X4zSsBWIOR5y6Y-bA='
 DUMMY_METHOD = 'dummy-method'
 DUMMY_OPERATION = 'dummy-operation'
@@ -88,7 +88,9 @@ DUMMY_FERNET_KEY = 'NDg3OTcyNzE1NTQ2Nzc3ODYxNjc0NjRFRDZGMjNFQzY='
 DUMMY_AESGCM_KEY = b'48797271554677786167464ED6F23EC6'
 DUMMY_AESGCM_STATIC_IV = b'\xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9'
 DUMMY_AESGCM_AAD_PREFIX = b'\xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9\xa88\xee\xbc[\xb1\xa9'
-DUMMY_AESGCM_AAD = b' \xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9\xa88\xee\xbc[\xb1\xa920251016'
+DUMMY_AESGCM_AAD = b' \xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9\xa88\xee\xbc[\xb1\xa920500101'
+# NOTE: we avoid any percent expansion values of actual date here freeze AAD
+DUMMY_FIXED_TIMESTAMP = '20500101'
 
 
 class MigSharedPwCrypto(MigTestCase):
@@ -515,19 +517,21 @@ class MigSharedPwCrypto(MigTestCase):
 
     def test_prepare_aesgcm_aad_fixed(self):
         """Test basic aesgcm additional auth data preparation on a fixed
-        entropy value.
+        entropy and date value.
         """
         expected = DUMMY_AESGCM_AAD
-        result = prepare_aesgcm_aad(self.dummy_conf, DUMMY_AESGCM_AAD_PREFIX)
+        result = prepare_aesgcm_aad(self.dummy_conf, DUMMY_AESGCM_AAD_PREFIX,
+                                    aad_stamp=DUMMY_FIXED_TIMESTAMP)
         self.assertEqual(expected, result, "failed prepare aesgcm aad")
 
     def test_aesgcm_encrypt_static_iv_fixed(self):
         """Test basic aesgcm password encrypt on a fixed string with a fixed
-        initialization vector.
+        initialization vector and date helper.
         """
         expected = DUMMY_MODERN_PW_AESGCM_SIV_ENCRYPTED
         result = aesgcm_encrypt_password(self.dummy_conf, DUMMY_MODERN_PW,
-                                         init_vector=DUMMY_AESGCM_STATIC_IV)
+                                         init_vector=DUMMY_AESGCM_STATIC_IV,
+                                         aad_stamp=DUMMY_FIXED_TIMESTAMP)
         self.assertEqual(expected, result, "failed fixed aesgcm static iv enc")
 
     def test_aesgcm_decrypt_static_iv_fixed(self):

--- a/tests/test_mig_shared_pwcrypto.py
+++ b/tests/test_mig_shared_pwcrypto.py
@@ -66,7 +66,7 @@ DUMMY_MODERN_PW_DIGEST = \
     "DIGEST$custom$CONFSALT$64756D6D792D7265616C6D3A64756D6D792D7520DE71261F96A2FE48A67DD0877F2A2C"
 DUMMY_MODERN_DIGEST_SCRAMBLE = "53BB031C1F96A2FE48A67DD0877F2A2C"
 DUMMY_MODERN_PW_SCRAMBLE = "53BB031C1F96A2FE48A67DD0877F2A2C"
-DUMMY_MODERN_PW_AESGCM_SIV_ENCRYPTED = b'xRsT1qHmiM3xqDjuvFuxqQ==.g4-Gt83uRrdvVWwXNHdk5guAy3dbosnmjJQ6rg==.ICAgIG1pZ3JpZCBhdXRoZW50aWNhdGVkMjAyNTEwMTM='
+DUMMY_MODERN_PW_AESGCM_SIV_ENCRYPTED = b'xRsT1qHmiM3xqDjuvFuxqQ==.g4-Gt83uRrdvVWwXiN0a29_PLwkqySS0Pb7MmA==.ICAgIG1pZ3JpZCBhdXRoZW50aWNhdGVkMjAyNTEwMTY='
 DUMMY_MODERN_PW_RESET_TOKEN = b'gAAAAABo63hYqeHE7Db93pMxWn1sWzj2Z-6td2UhA5gKYa4KV096ndV-AO0pp6hrR9jXKcwWAouLCMiNC0BRudeCAYHoBii15lTRbP9b7JzvJjeusbidjRxqcJg0om6bbtSK1Rz_RBTq_jhdAk4v-7PccWlZ15dVJ4j-X3X4zSsBWIOR5y6Y-bA='
 DUMMY_METHOD = 'dummy-method'
 DUMMY_OPERATION = 'dummy-operation'
@@ -88,7 +88,7 @@ DUMMY_FERNET_KEY = 'NDg3OTcyNzE1NTQ2Nzc3ODYxNjc0NjRFRDZGMjNFQzY='
 DUMMY_AESGCM_KEY = b'48797271554677786167464ED6F23EC6'
 DUMMY_AESGCM_STATIC_IV = b'\xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9'
 DUMMY_AESGCM_AAD_PREFIX = b'\xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9\xa88\xee\xbc[\xb1\xa9'
-DUMMY_AESGCM_AAD = b' \xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9\xa88\xee\xbc[\xb1\xa920251013'
+DUMMY_AESGCM_AAD = b' \xc5\x1b\x13\xd6\xa1\xe6\x88\xcd\xf1\xa88\xee\xbc[\xb1\xa9\xa88\xee\xbc[\xb1\xa920251016'
 
 
 class MigSharedPwCrypto(MigTestCase):
@@ -514,7 +514,7 @@ class MigSharedPwCrypto(MigTestCase):
         self.assertEqual(expected, result, "failed prepare aesgcm static iv")
 
     def test_prepare_aesgcm_aad_fixed(self):
-        """Test basic aesgcm additional auth dat preparation on a fixed
+        """Test basic aesgcm additional auth data preparation on a fixed
         entropy value.
         """
         expected = DUMMY_AESGCM_AAD

--- a/tests/test_mig_shared_pwcrypto.py
+++ b/tests/test_mig_shared_pwcrypto.py
@@ -113,6 +113,14 @@ class MigSharedPwCrypto(MigTestCase):
             site_login_methods=[DUMMY_SERVICE],
             site_signup_methods=[DUMMY_SERVICE],
         )
+        # TODO: fix the below pylint issue to make CI happy without this hack
+        # NOTE: for whatever reason pylint fails with Instance of
+        #       'FakeConfiguration' has no 'site_password_legacy_policy' member
+        #       (no-member) unless we explicitly (re-)init it here
+        self.dummy_conf.site_password_legacy_policy = getattr(
+            self.dummy_conf, 'site_password_legacy_policy', POLICY_NONE)
+        self.assertEqual(self.dummy_conf.site_password_legacy_policy,
+                         POLICY_MEDIUM)
 
     def test_best_crypt_salt(self):
         """Test selection of best salt based on salt availability in

--- a/tests/test_mig_shared_pwcrypto.py
+++ b/tests/test_mig_shared_pwcrypto.py
@@ -30,6 +30,7 @@
 import base64
 import os
 import sys
+import unittest
 
 from tests.support import MigTestCase, FakeConfiguration, \
     cleanpath, temppath, testmain
@@ -41,6 +42,7 @@ from mig.shared.pwcrypto import *
 
 DUMMY_USER = "dummy-user"
 DUMMY_ID = "dummy-id"
+# NOTE: these passwords are not and should not ever be used outside unit tests
 DUMMY_WEAK_PW = 'foobar'
 DUMMY_MEDIUM_PW = 'QZFnCp7h'
 DUMMY_HIGH_PW = 'QZFnp7I-GZ'
@@ -50,6 +52,19 @@ DUMMY_WEAK_PW_SHA256 = \
     "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"
 DUMMY_WEAK_PW_PBKDF2 = \
     "PBKDF2$sha256$10000$MDAwMDAwMDAwMDAw$epib2rEg/HYTQZFnCp7hmIGZ6rzHnViy"
+DUMMY_MEDIUM_PW_PBKDF2 = \
+    "PBKDF2$sha256$10000$ebQHnDX1rzY9Rizb$0vUJ9/4ThhsN4cRaKYmOj4N0YKEsozTr"
+DUMMY_HIGH_PW_PBKDF2 = \
+    "PBKDF2$sha256$10000$HR+KcqLyQe3v0WSk$CtxMAomi8JHiI7gWc/PH5Ey00zW1Now3"
+DUMMY_MODERN_PW_MD5 = "a06d169a171ef7d4383b212457162d93"
+DUMMY_MODERN_PW_SHA256 = \
+    "d293dcb9762c87641ea1decbfe76d84ec51b13d6a1e688cdf1a838eebc5bb1a9"
+DUMMY_MODERN_PW_PBKDF2 = \
+    "PBKDF2$sha256$10000$MDAwMDAwMDAwMDAw$B22uw6C7C4VFiYAe4Vf10n58FHrn1pjX"
+DUMMY_MODERN_PW_DIGEST = \
+    "DIGEST$custom$CONFSALT$64756D6D792D7265616C6D3A64756D6D792D7520DE71261F96A2FE48A67DD0877F2A2C"
+DUMMY_MODERN_PW_SCRAMBLE = "53BB031C1F96A2FE48A67DD0877F2A2C"
+DUMMY_MODERN_PW_RESET_TOKEN = b'gAAAAABo63hYqeHE7Db93pMxWn1sWzj2Z-6td2UhA5gKYa4KV096ndV-AO0pp6hrR9jXKcwWAouLCMiNC0BRudeCAYHoBii15lTRbP9b7JzvJjeusbidjRxqcJg0om6bbtSK1Rz_RBTq_jhdAk4v-7PccWlZ15dVJ4j-X3X4zSsBWIOR5y6Y-bA='
 DUMMY_HOME_DIR = 'dummy_user_home'
 DUMMY_SETTINGS_DIR = 'dummy_user_settings'
 # TODO: adjust password reset token helpers to handle configured services
@@ -57,7 +72,7 @@ DUMMY_SETTINGS_DIR = 'dummy_user_settings'
 # DUMMY_SERVICE = 'dummy-svc'
 DUMMY_SERVICE = 'migoid'
 DUMMY_REALM = 'dummy-realm'
-DUMMY_SALT = base64.b16encode(os.urandom(16))
+DUMMY_SALT = b'53BB031C4ECCE4900BD64AB8EA361B6B'
 
 
 class MigSharedPwCrypto(MigTestCase):
@@ -112,42 +127,36 @@ class MigSharedPwCrypto(MigTestCase):
         allow_modern = valid_login_password(self.dummy_conf, DUMMY_MODERN_PW)
         self.assertTrue(allow_modern, "refused login with modern pw")
 
-    def test_make_simple_hash_fixed_seed(self):
+    def test_make_simple_hash_fixed(self):
         """Test basic hashing of a fixed string to be constant"""
-        expected = DUMMY_WEAK_PW_MD5
-        actual = make_simple_hash(DUMMY_WEAK_PW)
+        expected = DUMMY_MODERN_PW_MD5
+        actual = make_simple_hash(DUMMY_MODERN_PW)
         self.assertEqual(actual, expected, "mismatch simple hash string")
 
     def test_make_simple_hash_constant_string(self):
-        """Test basic hashing of a fixed string to be constant for a particular
-        random seed. I.e. the value may differ across interpreter invocations
-        but remains constant in same interpreter.
-        """
-        first = make_simple_hash(DUMMY_WEAK_PW)
-        second = make_simple_hash(DUMMY_WEAK_PW)
+        """Test basic hashing of a fixed string to be constant"""
+        first = make_simple_hash(DUMMY_MODERN_PW)
+        second = make_simple_hash(DUMMY_MODERN_PW)
         self.assertEqual(first, second, "simple hashing is not constant")
 
-    def test_make_safe_hash_fixed_seed(self):
+    def test_make_safe_hash_fixed(self):
         """Test basic hashing of a fixed string to be constant"""
-        expected = DUMMY_WEAK_PW_SHA256
-        actual = make_safe_hash(DUMMY_WEAK_PW)
+        expected = DUMMY_MODERN_PW_SHA256
+        actual = make_safe_hash(DUMMY_MODERN_PW)
         self.assertEqual(actual, expected, "mismatch safe hash string")
 
     def test_make_safe_hash_constant_string(self):
-        """Test basic hashing of a fixed string to be constant for a particular
-        random seed. I.e. the value may differ across interpreter invocations
-        but remains constant in same interpreter.
-        """
-        first = make_safe_hash(DUMMY_WEAK_PW)
-        second = make_safe_hash(DUMMY_WEAK_PW)
+        """Test basic hashing of a fixed string to be constant"""
+        first = make_safe_hash(DUMMY_MODERN_PW)
+        second = make_safe_hash(DUMMY_MODERN_PW)
         self.assertEqual(first, second, "safe hashing is not constant")
 
     def test_make_hash_fixed_seed(self):
         """Test basic hashing of a fixed string to be constant for a fixed
         random seed.
         """
-        expected = DUMMY_WEAK_PW_PBKDF2
-        actual = make_hash(DUMMY_WEAK_PW, _urandom=lambda vlen: b'0' * vlen)
+        expected = DUMMY_MODERN_PW_PBKDF2
+        actual = make_hash(DUMMY_MODERN_PW, _urandom=lambda vlen: b'0' * vlen)
         self.assertEqual(actual, expected, "mismatch hashing string")
 
     def test_make_hash_constant_string(self):
@@ -155,15 +164,15 @@ class MigSharedPwCrypto(MigTestCase):
         random seed. I.e. the value may differ across interpreter invocations
         but remains constant in same interpreter.
         """
-        first = make_hash(DUMMY_WEAK_PW,
+        first = make_hash(DUMMY_MODERN_PW,
                           _urandom=lambda vlen: DUMMY_SALT[:vlen])
-        second = make_hash(DUMMY_WEAK_PW,
+        second = make_hash(DUMMY_MODERN_PW,
                            _urandom=lambda vlen: DUMMY_SALT[:vlen])
         self.assertEqual(first, second, "same seed hashing is not constant")
 
     def test_check_hash_reject_weak(self):
         """Test basic hash checking of a constant weak complexity password"""
-        expected = make_hash(DUMMY_WEAK_PW)
+        expected = DUMMY_WEAK_PW_PBKDF2
         result = check_hash(self.dummy_conf, DUMMY_SERVICE, DUMMY_USER,
                             DUMMY_WEAK_PW, expected, strict_policy=True)
         self.assertFalse(result, "check hash should fail on weak pw")
@@ -172,7 +181,7 @@ class MigSharedPwCrypto(MigTestCase):
         """Test basic hash checking of a constant medium complexity password
         without legacy password support.
         """
-        expected = make_hash(DUMMY_MEDIUM_PW)
+        expected = DUMMY_MEDIUM_PW_PBKDF2
         result = check_hash(self.dummy_conf, DUMMY_SERVICE, DUMMY_USER,
                             DUMMY_MEDIUM_PW, expected, strict_policy=True,
                             allow_legacy=False)
@@ -182,7 +191,7 @@ class MigSharedPwCrypto(MigTestCase):
         """Test basic hash checking of a constant medium complexity password
         with legacy password support.
         """
-        expected = make_hash(DUMMY_MEDIUM_PW)
+        expected = DUMMY_MEDIUM_PW_PBKDF2
         result = check_hash(self.dummy_conf, DUMMY_SERVICE, DUMMY_USER,
                             DUMMY_MEDIUM_PW, expected, strict_policy=True,
                             allow_legacy=True)
@@ -192,7 +201,7 @@ class MigSharedPwCrypto(MigTestCase):
         """Test basic hash checking of a constant high complexity password
         without legacy password support.
         """
-        expected = make_hash(DUMMY_HIGH_PW)
+        expected = DUMMY_HIGH_PW_PBKDF2
         self.dummy_conf.site_password_policy = POLICY_HIGH
         result = check_hash(self.dummy_conf, DUMMY_SERVICE, DUMMY_USER,
                             DUMMY_HIGH_PW, expected, strict_policy=True,
@@ -203,7 +212,7 @@ class MigSharedPwCrypto(MigTestCase):
         """Test basic hash checking of a constant modern complexity password
         without legacy password support.
         """
-        expected = make_hash(DUMMY_MODERN_PW)
+        expected = DUMMY_MODERN_PW_PBKDF2
         result = check_hash(self.dummy_conf, DUMMY_SERVICE, DUMMY_USER,
                             DUMMY_MODERN_PW, expected, strict_policy=True,
                             allow_legacy=False)
@@ -211,7 +220,7 @@ class MigSharedPwCrypto(MigTestCase):
 
     def test_check_hash_fixed(self):
         """Test basic hash checking of a fixed string"""
-        expected = make_hash(DUMMY_MEDIUM_PW)
+        expected = DUMMY_MEDIUM_PW_PBKDF2
         result = check_hash(self.dummy_conf, DUMMY_SERVICE, DUMMY_USER,
                             DUMMY_MEDIUM_PW, expected, strict_policy=True)
         self.assertFalse(result, "check hash should reject medium pw")
@@ -219,18 +228,18 @@ class MigSharedPwCrypto(MigTestCase):
                             DUMMY_MEDIUM_PW, expected, strict_policy=False,
                             allow_legacy=True)
         self.assertTrue(result, "check hash failed medium pw when not strict")
-        expected = make_hash(DUMMY_MODERN_PW)
+        expected = DUMMY_MODERN_PW_PBKDF2
         result = check_hash(self.dummy_conf, DUMMY_SERVICE, DUMMY_USER,
                             DUMMY_MODERN_PW, expected, strict_policy=True)
         self.assertTrue(result, "check hash failed modern pw")
 
     def test_check_hash_random(self):
-        """Test basic hash checking of a random string"""
+        """Test basic hashing and hash checking of a random string"""
         random_pw = generate_random_password(self.dummy_conf)
         expected = make_hash(random_pw)
         result = check_hash(self.dummy_conf, DUMMY_SERVICE, DUMMY_USER,
                             random_pw, expected)
-        self.assertTrue(result, "mismatch in random hash check")
+        self.assertTrue(result, "mismatch in random hash and check")
 
     def test_make_hash_variation(self):
         """Test how hashing of a fixed string varies depending on random seed.
@@ -259,23 +268,82 @@ class MigSharedPwCrypto(MigTestCase):
                             DUMMY_MODERN_PW, second)
         self.assertTrue(result, "mismatch in 2nd random password hash check")
 
-    def test_check_digest(self):
-        """Test basic digest checking of a random string"""
-        random_pw = generate_random_password(self.dummy_conf)
-        expected = make_digest(DUMMY_REALM, DUMMY_USER,
-                               DUMMY_MODERN_PW, DUMMY_SALT)
+    def test_make_digest_fixed(self):
+        """Test basic digest of a fixed string"""
+        expected = DUMMY_MODERN_PW_DIGEST
+        result = make_digest(DUMMY_REALM, DUMMY_USER, DUMMY_MODERN_PW,
+                             DUMMY_SALT)
+        self.assertEqual(expected, result, "mismatch in fixed digest")
+
+    def test_check_digest_fixed(self):
+        """Test basic digest checking of a fixed string"""
+        expected = DUMMY_MODERN_PW_DIGEST
         result = check_digest(self.dummy_conf, DUMMY_SERVICE, DUMMY_REALM,
                               DUMMY_USER, DUMMY_MODERN_PW, expected,
                               DUMMY_SALT)
-        self.assertTrue(result, "mismatch in digest check")
+        self.assertTrue(result, "mismatch in fixed digest check")
 
-    def test_check_scramble(self):
-        """Test basic scramble checking of a random string"""
+    def test_check_digest_random(self):
+        """Test basic digest checking of a random string"""
         random_pw = generate_random_password(self.dummy_conf)
-        expected = make_scramble(DUMMY_MODERN_PW, DUMMY_SALT)
+        random_salt = base64.b16encode(os.urandom(16))
+        expected = make_digest(DUMMY_REALM, DUMMY_USER, random_pw, random_salt)
+        result = check_digest(self.dummy_conf, DUMMY_SERVICE, DUMMY_REALM,
+                              DUMMY_USER, random_pw, expected, random_salt)
+        self.assertTrue(result, "mismatch in random digest check")
+
+    def test_digest_constant_string(self):
+        """Test basic digest of a fixed string to be constant for a particular
+        random seed. I.e. the value may differ across interpreter invocations
+        but remains constant in same interpreter.
+        """
+        first = make_digest(DUMMY_REALM, DUMMY_USER, DUMMY_MODERN_PW,
+                            DUMMY_SALT)
+        second = make_digest(DUMMY_REALM, DUMMY_USER, DUMMY_MODERN_PW,
+                             DUMMY_SALT)
+        self.assertEqual(first, second, "basic digest is not constant")
+
+    def test_scramble_password_fixed(self):
+        """Test basic scramble of a fixed string to be constant"""
+        expected = DUMMY_MODERN_PW_SCRAMBLE
+        actual = scramble_password(DUMMY_SALT, DUMMY_MODERN_PW)
+        self.assertEqual(actual, expected, "mismatch scramble pw string")
+
+    def test_unscramble_password_fixed(self):
+        """Test basic unscramble of a fixed string to be constant"""
+        expected = DUMMY_MODERN_PW
+        actual = unscramble_password(DUMMY_SALT, DUMMY_MODERN_PW_SCRAMBLE)
+        self.assertEqual(actual, expected, "mismatch unscramble pw string")
+
+    def test_make_scramble_fixed(self):
+        """Test basic scramble of a fixed string to be constant"""
+        expected = DUMMY_MODERN_PW_SCRAMBLE
+        actual = make_scramble(DUMMY_MODERN_PW, DUMMY_SALT)
+        self.assertEqual(actual, expected, "mismatch make scramble string")
+
+    def test_check_scramble_fixed(self):
+        """Test basic scramble checking of a fixed string"""
+        expected = DUMMY_MODERN_PW_SCRAMBLE
         result = check_scramble(self.dummy_conf, DUMMY_SERVICE, DUMMY_USER,
                                 DUMMY_MODERN_PW, expected, DUMMY_SALT)
-        self.assertTrue(result, "mismatch in scramble check")
+        self.assertTrue(result, "mismatch in fixed scramble check")
+
+    def test_check_scramble_random(self):
+        """Test basic scramble checking of a random string"""
+        random_pw = generate_random_password(self.dummy_conf)
+        random_salt = base64.b16encode(os.urandom(16))
+        expected = make_scramble(DUMMY_MODERN_PW, random_salt)
+        result = check_scramble(self.dummy_conf, DUMMY_SERVICE, DUMMY_USER,
+                                DUMMY_MODERN_PW, expected, random_salt)
+        self.assertTrue(result, "mismatch in random scramble check")
+
+    def test_scramble_constant_string(self):
+        """Test basic scramble of a fixed string to be constant for a particular
+        salt.
+        """
+        first = make_scramble(DUMMY_MODERN_PW, DUMMY_SALT)
+        second = make_scramble(DUMMY_MODERN_PW, DUMMY_SALT)
+        self.assertEqual(first, second, "basic scramble is not constant")
 
     def test_fernet_encrypt_decrypt(self):
         """Test basic fernet password encrypt and decrypt on a random string"""
@@ -343,6 +411,39 @@ class MigSharedPwCrypto(MigTestCase):
         result = check_encrypt(self.dummy_conf, DUMMY_SERVICE, DUMMY_USER,
                                random_pw, encrypted, algo='aesgcm_static')
         self.assertTrue(result, "mismatch in aesgcm_static encrypt check")
+
+    @unittest.skipIf(True, "requires constant random seed")
+    def test_generate_reset_token_fixed(self):
+        """Test basic password reset token generate for a fixed string"""
+        dummy_user = {'distinguished_name': DUMMY_USER}
+        dummy_user['password_hash'] = DUMMY_MODERN_PW_PBKDF2
+        timestamp = 42
+        expected = DUMMY_MODERN_PW_RESET_TOKEN
+        result = generate_reset_token(self.dummy_conf, dummy_user,
+                                      DUMMY_SERVICE, timestamp)
+        self.assertEqual(expected, result,
+                         "failed generate password reset token")
+
+    @unittest.skipIf(True, "requires constant random seed")
+    def test_parse_reset_token_fixed(self):
+        """Test basic password reset token parse for a fixed string"""
+        timestamp = 42
+        result = parse_reset_token(self.dummy_conf, DUMMY_MODERN_PW_RESET_TOKEN,
+                                   DUMMY_SERVICE)
+        self.assertEqual(result[0], timestamp, "failed parse token time")
+        self.assertEqual(result[1], DUMMY_MODERN_PW_PBKDF2,
+                         "failed parse token hash")
+
+    @unittest.skipIf(True, "requires constant random seed")
+    def test_verify_reset_token_fixed(self):
+        """Test basic password reset token verify for a fixed string"""
+        dummy_user = {'distinguished_name': DUMMY_USER}
+        dummy_user['password_hash'] = DUMMY_MODERN_PW_PBKDF2
+        timestamp = 42
+        result = verify_reset_token(self.dummy_conf, dummy_user,
+                                    DUMMY_MODERN_PW_RESET_TOKEN,
+                                    DUMMY_SERVICE, timestamp)
+        self.assertTrue(result, "failed password reset token handling")
 
     def test_password_reset_token_generate_and_verify(self):
         """Test basic password reset token generate and verify helper"""


### PR DESCRIPTION
Significantly improve test coverage and add fixed string checks for basic functionality of several of the `pwcrypto` helper functions as suggested by @albu-diku in the comments to PR #343 . 
Some of the new tests require adjustment of the helper functions to expose the random seed as argument, so they have been left disabled with **TODO** markers for now.