### PR TITLE
Add support for letting janitor accept authenticated account renewal requests

### DIFF
--- a/mig/lib/janitor.py
+++ b/mig/lib/janitor.py
@@ -263,6 +263,7 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
     req_expire = req_dict.get("expire", now)
     user_dict = load_user_dict(_logger, client_id, db_path)
     req_invalid = req_dict.get("invalid", None)
+    authorized = req_dict.get("authorized", False)
     reset_token = req_dict.get("reset_token", "")
     req_auth = req_dict.get("auth", ["migoid"])[-1]
     auth_type = req_auth.lstrip("mig").lstrip("ext")
@@ -288,6 +289,17 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
             )
         else:
             _logger.info("rejected invalid %r account request" % client_id)
+    elif authorized:
+        _logger.info("%r requested renew and authorized password change" %
+                     client_id)
+        peer_id = user_dict.get("peers", [None])[0]
+        if accept_account_req(req_id, configuration, peer_id,
+                              user_copy=user_copy, admin_copy=admin_copy,
+                              auth_type=auth_type,
+                              default_renew=default_renew):
+            _logger.info("accepted authorized %r access renew" % client_id)
+        else:
+            _logger.warning("failed authorized %r access renew" % client_id)
     elif reset_token:
         # TODO: handle loaded user_dict == None here (e.g. recently removed)
         #       to avoid verify_reset_token failing on DN access.

--- a/mig/lib/janitor.py
+++ b/mig/lib/janitor.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # janitor - janitor helpers to handle recurring clean up and update tasks
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -293,6 +293,8 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
         _logger.info("%r requested renew and authorized password change" %
                      client_id)
         peer_id = user_dict.get("peers", [None])[0]
+        # NOTE: let authorized reqs (with valid peer) renew even with pw change
+        default_renew = True
         if accept_account_req(req_id, configuration, peer_id,
                               user_copy=user_copy, admin_copy=admin_copy,
                               auth_type=auth_type,

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -611,7 +611,6 @@ class MigLibJanitor(MigTestCase):
         self.assertFalse(os.path.exists(req_path),
                          "Failed cleanup collision for %s" % req_path)
 
-    @unittest.skip("TODO: enable once janitor handles auth change reqs")
     def test_manage_single_req_auth_change(self):
         """Test request handling with auth password change"""
         req_dict = {

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -837,6 +837,8 @@ class MigLibJanitor(MigTestCase):
 
         self.assertTrue(any('accepted' in msg.lower()
                             for msg in log_capture.output))
+        self.assertFalse(os.path.exists(req_path),
+                         "Failed cleanup invalid token for %s" % req_path)
 
     def test_remind_and_expire_edge_cases(self):
         """Test request expiration with exact boundary timestamps"""


### PR DESCRIPTION
Add support for letting janitor accept authenticated account renewal requests with optional password change, that is, account requests submitted while explicitly logged in. Useful to let users change password directly while their account access is still active.

NOTE: this is tested to work in practice and we explicitly only add the `authorized` field if authenticated `client_id` matches the request user ID. 