### PR TITLE
Improved unit test coverage of mig lib daemon

### DIFF
--- a/mig/lib/daemon.py
+++ b/mig/lib/daemon.py
@@ -68,6 +68,18 @@ def register_run_handler(configuration, run_signal=signal.SIGCONT):
     signal.signal(run_signal, run_handler)
 
 
+def unregister_signal_handlers(configuration, target_signals=None):
+    """Remove any handlers registered to react on provided target_signals list.
+    Default to SIGCONT, SIGUSR1 and SIGUSR2 if target_signals is left to None.
+    """
+    if target_signals is None:
+        target_signals = [signal.SIGCONT, signal.SIGUSR1, signal.SIGUSR2]
+    for target in target_signals:
+        original_handler = signal.getsignal(target)
+        if original_handler:
+            signal.signal(target, signal.SIG_IGN)
+
+
 def interruptible_sleep(configuration, max_secs, break_checks, nap_secs=0.1):
     """Idle loop for max_secs or until one or more break_checks succeed"""
     assert nap_secs > 0.0, "Invalid non-positive nap_secs value"

--- a/mig/lib/daemon.py
+++ b/mig/lib/daemon.py
@@ -70,7 +70,9 @@ def register_run_handler(configuration, run_signal=signal.SIGCONT):
 
 def interruptible_sleep(configuration, max_secs, break_checks, nap_secs=0.1):
     """Idle loop for max_secs or until one or more break_checks succeed"""
-    assert max_secs >= nap_secs, "Invalid max_secs value smaller than nap_secs"
+    assert nap_secs > 0.0, "Invalid non-positive nap_secs value"
+    if max_secs < nap_secs:
+        return
     for _ in range(int(max_secs / nap_secs)):
         for check in break_checks:
             if check():

--- a/tests/test_mig_lib_daemon.py
+++ b/tests/test_mig_lib_daemon.py
@@ -27,27 +27,38 @@
 
 """Unit tests for the migrid module pointed to in the filename"""
 
+import os
 import signal
 import time
 
-from tests.support import MigTestCase
+from tests.support import FakeConfiguration, MigTestCase
 
-from mig.lib.daemon import check_run, check_stop, do_run, interruptible_sleep, \
-    register_run_handler, register_stop_handler, stop_running
+from mig.lib.daemon import _run_event, _stop_event, check_run, check_stop, \
+    do_run, reset_run, reset_stop, stop_running, interruptible_sleep, \
+    register_run_handler, register_stop_handler, run_handler, stop_handler
 
 
 class MigLibDaemon(MigTestCase):
     """Unit tests for daemon related helper functions"""
 
+    def before_each(self):
+        """Set up test configuration and reset state before each test"""
+
+        # Create fake configuration, sig and frame for test isolation
+        self.dummy_conf = FakeConfiguration()
+        self.sig = None
+        self.frame = None
+
+        # Reset event states
+        reset_run()
+        reset_stop()
+
     def test_register_run_handler_manual(self):
         """Register a run handler and verify it can be manually overriden to
         mark early run.
         """
-
-        # We don't actually need a configuration here so just pass None
-        configuration = None
         # It's easier to test with alarm than the usual interrupt signal
-        register_run_handler(configuration, run_signal=signal.SIGALRM)
+        register_run_handler(self.dummy_conf, run_signal=signal.SIGALRM)
         self.assertFalse(check_run())
         signal.alarm(3)
         time.sleep(1)
@@ -56,11 +67,8 @@ class MigLibDaemon(MigTestCase):
 
     def test_register_run_handler_signal(self):
         """Register a run handler and verify it can be used to trigger run"""
-
-        # We don't actually need a configuration here so just pass None
-        configuration = None
         # It's easier to test with alarm than the usual interrupt signal
-        register_run_handler(configuration, run_signal=signal.SIGALRM)
+        register_run_handler(self.dummy_conf, run_signal=signal.SIGALRM)
         self.assertFalse(check_run())
         signal.alarm(1)
         time.sleep(1)
@@ -70,16 +78,13 @@ class MigLibDaemon(MigTestCase):
         """Register a run handler and verify it can be used for interruptible
         sleep to let daemon be responsive when needed.
         """
-
-        # We don't actually need a configuration here so just pass None
-        configuration = None
         # It's easier to test with alarm than the usual interrupt signal
-        register_run_handler(configuration, run_signal=signal.SIGALRM)
+        register_run_handler(self.dummy_conf, run_signal=signal.SIGALRM)
         self.assertFalse(check_run())
         max_secs = 4.2
         start = time.time()
         signal.alarm(1)
-        interruptible_sleep(configuration, max_secs, (check_run, ))
+        interruptible_sleep(self.dummy_conf, max_secs, (check_run, ))
         self.assertTrue(check_run())
         end = time.time()
         self.assertTrue(end < start + max_secs)
@@ -88,11 +93,8 @@ class MigLibDaemon(MigTestCase):
         """Register a stop handler and verify it can be manually overriden to
         mark early stop.
         """
-
-        # We don't actually need a configuration here so just pass None
-        configuration = None
         # It's easier to test with alarm than the usual interrupt signal
-        register_stop_handler(configuration, stop_signal=signal.SIGALRM)
+        register_stop_handler(self.dummy_conf, stop_signal=signal.SIGALRM)
         self.assertFalse(check_stop())
         signal.alarm(3)
         time.sleep(1)
@@ -103,12 +105,205 @@ class MigLibDaemon(MigTestCase):
         """Register a stop handler and verify it can be used to mark stop upon
         receiving the signal registered.
         """
-
-        # We don't actually need a configuration here so just pass None
-        configuration = None
         # It's easier to test with alarm than the usual interrupt signal
-        register_stop_handler(configuration, stop_signal=signal.SIGALRM)
+        register_stop_handler(self.dummy_conf, stop_signal=signal.SIGALRM)
         self.assertFalse(check_stop())
         signal.alarm(1)
         time.sleep(1)
         self.assertTrue(check_stop())
+
+    def test_low_level_event_helpers(self):
+        """Test basic event control helpers"""
+        # Initial state
+        self.assertFalse(check_run())
+        self.assertFalse(check_stop())
+
+        # Test manual run control
+        do_run()
+        self.assertTrue(check_run())
+        reset_run()
+        self.assertFalse(check_run())
+
+        # Test manual stop control
+        stop_running()
+        self.assertTrue(check_stop())
+        reset_stop()
+        self.assertFalse(check_stop())
+
+    def test_run_handler_direct(self):
+        """Test run handler directly without signals"""
+        self.assertFalse(check_run())
+        run_handler(self.sig, self.frame)
+        self.assertTrue(check_run())
+        # Verify repeated triggering
+        run_handler(self.sig, self.frame)
+        self.assertTrue(check_run())
+
+    def test_stop_handler_direct(self):
+        """Test stop handler directly without signals"""
+        self.assertFalse(check_stop())
+        stop_handler(self.sig, self.frame)
+        self.assertTrue(check_stop())
+        # Verify repeated triggering
+        stop_handler(self.sig, self.frame)
+        self.assertTrue(check_stop())
+
+    def test_interruptible_sleep_edge_cases(self):
+        """Test interruptible_sleep with edge case parameters"""
+        # Should complete instantly since max_secs == nap_secs
+        start = time.time()
+        interruptible_sleep(self.dummy_conf, 0.01, [], nap_secs=0.05)
+        self.assertTrue(time.time() - start < 0.05)
+
+        # Test zero max_secs
+        interruptible_sleep(self.dummy_conf, 0.0, [])
+        interruptible_sleep(self.dummy_conf, -1.0, [])
+
+    def test_interruptible_sleep_multiple_conditions(self):
+        """Test interruptible_sleep with multiple break conditions"""
+        conditions = [
+            lambda: False,
+            lambda: False,
+            lambda: True,  # This triggers break
+        ]
+        start = time.time()
+        interruptible_sleep(self.dummy_conf, 5.0, conditions)
+        self.assertTrue(time.time() - start < 0.2)
+
+    def test_handler_registration_conflict(self):
+        """Test registering handlers with conflicting signals"""
+        # First register USR1 for both handlers
+        register_run_handler(self.dummy_conf, signal.SIGUSR1)
+        register_stop_handler(self.dummy_conf, signal.SIGUSR1)
+
+        # Should still work
+        signal.alarm(1)
+        time.sleep(0.5)
+        register_run_handler(self.dummy_conf, signal.SIGUSR2)
+        register_stop_handler(self.dummy_conf, signal.SIGUSR2)
+
+    def test_concurrent_event_handling(self):
+        """Test concurrent event triggers and state maintenance"""
+        # Setup both handlers
+        self.assertFalse(check_run())
+        self.assertFalse(check_stop())
+        register_run_handler(self.dummy_conf, signal.SIGCONT)
+        register_stop_handler(self.dummy_conf, signal.SIGINT)
+        os.kill(os.getpid(), signal.SIGCONT)
+        os.kill(os.getpid(), signal.SIGINT)
+        time.sleep(0.3)
+        self.assertTrue(check_run())
+        self.assertTrue(check_stop())
+
+        # Verify safe reset
+        reset_run()
+        reset_stop()
+        self.assertFalse(check_run())
+        self.assertFalse(check_stop())
+
+    def test_interruptible_sleep_immediate_break(self):
+        """Test interruptible_sleep with immediate break condition"""
+        def immediate_true():
+            return True
+
+        start = time.time()
+        interruptible_sleep(self.dummy_conf, 5.0, [immediate_true])
+        duration = time.time() - start
+        self.assertTrue(duration < 0.1,
+                        "Sleep should exit immediately but took %s" % duration)
+
+    def test_reset_event_helpers(self):
+        """Test simple event reset helpers"""
+        # Manually set events
+        _run_event.set()
+        _stop_event.set()
+        self.assertTrue(check_run())
+        self.assertTrue(check_stop())
+
+        reset_run()
+        reset_stop()
+        self.assertFalse(check_run())
+        self.assertFalse(check_stop())
+
+    def test_invalid_nap_secs(self):
+        """Test invalid nap_secs parameter"""
+        with self.assertRaises(AssertionError):
+            interruptible_sleep(self.dummy_conf, 0.5, [], nap_secs=-1.0)
+
+    def test_event_state_persistence(self):
+        """Test event states persist across multiple checks"""
+        do_run()
+        self.assertTrue(check_run())
+        # Repeated checks should maintain state
+        self.assertTrue(check_run())
+
+        stop_running()
+        self.assertTrue(check_stop())
+        self.assertTrue(check_stop())
+
+    def test_signal_handler_dispatch(self):
+        """Verify signal handlers dispatch correct signals"""
+        test_signals = {
+            'run': [signal.SIGUSR1],
+            'stop': [signal.SIGUSR2]
+        }
+
+        for func, sigs in [(register_run_handler, test_signals['run']),
+                           (register_stop_handler, test_signals['stop'])]:
+            for sig in sigs:
+                func(self.dummy_conf, sig)
+                # Verify handler registration
+                dispatch = signal.getsignal(sig)
+                if func == register_run_handler:
+                    self.assertEqual(dispatch.__name__, 'run_handler')
+                else:
+                    self.assertEqual(dispatch.__name__, 'stop_handler')
+
+    def test_event_set_unset_lifecycle(self):
+        """Verify full event lifecycle"""
+        for func in (do_run, stop_running):
+            func()
+            if func == do_run:
+                self.assertTrue(check_run())
+                reset_run()
+                self.assertFalse(check_run())
+            else:
+                self.assertTrue(check_stop())
+                reset_stop()
+                self.assertFalse(check_stop())
+
+    def test_multiple_reset_cycles(self):
+        """Test running multiple reset/manipulation cycles"""
+        for _ in range(5):
+            # Run through full event lifecycle
+            self.assertFalse(check_run())
+            do_run()
+            self.assertTrue(check_run())
+            reset_run()
+            self.assertFalse(check_run())
+
+            self.assertFalse(check_stop())
+            stop_running()
+            self.assertTrue(check_stop())
+            reset_stop()
+            self.assertFalse(check_stop())
+
+    def test_interruptible_sleep_nap_accuracy(self):
+        """Verify nap timing accuracy in sleep function"""
+        start = time.time()
+        interruptible_sleep(self.dummy_conf, 0.3, [], nap_secs=0.1)
+        duration = time.time() - start
+        # Should be ~0.3 secs +/- 0.1 tolerance
+        self.assertAlmostEqual(duration, 0.3, delta=0.1)
+
+    def test_interruptible_sleep_no_break_conditions(self):
+        """Test sleep with no break conditions"""
+        start = time.time()
+        interruptible_sleep(self.dummy_conf, 0.2, [])
+        duration = time.time() - start
+        self.assertAlmostEqual(duration, 0.2, delta=0.05)
+
+    def test_interruptible_sleep_invalid_break_conditions(self):
+        """Test sleep with improperly formatted break conditions"""
+        with self.assertRaises(TypeError):
+            interruptible_sleep(self.dummy_conf, 0.2, [None])

--- a/tests/test_mig_lib_daemon.py
+++ b/tests/test_mig_lib_daemon.py
@@ -433,7 +433,7 @@ class MigLibDaemon(MigTestCase):
         # Contains both valid and invalid break check items
         checks = [lambda: True, "not-callable"]
         start = time.time()
-        result = interruptible_sleep(self.configuration, 0.1, checks)
+        interruptible_sleep(self.configuration, 0.1, checks)
         duration = time.time() - start
         # Should complete when valid condition returns True
         self.assertTrue(duration < 0.05)
@@ -460,8 +460,7 @@ class MigLibDaemon(MigTestCase):
         """Test interruptible_sleep counts down remaining naps correctly"""
         checks = [lambda: False]
         start = time.time()
-        result = interruptible_sleep(
-            self.configuration, 0.25, checks, nap_secs=0.1)
+        interruptible_sleep(self.configuration, 0.25, checks, nap_secs=0.1)
         duration = time.time() - start
         # 2*0.1=0.2 < 0.25, 3*0.1=0.3 >0.25 -> should do 3rd nap with 0.05 actual sleep
         self.assertAlmostEqual(duration, 0.25, delta=0.05)

--- a/tests/test_mig_lib_daemon.py
+++ b/tests/test_mig_lib_daemon.py
@@ -232,8 +232,12 @@ class MigLibDaemon(MigTestCase):
         self.assertTrue(time.time() - start < 0.05)
 
         # Test zero and negative max_secs returns immediately
+        start = time.time()
         interruptible_sleep(self.configuration, 0.0, [])
+        self.assertTrue(time.time() - start < 0.01)
+        start = time.time()
         interruptible_sleep(self.configuration, -1.0, [])
+        self.assertTrue(time.time() - start < 0.01)
 
     def test_interruptible_sleep_multiple_conditions(self):
         """Test interruptible_sleep with multiple break conditions"""

--- a/tests/test_mig_lib_daemon.py
+++ b/tests/test_mig_lib_daemon.py
@@ -85,8 +85,8 @@ class MigLibDaemon(MigTestCase):
         self.assertTrue(check_run())
 
     def test_interruptible_sleep(self):
-        """Register a run handler and verify it can be used for interruptible
-        sleep to let daemon be responsive when needed.
+        """Register a run handler and verify it can be used for idle looping.
+        That is, interruptible sleep to let daemon be responsive when needed.
         """
         # It's easier to test with alarm than the usual interrupt signal
         register_run_handler(self.configuration, run_signal=signal.SIGALRM)
@@ -97,7 +97,7 @@ class MigLibDaemon(MigTestCase):
         interruptible_sleep(self.configuration, max_secs, (check_run, ))
         self.assertTrue(check_run())
         end = time.time()
-        self.assertTrue(end < start + max_secs)
+        self.assertTrue(end - start < max_secs)
 
     def test_register_stop_handler_manual(self):
         """Register a stop handler and verify it can be manually overriden to
@@ -230,6 +230,13 @@ class MigLibDaemon(MigTestCase):
         start = time.time()
         interruptible_sleep(self.configuration, 0.01, [], nap_secs=0.05)
         self.assertTrue(time.time() - start < 0.05)
+
+        # Similar test with max_secs = nap_secs
+        start = time.time()
+        interruptible_sleep(self.configuration, 0.05, [], nap_secs=0.05)
+        # Takes 0.05 sec but completes normally
+        self.assertTrue(time.time() - start >= 0.05)
+        self.assertTrue(time.time() - start < 0.06)
 
         # Test zero and negative max_secs returns immediately
         start = time.time()
@@ -380,6 +387,84 @@ class MigLibDaemon(MigTestCase):
             self.logger.check_empty_and_reset()
         except RuntimeError as rte:
             self.assertTrue(SLEEP_ERR in str(rte), "failed sleep break exc")
+
+    def test_unregister_default_signals(self):
+        """Test unregister_signal_handlers with default target_signals"""
+        # First register handlers on default and custom signals
+        register_run_handler(self.configuration, signal.SIGCONT)
+        register_stop_handler(self.configuration, signal.SIGUSR2)
+        register_run_handler(self.configuration, signal.SIGINT)
+        register_stop_handler(self.configuration, signal.SIGALRM)
+        # Now unregister with overlapping default signals
+        unregister_signal_handlers(self.configuration, target_signals=None)
+
+        # Verify default signals were unregistered
+        self.assertEqual(signal.getsignal(signal.SIGCONT), signal.SIG_IGN)
+        self.assertEqual(signal.getsignal(signal.SIGUSR2), signal.SIG_IGN)
+        # Verify custom signals remain after default unregister
+        self.assertEqual(signal.getsignal(signal.SIGINT).__name__,
+                         'run_handler')
+        self.assertEqual(signal.getsignal(signal.SIGALRM).__name__,
+                         'stop_handler')
+
+    def test_register_default_signal(self):
+        """Test handler registration with default signal values"""
+        # Run handler should default to SIGCONT
+        register_run_handler(self.configuration)
+        self.assertEqual(signal.getsignal(signal.SIGCONT).__name__,
+                         'run_handler')
+
+        # Stop handler should default to SIGINT
+        register_stop_handler(self.configuration)
+        self.assertEqual(signal.getsignal(signal.SIGINT).__name__,
+                         'stop_handler')
+
+    def test_reset_unregistered_signals(self):
+        """Test unregister responds gracefully to previously unregistered signals"""
+        self.assertEqual(signal.getsignal(signal.SIGCONT), signal.SIG_IGN)
+        unregister_signal_handlers(self.configuration, [signal.SIGCONT])
+        self.assertEqual(signal.getsignal(signal.SIGCONT), signal.SIG_IGN)
+        # Should succeed even though not registered
+        unregister_signal_handlers(self.configuration, [signal.SIGCONT])
+        self.assertEqual(signal.getsignal(signal.SIGCONT), signal.SIG_IGN)
+
+    def test_interruptible_sleep_break_not_callable(self):
+        """Test interruptible_sleep ignores non-callable break conditions"""
+        # Contains both valid and invalid break check items
+        checks = [lambda: True, "not-callable"]
+        start = time.time()
+        result = interruptible_sleep(self.configuration, 0.1, checks)
+        duration = time.time() - start
+        # Should complete when valid condition returns True
+        self.assertTrue(duration < 0.05)
+
+    def test_interruptible_sleep_all_conditions_checked(self):
+        """Verify all break conditions are checked each sleep interval"""
+        counter = {'count': 0}
+        max_checks = 3
+
+        def counter_condition():
+            if counter['count'] < max_checks:
+                counter['count'] += 1
+            return counter['count'] >= max_checks
+
+        start = time.time()
+        interruptible_sleep(self.configuration, 5.0, [counter_condition],
+                            nap_secs=0.1)
+        duration = time.time() - start
+        # Should run for ~0.3 sec (3 naps of 0.1 sec)
+        self.assertAlmostEqual(duration, 0.3, delta=0.15)
+        self.assertEqual(counter['count'], max_checks)
+
+    def test_interruptible_sleep_naps_remaining(self):
+        """Test interruptible_sleep counts down remaining naps correctly"""
+        checks = [lambda: False]
+        start = time.time()
+        result = interruptible_sleep(
+            self.configuration, 0.25, checks, nap_secs=0.1)
+        duration = time.time() - start
+        # 2*0.1=0.2 < 0.25, 3*0.1=0.3 >0.25 -> should do 3rd nap with 0.05 actual sleep
+        self.assertAlmostEqual(duration, 0.25, delta=0.05)
 
     def test_reset_run(self):
         """Test reset_run helper"""

--- a/tests/test_mig_lib_daemon.py
+++ b/tests/test_mig_lib_daemon.py
@@ -35,7 +35,7 @@ from mig.lib.daemon import _run_event, _stop_event, check_run, check_stop, \
     do_run, interruptible_sleep, register_run_handler, register_stop_handler, \
     reset_run, reset_stop, run_handler, stop_handler, stop_running, \
     unregister_signal_handlers
-from tests.support import FakeConfiguration, MigTestCase
+from tests.support import FakeConfiguration, FakeLogger, MigTestCase
 
 
 class MigLibDaemon(MigTestCase):
@@ -46,6 +46,7 @@ class MigLibDaemon(MigTestCase):
 
         # Create fake configuration, sig and frame for test isolation
         self.dummy_conf = FakeConfiguration()
+        self.dummy_conf.logger = FakeLogger()
         self.sig = None
         self.frame = None
 
@@ -55,7 +56,7 @@ class MigLibDaemon(MigTestCase):
 
         # Unregister any existing signal handlers
         used_signals = [signal.SIGCONT, signal.SIGINT, signal.SIGALRM,
-                        signal.SIGUSR1, signal.SIGUSR2]
+                        signal.SIGABRT, signal.SIGUSR1, signal.SIGUSR2]
         unregister_signal_handlers(self.dummy_conf, used_signals)
 
     def test_register_run_handler_manual(self):
@@ -194,7 +195,7 @@ class MigLibDaemon(MigTestCase):
         self.assertFalse(check_run())
         self.assertFalse(check_stop())
 
-        # Restore original handlers to avoid test pollution
+        # Restore original handlers to avoid test pollution, even if not needed
         signal.signal(signal.SIGCONT, original_cont)
         signal.signal(signal.SIGINT, original_int)
 
@@ -221,12 +222,12 @@ class MigLibDaemon(MigTestCase):
 
     def test_interruptible_sleep_edge_cases(self):
         """Test interruptible_sleep with edge case parameters"""
-        # Should complete instantly since max_secs == nap_secs
+        # Should complete instantly since max_secs < nap_secs
         start = time.time()
         interruptible_sleep(self.dummy_conf, 0.01, [], nap_secs=0.05)
         self.assertTrue(time.time() - start < 0.05)
 
-        # Test zero max_secs
+        # Test zero and negative max_secs returns immediately
         interruptible_sleep(self.dummy_conf, 0.0, [])
         interruptible_sleep(self.dummy_conf, -1.0, [])
 
@@ -300,6 +301,103 @@ class MigLibDaemon(MigTestCase):
         """Test invalid nap_secs parameter"""
         with self.assertRaises(AssertionError):
             interruptible_sleep(self.dummy_conf, 0.5, [], nap_secs=-1.0)
+
+    def test_unregister_signal_handlers_explicit(self):
+        """Test explicit unregistration of signal handlers"""
+        # Register handlers first
+        register_run_handler(self.dummy_conf, signal.SIGALRM)
+        register_stop_handler(self.dummy_conf, signal.SIGABRT)
+
+        # Verify handlers were set
+        self.assertEqual(signal.getsignal(
+            signal.SIGALRM).__name__, 'run_handler')
+        self.assertEqual(signal.getsignal(
+            signal.SIGABRT).__name__, 'stop_handler')
+
+        # Unregister specific signals
+        unregister_signal_handlers(
+            self.dummy_conf, [signal.SIGALRM, signal.SIGABRT])
+        self.assertEqual(signal.getsignal(signal.SIGALRM), signal.SIG_IGN)
+        self.assertEqual(signal.getsignal(signal.SIGABRT), signal.SIG_IGN)
+
+    def test_interruptible_sleep_condition_after_interval(self):
+        """Test interruptible_sleep break condition after one interval"""
+        state = {'count': 0}
+
+        def counter_condition():
+            state['count'] += 1
+            return state['count'] >= 2
+
+        start = time.time()
+        interruptible_sleep(self.dummy_conf, 5.0, [
+                            counter_condition], nap_secs=0.1)
+        duration = time.time() - start
+        self.assertAlmostEqual(duration, 0.2, delta=0.15)
+
+    def test_interruptible_sleep_maxsecs_equals_napsecs(self):
+        """Test interruptible_sleep with max_secs exactly matching nap_secs"""
+        start = time.time()
+        interruptible_sleep(self.dummy_conf, 0.1, [lambda: False],
+                            nap_secs=0.1)
+        duration = time.time() - start
+        self.assertAlmostEqual(duration, 0.1, delta=0.05)
+
+    def test_interruptible_sleep_break_func_exception(self):
+        """Test interruptible_sleep handles break function exceptions"""
+
+        SLEEP_ERR = "Sleep Test Error"
+
+        def faulty_condition():
+            self.dummy_conf.logger.error(SLEEP_ERR)
+
+        start = time.time()
+        interruptible_sleep(self.dummy_conf, 0.1, [faulty_condition],
+                            nap_secs=0.01)
+        duration = time.time() - start
+        self.assertAlmostEqual(duration, 0.1, delta=0.05)
+        try:
+            self.dummy_conf.logger.check_empty_and_reset()
+        except RuntimeError as rte:
+            self.assertTrue(SLEEP_ERR in str(rte), "failed sleep break exc")
+
+    def test_reset_run(self):
+        """Test reset_run helper"""
+        do_run()
+        self.assertTrue(check_run())
+        reset_run()
+        self.assertFalse(check_run())
+
+    def test_reset_stop(self):
+        """Test reset_stop helper"""
+        stop_running()
+        self.assertTrue(check_stop())
+        reset_stop()
+        self.assertFalse(check_stop())
+
+    def test_do_run(self):
+        """Test explicit execution of do_run helper"""
+        self.assertFalse(check_run())
+        do_run()
+        self.assertTrue(check_run())
+
+    def test_stop_running(self):
+        """Test explicit execution of stop_running helper"""
+        self.assertFalse(check_stop())
+        stop_running()
+        self.assertTrue(check_stop())
+
+    def test_signal_handlers_with_real_signals(self):
+        """Test signal handlers with real signal delivery"""
+        register_run_handler(self.dummy_conf, signal.SIGUSR1)
+        register_stop_handler(self.dummy_conf, signal.SIGUSR2)
+
+        os.kill(os.getpid(), signal.SIGUSR1)
+        time.sleep(0.1)
+        self.assertTrue(check_run())
+
+        os.kill(os.getpid(), signal.SIGUSR2)
+        time.sleep(0.1)
+        self.assertTrue(check_stop())
 
     def test_event_state_persistence(self):
         """Test event states persist across multiple checks"""

--- a/tests/test_mig_lib_daemon.py
+++ b/tests/test_mig_lib_daemon.py
@@ -41,30 +41,34 @@ from tests.support import FakeConfiguration, FakeLogger, MigTestCase
 class MigLibDaemon(MigTestCase):
     """Unit tests for daemon related helper functions"""
 
-    def before_each(self):
-        """Set up test configuration and reset state before each test"""
+    # Signals registered across the tests and explicitly unregistered on init
+    _used_signals = [signal.SIGCONT, signal.SIGINT, signal.SIGALRM,
+                     signal.SIGABRT, signal.SIGUSR1, signal.SIGUSR2]
 
-        # Create fake configuration, sig and frame for test isolation
-        self.dummy_conf = FakeConfiguration()
-        self.dummy_conf.logger = FakeLogger()
-        self.sig = None
-        self.frame = None
+    def _provide_configuration(self):
+        """Set up isolated test configuration and logger for the tests"""
+        return 'testconfig'
+
+    def before_each(self):
+        """Set up any test configuration and reset state before each test"""
+
+        # Create dummy sig and frame values for isolated test use
+        self.sig = 'SIGNAL'
+        self.frame = 'FRAME'
 
         # Reset event states
         reset_run()
         reset_stop()
 
         # Unregister any existing signal handlers
-        used_signals = [signal.SIGCONT, signal.SIGINT, signal.SIGALRM,
-                        signal.SIGABRT, signal.SIGUSR1, signal.SIGUSR2]
-        unregister_signal_handlers(self.dummy_conf, used_signals)
+        unregister_signal_handlers(self.configuration, self._used_signals)
 
     def test_register_run_handler_manual(self):
         """Register a run handler and verify it can be manually overriden to
         mark early run.
         """
         # It's easier to test with alarm than the usual interrupt signal
-        register_run_handler(self.dummy_conf, run_signal=signal.SIGALRM)
+        register_run_handler(self.configuration, run_signal=signal.SIGALRM)
         self.assertFalse(check_run())
         signal.alarm(3)
         time.sleep(1)
@@ -74,7 +78,7 @@ class MigLibDaemon(MigTestCase):
     def test_register_run_handler_signal(self):
         """Register a run handler and verify it can be used to trigger run"""
         # It's easier to test with alarm than the usual interrupt signal
-        register_run_handler(self.dummy_conf, run_signal=signal.SIGALRM)
+        register_run_handler(self.configuration, run_signal=signal.SIGALRM)
         self.assertFalse(check_run())
         signal.alarm(1)
         time.sleep(1)
@@ -85,12 +89,12 @@ class MigLibDaemon(MigTestCase):
         sleep to let daemon be responsive when needed.
         """
         # It's easier to test with alarm than the usual interrupt signal
-        register_run_handler(self.dummy_conf, run_signal=signal.SIGALRM)
+        register_run_handler(self.configuration, run_signal=signal.SIGALRM)
         self.assertFalse(check_run())
         max_secs = 4.2
         start = time.time()
         signal.alarm(1)
-        interruptible_sleep(self.dummy_conf, max_secs, (check_run, ))
+        interruptible_sleep(self.configuration, max_secs, (check_run, ))
         self.assertTrue(check_run())
         end = time.time()
         self.assertTrue(end < start + max_secs)
@@ -100,7 +104,7 @@ class MigLibDaemon(MigTestCase):
         mark early stop.
         """
         # It's easier to test with alarm than the usual interrupt signal
-        register_stop_handler(self.dummy_conf, stop_signal=signal.SIGALRM)
+        register_stop_handler(self.configuration, stop_signal=signal.SIGALRM)
         self.assertFalse(check_stop())
         signal.alarm(3)
         time.sleep(1)
@@ -112,7 +116,7 @@ class MigLibDaemon(MigTestCase):
         receiving the signal registered.
         """
         # It's easier to test with alarm than the usual interrupt signal
-        register_stop_handler(self.dummy_conf, stop_signal=signal.SIGALRM)
+        register_stop_handler(self.configuration, stop_signal=signal.SIGALRM)
         self.assertFalse(check_stop())
         signal.alarm(1)
         time.sleep(1)
@@ -157,7 +161,7 @@ class MigLibDaemon(MigTestCase):
     def test_interruptible_sleep_immediate_exit(self):
         """Test interruptible_sleep with max_secs < nap_secs"""
         start = time.time()
-        interruptible_sleep(self.dummy_conf, 0.1, [], nap_secs=0.2)
+        interruptible_sleep(self.configuration, 0.1, [], nap_secs=0.2)
         duration = time.time() - start
         self.assertTrue(duration < 0.15)
 
@@ -171,14 +175,14 @@ class MigLibDaemon(MigTestCase):
     def test_interruptible_sleep_negative_max_secs(self):
         """Test interruptible_sleep with negative max_secs"""
         start = time.time()
-        interruptible_sleep(self.dummy_conf, -1.0, [])
+        interruptible_sleep(self.configuration, -1.0, [])
         duration = time.time() - start
         self.assertTrue(duration < 0.1)
 
     def test_interruptible_sleep_zero_max_secs(self):
         """Test interruptible_sleep with zero max_secs"""
         start = time.time()
-        interruptible_sleep(self.dummy_conf, 0.0, [])
+        interruptible_sleep(self.configuration, 0.0, [])
         duration = time.time() - start
         self.assertTrue(duration < 0.1)
 
@@ -201,8 +205,8 @@ class MigLibDaemon(MigTestCase):
 
     def test_consecutive_signal_handling(self):
         """Test back-to-back signal handling"""
-        register_run_handler(self.dummy_conf, signal.SIGUSR1)
-        register_stop_handler(self.dummy_conf, signal.SIGUSR2)
+        register_run_handler(self.configuration, signal.SIGUSR1)
+        register_stop_handler(self.configuration, signal.SIGUSR2)
 
         # First signal pair
         os.kill(os.getpid(), signal.SIGUSR1)
@@ -224,12 +228,12 @@ class MigLibDaemon(MigTestCase):
         """Test interruptible_sleep with edge case parameters"""
         # Should complete instantly since max_secs < nap_secs
         start = time.time()
-        interruptible_sleep(self.dummy_conf, 0.01, [], nap_secs=0.05)
+        interruptible_sleep(self.configuration, 0.01, [], nap_secs=0.05)
         self.assertTrue(time.time() - start < 0.05)
 
         # Test zero and negative max_secs returns immediately
-        interruptible_sleep(self.dummy_conf, 0.0, [])
-        interruptible_sleep(self.dummy_conf, -1.0, [])
+        interruptible_sleep(self.configuration, 0.0, [])
+        interruptible_sleep(self.configuration, -1.0, [])
 
     def test_interruptible_sleep_multiple_conditions(self):
         """Test interruptible_sleep with multiple break conditions"""
@@ -239,28 +243,28 @@ class MigLibDaemon(MigTestCase):
             lambda: True,  # This triggers break
         ]
         start = time.time()
-        interruptible_sleep(self.dummy_conf, 5.0, conditions)
+        interruptible_sleep(self.configuration, 5.0, conditions)
         self.assertTrue(time.time() - start < 0.2)
 
     def test_handler_registration_conflict(self):
         """Test registering handlers with conflicting signals"""
         # First register USR1 for both handlers
-        register_run_handler(self.dummy_conf, signal.SIGUSR1)
-        register_stop_handler(self.dummy_conf, signal.SIGUSR1)
+        register_run_handler(self.configuration, signal.SIGUSR1)
+        register_stop_handler(self.configuration, signal.SIGUSR1)
 
         # Should still work
         signal.alarm(1)
         time.sleep(0.5)
-        register_run_handler(self.dummy_conf, signal.SIGUSR2)
-        register_stop_handler(self.dummy_conf, signal.SIGUSR2)
+        register_run_handler(self.configuration, signal.SIGUSR2)
+        register_stop_handler(self.configuration, signal.SIGUSR2)
 
     def test_concurrent_event_handling(self):
         """Test concurrent event triggers and state maintenance"""
         # Setup both handlers
         self.assertFalse(check_run())
         self.assertFalse(check_stop())
-        register_run_handler(self.dummy_conf, signal.SIGCONT)
-        register_stop_handler(self.dummy_conf, signal.SIGINT)
+        register_run_handler(self.configuration, signal.SIGCONT)
+        register_stop_handler(self.configuration, signal.SIGINT)
         os.kill(os.getpid(), signal.SIGCONT)
         os.kill(os.getpid(), signal.SIGINT)
         time.sleep(0.3)
@@ -279,7 +283,7 @@ class MigLibDaemon(MigTestCase):
             return True
 
         start = time.time()
-        interruptible_sleep(self.dummy_conf, 5.0, [immediate_true])
+        interruptible_sleep(self.configuration, 5.0, [immediate_true])
         duration = time.time() - start
         self.assertTrue(duration < 0.1,
                         "Sleep should exit immediately but took %s" % duration)
@@ -300,23 +304,23 @@ class MigLibDaemon(MigTestCase):
     def test_invalid_nap_secs(self):
         """Test invalid nap_secs parameter"""
         with self.assertRaises(AssertionError):
-            interruptible_sleep(self.dummy_conf, 0.5, [], nap_secs=-1.0)
+            interruptible_sleep(self.configuration, 0.5, [], nap_secs=-1.0)
 
     def test_unregister_signal_handlers_explicit(self):
         """Test explicit unregistration of signal handlers"""
         # Register handlers first
-        register_run_handler(self.dummy_conf, signal.SIGALRM)
-        register_stop_handler(self.dummy_conf, signal.SIGABRT)
+        register_run_handler(self.configuration, signal.SIGALRM)
+        register_stop_handler(self.configuration, signal.SIGABRT)
 
         # Verify handlers were set
-        self.assertEqual(signal.getsignal(
-            signal.SIGALRM).__name__, 'run_handler')
-        self.assertEqual(signal.getsignal(
-            signal.SIGABRT).__name__, 'stop_handler')
+        self.assertEqual(signal.getsignal(signal.SIGALRM).__name__,
+                         'run_handler')
+        self.assertEqual(signal.getsignal(signal.SIGABRT).__name__,
+                         'stop_handler')
 
         # Unregister specific signals
-        unregister_signal_handlers(
-            self.dummy_conf, [signal.SIGALRM, signal.SIGABRT])
+        unregister_signal_handlers(self.configuration, [signal.SIGALRM,
+                                                        signal.SIGABRT])
         self.assertEqual(signal.getsignal(signal.SIGALRM), signal.SIG_IGN)
         self.assertEqual(signal.getsignal(signal.SIGABRT), signal.SIG_IGN)
 
@@ -329,15 +333,15 @@ class MigLibDaemon(MigTestCase):
             return state['count'] >= 2
 
         start = time.time()
-        interruptible_sleep(self.dummy_conf, 5.0, [
-                            counter_condition], nap_secs=0.1)
+        interruptible_sleep(self.configuration, 5.0, [counter_condition],
+                            nap_secs=0.1)
         duration = time.time() - start
         self.assertAlmostEqual(duration, 0.2, delta=0.15)
 
     def test_interruptible_sleep_maxsecs_equals_napsecs(self):
         """Test interruptible_sleep with max_secs exactly matching nap_secs"""
         start = time.time()
-        interruptible_sleep(self.dummy_conf, 0.1, [lambda: False],
+        interruptible_sleep(self.configuration, 0.1, [lambda: False],
                             nap_secs=0.1)
         duration = time.time() - start
         self.assertAlmostEqual(duration, 0.1, delta=0.05)
@@ -348,15 +352,15 @@ class MigLibDaemon(MigTestCase):
         SLEEP_ERR = "Sleep Test Error"
 
         def faulty_condition():
-            self.dummy_conf.logger.error(SLEEP_ERR)
+            self.logger.error(SLEEP_ERR)
 
         start = time.time()
-        interruptible_sleep(self.dummy_conf, 0.1, [faulty_condition],
+        interruptible_sleep(self.configuration, 0.1, [faulty_condition],
                             nap_secs=0.01)
         duration = time.time() - start
         self.assertAlmostEqual(duration, 0.1, delta=0.05)
         try:
-            self.dummy_conf.logger.check_empty_and_reset()
+            self.logger.check_empty_and_reset()
         except RuntimeError as rte:
             self.assertTrue(SLEEP_ERR in str(rte), "failed sleep break exc")
 
@@ -388,8 +392,8 @@ class MigLibDaemon(MigTestCase):
 
     def test_signal_handlers_with_real_signals(self):
         """Test signal handlers with real signal delivery"""
-        register_run_handler(self.dummy_conf, signal.SIGUSR1)
-        register_stop_handler(self.dummy_conf, signal.SIGUSR2)
+        register_run_handler(self.configuration, signal.SIGUSR1)
+        register_stop_handler(self.configuration, signal.SIGUSR2)
 
         os.kill(os.getpid(), signal.SIGUSR1)
         time.sleep(0.1)
@@ -420,7 +424,7 @@ class MigLibDaemon(MigTestCase):
         for func, sigs in [(register_run_handler, test_signals['run']),
                            (register_stop_handler, test_signals['stop'])]:
             for sig in sigs:
-                func(self.dummy_conf, sig)
+                func(self.configuration, sig)
                 # Verify handler registration
                 dispatch = signal.getsignal(sig)
                 if func == register_run_handler:
@@ -460,7 +464,7 @@ class MigLibDaemon(MigTestCase):
     def test_interruptible_sleep_nap_accuracy(self):
         """Verify nap timing accuracy in sleep function"""
         start = time.time()
-        interruptible_sleep(self.dummy_conf, 0.3, [], nap_secs=0.1)
+        interruptible_sleep(self.configuration, 0.3, [], nap_secs=0.1)
         duration = time.time() - start
         # Should be ~0.3 secs +/- 0.1 tolerance
         self.assertAlmostEqual(duration, 0.3, delta=0.1)
@@ -468,11 +472,11 @@ class MigLibDaemon(MigTestCase):
     def test_interruptible_sleep_no_break_conditions(self):
         """Test sleep with no break conditions"""
         start = time.time()
-        interruptible_sleep(self.dummy_conf, 0.2, [])
+        interruptible_sleep(self.configuration, 0.2, [])
         duration = time.time() - start
         self.assertAlmostEqual(duration, 0.2, delta=0.05)
 
     def test_interruptible_sleep_invalid_break_conditions(self):
         """Test sleep with improperly formatted break conditions"""
         with self.assertRaises(TypeError):
-            interruptible_sleep(self.dummy_conf, 0.2, [None])
+            interruptible_sleep(self.configuration, 0.2, [None])

--- a/tests/test_mig_lib_daemon.py
+++ b/tests/test_mig_lib_daemon.py
@@ -31,11 +31,11 @@ import os
 import signal
 import time
 
-from tests.support import FakeConfiguration, MigTestCase
-
 from mig.lib.daemon import _run_event, _stop_event, check_run, check_stop, \
-    do_run, reset_run, reset_stop, stop_running, interruptible_sleep, \
-    register_run_handler, register_stop_handler, run_handler, stop_handler
+    do_run, interruptible_sleep, register_run_handler, register_stop_handler, \
+    reset_run, reset_stop, run_handler, stop_handler, stop_running, \
+    unregister_signal_handlers
+from tests.support import FakeConfiguration, MigTestCase
 
 
 class MigLibDaemon(MigTestCase):
@@ -52,6 +52,11 @@ class MigLibDaemon(MigTestCase):
         # Reset event states
         reset_run()
         reset_stop()
+
+        # Unregister any existing signal handlers
+        used_signals = [signal.SIGCONT, signal.SIGINT, signal.SIGALRM,
+                        signal.SIGUSR1, signal.SIGUSR2]
+        unregister_signal_handlers(self.dummy_conf, used_signals)
 
     def test_register_run_handler_manual(self):
         """Register a run handler and verify it can be manually overriden to
@@ -146,6 +151,72 @@ class MigLibDaemon(MigTestCase):
         self.assertTrue(check_stop())
         # Verify repeated triggering
         stop_handler(self.sig, self.frame)
+        self.assertTrue(check_stop())
+
+    def test_interruptible_sleep_immediate_exit(self):
+        """Test interruptible_sleep with max_secs < nap_secs"""
+        start = time.time()
+        interruptible_sleep(self.dummy_conf, 0.1, [], nap_secs=0.2)
+        duration = time.time() - start
+        self.assertTrue(duration < 0.15)
+
+    def test_interruptible_sleep_positional_args(self):
+        """Test interruptible_sleep works without named arguments"""
+        start = time.time()
+        interruptible_sleep(None, 0.1, [lambda: False])
+        duration = time.time() - start
+        self.assertAlmostEqual(duration, 0.1, delta=0.15)
+
+    def test_interruptible_sleep_negative_max_secs(self):
+        """Test interruptible_sleep with negative max_secs"""
+        start = time.time()
+        interruptible_sleep(self.dummy_conf, -1.0, [])
+        duration = time.time() - start
+        self.assertTrue(duration < 0.1)
+
+    def test_interruptible_sleep_zero_max_secs(self):
+        """Test interruptible_sleep with zero max_secs"""
+        start = time.time()
+        interruptible_sleep(self.dummy_conf, 0.0, [])
+        duration = time.time() - start
+        self.assertTrue(duration < 0.1)
+
+    def test_handler_unregistered_signals(self):
+        """Test event handlers don't fire for unregistered signals"""
+        # Verify default signal handlers
+        original_cont = signal.getsignal(signal.SIGCONT)
+        original_int = signal.getsignal(signal.SIGINT)
+
+        os.kill(os.getpid(), signal.SIGCONT)
+        os.kill(os.getpid(), signal.SIGINT)
+        time.sleep(0.1)
+
+        self.assertFalse(check_run())
+        self.assertFalse(check_stop())
+
+        # Restore original handlers to avoid test pollution
+        signal.signal(signal.SIGCONT, original_cont)
+        signal.signal(signal.SIGINT, original_int)
+
+    def test_consecutive_signal_handling(self):
+        """Test back-to-back signal handling"""
+        register_run_handler(self.dummy_conf, signal.SIGUSR1)
+        register_stop_handler(self.dummy_conf, signal.SIGUSR2)
+
+        # First signal pair
+        os.kill(os.getpid(), signal.SIGUSR1)
+        os.kill(os.getpid(), signal.SIGUSR2)
+        time.sleep(0.2)
+        self.assertTrue(check_run())
+        self.assertTrue(check_stop())
+        reset_run()
+        reset_stop()
+
+        # Second signal pair
+        os.kill(os.getpid(), signal.SIGUSR1)
+        os.kill(os.getpid(), signal.SIGUSR2)
+        time.sleep(0.2)
+        self.assertTrue(check_run())
         self.assertTrue(check_stop())
 
     def test_interruptible_sleep_edge_cases(self):

--- a/tests/test_mig_lib_daemon.py
+++ b/tests/test_mig_lib_daemon.py
@@ -256,11 +256,24 @@ class MigLibDaemon(MigTestCase):
         register_run_handler(self.configuration, signal.SIGUSR1)
         register_stop_handler(self.configuration, signal.SIGUSR1)
 
-        # Should still work
-        signal.alarm(1)
-        time.sleep(0.5)
-        register_run_handler(self.configuration, signal.SIGUSR2)
+        os.kill(os.getpid(), signal.SIGUSR1)
+        time.sleep(0.1)
+        # Make sure that only most recently assigned handler triggered
+        self.assertTrue(check_stop())
+        self.assertFalse(check_run())
+
+        # Reset and test with additional signals
+        reset_run()
+        reset_stop()
+
+        # Second signal pair on USR2
         register_stop_handler(self.configuration, signal.SIGUSR2)
+        register_run_handler(self.configuration, signal.SIGUSR2)
+        # Should still work just reversed to fit most recent assignment
+        os.kill(os.getpid(), signal.SIGUSR2)
+        time.sleep(0.1)
+        self.assertTrue(check_run())
+        self.assertFalse(check_stop())
 
     def test_concurrent_event_handling(self):
         """Test concurrent event triggers and state maintenance"""


### PR DESCRIPTION
Improved unit test coverage of `mig/lib/daemon.py` for complete coverage. Added a lot of corner case tests to test signal passing and handlers. Some of the tests include fuzzy timing assertions, which _may_ need further tweaking to avoid false positives.

Adds one new function to the tested library to remove already registered signal handlers, but it is only ever used in the unit tests so far.
Slightly tweaks `interruptible_sleep` corner cases to fail an assertion if  called with non-positive `nap_secs` and to return right away if called with `max_sleep` less than `nap_secs`. Both are unused corner cases only used in the test for now but they may or may not be of use to daemons in the future.