### PR TITLE
Make sure useradm notify helper always returns on a consistent format

### DIFF
--- a/mig/shared/useradm.py
+++ b/mig/shared/useradm.py
@@ -2400,6 +2400,9 @@ def _user_general_notify(user_id, targets, conf_path, db_path,
     else:
         configuration = get_configuration_object()
     _logger = configuration.logger
+    addresses = dict(zip(configuration.notify_protocols,
+                         [[] for _ in configuration.notify_protocols]))
+    addresses['email'] = []
     if db_path == keyword_auto:
         db_path = default_db_path(configuration)
     try:
@@ -2414,7 +2417,8 @@ def _user_general_notify(user_id, targets, conf_path, db_path,
         if verbose:
             print(err_msg)
         _logger.error(err_msg)
-        return []
+        errors.append("notify %r preparation failed: %s" % (user_id, err_msg))
+        return (configuration, None, addresses, errors)
 
     user_fields = {}
     if user_id in user_db:
@@ -2439,9 +2443,6 @@ def _user_general_notify(user_id, targets, conf_path, db_path,
         for field in get_fields:
             user_fields[field] = user_dict.get(field, None)
 
-    addresses = dict(zip(configuration.notify_protocols,
-                         [[] for _ in configuration.notify_protocols]))
-    addresses['email'] = []
     for (proto, address_list) in targets.items():
         if not proto in configuration.notify_protocols + ['email']:
             errors.append('unsupported protocol: %s' % proto)


### PR DESCRIPTION
Make sure `useradm` notify helper always returns on a consistent format, namely a 3-tuple with errors listed last if e.g. user DB load fails.
Addresses an issue in reject expired account request as detected during janitor unit test extension.

The adjusted function is _only_ called from inside the `useradm` module itself and each time implicitly asserting that the result is a 3-tuple, so the empty list return value would **always** fail.