### PR TITLE
Improved unit test coverage of mig lib janitor

### DIFF
--- a/mig/lib/janitor.py
+++ b/mig/lib/janitor.py
@@ -432,11 +432,19 @@ def remind_and_expire_user_pending(configuration, now=None):
                 "found stale account request in %r : %dd"
                 % (req_path, req_age_days)
             )
+            print(
+                "found stale account request in %r : %dd"
+                % (req_path, req_age_days)
+            )
             # TODO: actually remind operator and user that request is pending
             #       ... possibly with copy to peers if pending acceptance.
             handled += 1
         if req_age_days > EXPIRE_REQ_DAYS:
             _logger.info(
+                "found expired account request from %r in %s : %dd"
+                % (client_id, req_path, req_age_days)
+            )
+            print(
                 "found expired account request from %r in %s : %dd"
                 % (client_id, req_path, req_age_days)
             )

--- a/mig/lib/janitor.py
+++ b/mig/lib/janitor.py
@@ -287,6 +287,8 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
         else:
             _logger.info("rejected invalid %r account request" % client_id)
     elif reset_token:
+        # TODO: handle loaded user_dict == None here (e.g. recently removed)
+        #       to avoid verify_reset_token failing on DN access.
         valid_reset = verify_reset_token(
             configuration, user_dict, reset_token, req_auth, req_timestamp
         )

--- a/mig/lib/janitor.py
+++ b/mig/lib/janitor.py
@@ -432,19 +432,11 @@ def remind_and_expire_user_pending(configuration, now=None):
                 "found stale account request in %r : %dd"
                 % (req_path, req_age_days)
             )
-            print(
-                "found stale account request in %r : %dd"
-                % (req_path, req_age_days)
-            )
             # TODO: actually remind operator and user that request is pending
             #       ... possibly with copy to peers if pending acceptance.
             handled += 1
         if req_age_days > EXPIRE_REQ_DAYS:
             _logger.info(
-                "found expired account request from %r in %s : %dd"
-                % (client_id, req_path, req_age_days)
-            )
-            print(
                 "found expired account request from %r in %s : %dd"
                 % (client_id, req_path, req_age_days)
             )

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -28,11 +28,14 @@
 """Unit tests for the migrid module pointed to in the filename"""
 
 import os
+import pickle
 import time
 
 from tests.support import FakeConfiguration, MigTestCase, ensure_dirs_exist
 from mig.shared.accountreq import save_account_request
-from mig.lib.janitor import task_triggers, _lookup_last_run, _update_last_run, \
+from mig.shared.base import distinguished_name_to_user
+from mig.lib.janitor import task_triggers, _clean_stale_state_files, \
+    _lookup_last_run, _update_last_run, \
     SECS_PER_MINUTE, SECS_PER_HOUR, SECS_PER_DAY, \
     EXPIRE_STATE_DAYS, EXPIRE_DUMMY_JOBS_DAYS, EXPIRE_TWOFACTOR_DAYS, \
     EXPIRE_REQ_DAYS, MANAGE_TRIVIAL_REQ_MINUTES, REMIND_REQ_DAYS, \
@@ -43,13 +46,14 @@ from mig.lib.janitor import task_triggers, _lookup_last_run, _update_last_run, \
     remind_and_expire_user_pending, handle_pending_requests, \
     handle_cache_updates, handle_janitor_tasks
 
-DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=noreply@migrid.org'
+DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.org'
 DUMMY_FULL_NAME = "Test User"
 DUMMY_ORGANIZATION = "Test Org"
-# TODO: mark as unroutable somehow to skip sending email from tests?
-DUMMY_EMAIL = "noreply@migrid.org"
-DUMMY_CLIENT_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=noreply@migrid.org'
+DUMMY_EMAIL = "test@example.org"
+DUMMY_SKIP_EMAIL = ''
+DUMMY_CLIENT_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.org'
 DUMMY_AUTH = 'migcert'
+DUMMY_USERDB = 'MiG-users.db'
 DUMMY_PEER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=peer@example.com'
 # NOTE: these passwords are not and should not ever be used outside unit tests
 DUMMY_MODERN_PW = 'QZFnCp7hmI1G'
@@ -63,6 +67,11 @@ class MigLibJanitor(MigTestCase):
     def _provide_configuration(self):
         """Prepare isolated test config"""
         return 'testconfig'
+
+    def _write_user_db(self, user_db_dict):
+        """Write user_db_dict to user database - truncating any contents"""
+        with open(self.user_db_path, 'wb') as udb:
+            udb.write(pickle.dumps(user_db_dict))
 
     def before_each(self):
         """Set up test configuration and reset state before each test"""
@@ -83,6 +92,14 @@ class MigLibJanitor(MigTestCase):
         # Remap test configuration to dummy_conf for consistency
         self.dummy_conf = self.configuration
         self.dummy_conf.site_enable_jobs = True
+        # Prevent admin email during reject, etc.
+        self.dummy_conf.admin_email = DUMMY_SKIP_EMAIL
+
+        # Prepare user DB with a single dummy user for all tests
+        self.user_db_path = os.path.join(self.dummy_conf.user_db_home,
+                                         DUMMY_USERDB)
+        user_dict = distinguished_name_to_user(DUMMY_USER_DN)
+        self._write_user_db({DUMMY_USER_DN: user_dict})
 
         # Reset task triggers
         global task_triggers
@@ -243,11 +260,13 @@ class MigLibJanitor(MigTestCase):
             'distinguished_name': DUMMY_USER_DN,
             'auth': [DUMMY_AUTH],
             'full_name': DUMMY_FULL_NAME,
+            'organization': DUMMY_ORGANIZATION,
             'password_hash': DUMMY_MODERN_PW_PBKDF2,
             'password': DUMMY_MODERN_PW,
             'peers': [DUMMY_PEER_DN],
             'email': DUMMY_EMAIL,
         }
+
         self.assertDirEmpty(self.dummy_conf.user_pending)
         saved, req_path = save_account_request(self.dummy_conf, req_dict)
         self.assertTrue(saved, "failed to save account req")
@@ -270,6 +289,7 @@ class MigLibJanitor(MigTestCase):
             'distinguished_name': DUMMY_USER_DN,
             'auth': [DUMMY_AUTH],
             'full_name': DUMMY_FULL_NAME,
+            'organization': DUMMY_ORGANIZATION,
             'password': DUMMY_MODERN_PW,
             'peers': [DUMMY_PEER_DN],
             'email': DUMMY_EMAIL,
@@ -295,6 +315,7 @@ class MigLibJanitor(MigTestCase):
             'distinguished_name': DUMMY_USER_DN,
             'auth': [DUMMY_AUTH],
             'full_name': DUMMY_FULL_NAME,
+            'organization': DUMMY_ORGANIZATION,
             'password_hash': DUMMY_MODERN_PW_PBKDF2,
             'password': DUMMY_MODERN_PW,
             'peers': [DUMMY_PEER_DN],
@@ -313,6 +334,7 @@ class MigLibJanitor(MigTestCase):
             'distinguished_name': DUMMY_USER_DN,
             'auth': [DUMMY_AUTH],
             'full_name': DUMMY_FULL_NAME,
+            'organization': DUMMY_ORGANIZATION,
             'password': DUMMY_MODERN_PW,
             'peers': [DUMMY_PEER_DN],
             'email': DUMMY_EMAIL,
@@ -354,6 +376,7 @@ class MigLibJanitor(MigTestCase):
             'distinguished_name': DUMMY_USER_DN,
             'auth': [DUMMY_AUTH],
             'full_name': DUMMY_FULL_NAME,
+            'organization': DUMMY_ORGANIZATION,
             'password': DUMMY_MODERN_PW,
             'peers': [DUMMY_PEER_DN],
             'email': DUMMY_EMAIL,
@@ -384,3 +407,199 @@ class MigLibJanitor(MigTestCase):
         handled = handle_janitor_tasks(self.dummy_conf, now=now)
         # self.assertEqual(handled, 3)  # state+session+requests
         self.assertEqual(handled, 4)  # state (expired+stale)+session+requests
+
+    def test__clean_stale_state_files(self):
+        """Test core stale state file cleaner helper"""
+        test_dir = self.temppath('stale_state_test', ensure_dir=True)
+        patterns = ['tmp_*', 'session_*']
+
+        # Create test files (fresh, expired, unexpired, non-matching)
+        test_files = [
+            ('tmp_fresh.txt', -1),
+            ('tmp_expired.txt', EXPIRE_STATE_DAYS * SECS_PER_DAY + 1),
+            ('session_valid.dat', 0),
+            ('session_old.dat', EXPIRE_STATE_DAYS * SECS_PER_DAY + 1),
+            ('other_file.log', EXPIRE_STATE_DAYS * SECS_PER_DAY + 1),
+        ]
+
+        for (name, age_diff) in test_files:
+            path = os.path.join(test_dir, name)
+            with open(path, 'w') as fp:
+                fp.write('test')
+            mtime = time.time() - age_diff
+            os.utime(path, (mtime, mtime))
+
+        handled = _clean_stale_state_files(
+            self.dummy_conf,
+            test_dir,
+            patterns,
+            EXPIRE_STATE_DAYS,
+            time.time(),
+            include_dotfiles=False
+        )
+        self.assertEqual(handled, 2)  # tmp_expired.txt + session_old.dat
+        self.assertTrue(os.path.exists(os.path.join(test_dir,
+                                                    'tmp_fresh.txt')))
+        self.assertFalse(os.path.exists(os.path.join(test_dir,
+                                                     'tmp_expired.txt')))
+        self.assertTrue(os.path.exists(os.path.join(test_dir,
+                                                    'other_file.log')))
+
+    def test_manage_single_req_invalid(self):
+        """Test request handling for invalid request"""
+        req_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'invalid': ['Missing required field: organization'],
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'password_hash': DUMMY_MODERN_PW_PBKDF2,
+            # NOTE: disable email to prevent send failing on reject
+            'email': DUMMY_SKIP_EMAIL,
+        }
+        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        req_id = os.path.basename(req_path)
+
+        with self.assertLogs(level='INFO') as log_capture:
+            manage_single_req(
+                self.dummy_conf,
+                req_id,
+                req_path,
+                self.user_db_path,
+                time.time()
+            )
+
+        self.assertTrue(any('invalid account request' in msg
+                            for msg in log_capture.output))
+        self.assertFalse(os.path.exists(req_path),
+                         "Failed to clean invalid req for %s" % req_path)
+
+    def test_manage_single_req_expired_token(self):
+        """Test request handling with expired reset token"""
+        req_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'organization': DUMMY_ORGANIZATION,
+            # NOTE: disable email to prevent send failing on reject
+            'email': DUMMY_SKIP_EMAIL,
+            'reset_token': 'INVALID_TOKEN',
+            'expire': time.time() - SECS_PER_DAY,
+        }
+        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        req_id = os.path.basename(req_path)
+
+        user_dict = {'distinguished_name': DUMMY_USER_DN,
+                     'password_hash': DUMMY_MODERN_PW_PBKDF2}
+        self._write_user_db({DUMMY_USER_DN: user_dict})
+
+        with self.assertLogs(level='WARNING') as log_capture:
+            manage_single_req(
+                self.dummy_conf,
+                req_id,
+                req_path,
+                self.user_db_path,
+                time.time()
+            )
+
+        self.assertTrue(any('bad token' in msg for msg in log_capture.output))
+        self.assertFalse(os.path.exists(req_path),
+                         "Failed to clean token req for %s" % req_path)
+
+    def test_manage_single_req_collision(self):
+        """Test request handling with existing user collision"""
+        # Setup existing user
+        user_dir = os.path.join(self.dummy_conf.user_home, DUMMY_CLIENT_DIR)
+        os.makedirs(user_dir)
+        # Create dummy user DB
+        user_entry = {'distinguished_name': DUMMY_USER_DN}
+        self._write_user_db({DUMMY_USER_DN: user_entry})
+
+        changed_full_name = "Changed Test Name"
+        req_dict = {
+            'client_id': DUMMY_USER_DN.replace(DUMMY_FULL_NAME,
+                                               changed_full_name),
+            'distinguished_name': DUMMY_USER_DN.replace(DUMMY_FULL_NAME,
+                                                        changed_full_name),
+            'auth': [DUMMY_AUTH],
+            'full_name': changed_full_name,
+            'organization': DUMMY_ORGANIZATION,
+            'password_hash': DUMMY_MODERN_PW_PBKDF2,
+            # NOTE: disable email to prevent send failing on reject
+            'email': DUMMY_SKIP_EMAIL,
+        }
+        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        req_id = os.path.basename(req_path)
+
+        with self.assertLogs(level='WARNING') as log_capture:
+            manage_single_req(
+                self.dummy_conf,
+                req_id,
+                req_path,
+                self.user_db_path,
+                time.time()
+            )
+        self.assertTrue(any('ID collision' in msg
+                            for msg in log_capture.output))
+        self.assertFalse(os.path.exists(req_path),
+                         "Failed cleanup collision for %s" % req_path)
+
+    def test_handle_cache_updates_stub(self):
+        """Test handle_cache_updates placeholder returns zero"""
+        handled = handle_cache_updates(self.dummy_conf)
+        self.assertEqual(handled, 0)
+
+    def test_janitor_update_timestamps(self):
+        """Test task trigger timestamp updates in janitor"""
+        now = time.time()
+        task = 'test-task'
+
+        # Initial state
+        stamp = _lookup_last_run(self.dummy_conf, task)
+        self.assertEqual(stamp, -1)
+
+        # Update & verify
+        updated = _update_last_run(self.dummy_conf, task, now)
+        self.assertEqual(updated, now)
+
+        # Check persistence (within process)
+        retrieved = _lookup_last_run(self.dummy_conf, task)
+        self.assertEqual(retrieved, now)
+
+    def test__clean_stale_state_files_edge(self):
+        """Test state file cleaner with special cases"""
+        test_dir = self.temppath('edge_case_test', ensure_dir=True)
+
+        # Dot file
+        dot_path = os.path.join(test_dir, '.hidden.tmp')
+        with open(dot_path, 'w') as fp:
+            fp.write('test')
+        os.utime(dot_path,
+                 (time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1,
+                  time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1))
+
+        # Directory
+        dir_path = os.path.join(test_dir, 'subdir')
+        os.makedirs(dir_path)
+
+        handled = _clean_stale_state_files(
+            self.dummy_conf,
+            test_dir,
+            ['*'],
+            EXPIRE_STATE_DAYS,
+            time.time(),
+            include_dotfiles=False
+        )
+        self.assertEqual(handled, 0)
+
+        # Now include dotfiles
+        handled = _clean_stale_state_files(
+            self.dummy_conf,
+            test_dir,
+            ['*'],
+            EXPIRE_STATE_DAYS,
+            time.time(),
+            include_dotfiles=True
+        )
+        self.assertEqual(handled, 1)

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -27,24 +27,360 @@
 
 """Unit tests for the migrid module pointed to in the filename"""
 
+import os
 import time
 
-from tests.support import MigTestCase, FakeConfiguration
+from tests.support import FakeConfiguration, MigTestCase, ensure_dirs_exist
+from mig.shared.accountreq import save_account_request
+from mig.lib.janitor import task_triggers, _lookup_last_run, _update_last_run, \
+    SECS_PER_MINUTE, SECS_PER_HOUR, SECS_PER_DAY, \
+    EXPIRE_STATE_DAYS, EXPIRE_DUMMY_JOBS_DAYS, EXPIRE_TWOFACTOR_DAYS, \
+    EXPIRE_REQ_DAYS, MANAGE_TRIVIAL_REQ_MINUTES, REMIND_REQ_DAYS, \
+    clean_mig_system_files, clean_webserver_home, clean_no_job_helpers, \
+    clean_twofactor_sessions, handle_state_cleanup, \
+    clean_sessid_to_mrls_link_home, handle_session_cleanup, \
+    manage_trivial_user_requests, manage_single_req, \
+    remind_and_expire_user_pending, handle_pending_requests, \
+    handle_cache_updates, handle_janitor_tasks
 
-from mig.lib.janitor import task_triggers, _lookup_last_run, _update_last_run
+DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=noreply@migrid.org'
+DUMMY_FULL_NAME = "Test User"
+DUMMY_ORGANIZATION = "Test Org"
+# TODO: mark as unroutable somehow to skip sending email from tests?
+DUMMY_EMAIL = "noreply@migrid.org"
+DUMMY_CLIENT_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=noreply@migrid.org'
+DUMMY_AUTH = 'migcert'
+DUMMY_PEER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=peer@example.com'
+# NOTE: these passwords are not and should not ever be used outside unit tests
+DUMMY_MODERN_PW = 'QZFnCp7hmI1G'
+DUMMY_MODERN_PW_PBKDF2 = \
+    "PBKDF2$sha256$10000$MDAwMDAwMDAwMDAw$B22uw6C7C4VFiYAe4Vf10n58FHrn1pjX"
 
 
 class MigLibJanitor(MigTestCase):
     """Unit tests for janitor related helper functions"""
 
+    def _provide_configuration(self):
+        """Prepare isolated test config"""
+        return 'testconfig'
+
+    def before_each(self):
+        """Set up test configuration and reset state before each test"""
+        # Create fake configuration matching real systems
+        ensure_dirs_exist(self.configuration.user_pending)
+        ensure_dirs_exist(self.configuration.user_db_home)
+        ensure_dirs_exist(self.configuration.user_home)
+        ensure_dirs_exist(self.configuration.user_settings)
+        ensure_dirs_exist(self.configuration.user_cache)
+        ensure_dirs_exist(self.configuration.twofactor_home)
+        ensure_dirs_exist(self.configuration.mig_system_files)
+        ensure_dirs_exist(self.configuration.mig_server_home)
+        ensure_dirs_exist(self.configuration.gdp_home)
+        ensure_dirs_exist(self.configuration.webserver_home)
+        ensure_dirs_exist(self.configuration.sessid_to_mrsl_link_home)
+        ensure_dirs_exist(self.configuration.mrsl_files_dir)
+        ensure_dirs_exist(self.configuration.resource_pending)
+        # Remap test configuration to dummy_conf for consistency
+        self.dummy_conf = self.configuration
+        self.dummy_conf.site_enable_jobs = True
+
+        # Reset task triggers
+        global task_triggers
+        task_triggers = {}
+
     def test_last_run_bookkeeping(self):
         """Register a last run timestamp and check it"""
         expect = -1
-        stamp = _lookup_last_run(self.configuration, 'janitor_task')
+        stamp = _lookup_last_run(self.dummy_conf, 'janitor_task')
         self.assertEqual(stamp, expect)
         expect = 42
-        stamp = _update_last_run(self.configuration, 'janitor_task', expect)
+        stamp = _update_last_run(self.dummy_conf, 'janitor_task', expect)
         self.assertEqual(stamp, expect)
         expect = time.time()
-        stamp = _update_last_run(self.configuration, 'janitor_task', expect)
+        stamp = _update_last_run(self.dummy_conf, 'janitor_task', expect)
         self.assertEqual(stamp, expect)
+
+    def test_clean_mig_system_files(self):
+        """Test clean_mig system files helper"""
+        test_time = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        valid_filenames = ['fresh.log', 'current.tmp']
+        stale_filenames = ['tmp_expired.txt', 'no_grid_jobs.123']
+        for name in valid_filenames + stale_filenames:
+            path = os.path.join(self.dummy_conf.mig_system_files, name)
+            with open(path, 'w') as fp:
+                fp.write('test')
+            os.utime(path, (test_time, test_time))
+            if name in valid_filenames:
+                # Make one file fresh
+                os.utime(path, None)
+        handled = clean_mig_system_files(self.dummy_conf)
+        self.assertEqual(handled, len(stale_filenames))
+        self.assertEqual(len(os.listdir(self.dummy_conf.mig_system_files)),
+                         len(valid_filenames))
+
+    def test_clean_webserver_home(self):
+        """Test clean webserver files helper"""
+        test_time = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        valid_filename = 'fresh.log'
+        stale_filename = 'stale.log'
+        for name in [valid_filename, stale_filename]:
+            path = os.path.join(self.dummy_conf.webserver_home, name)
+            with open(path, 'w') as fp:
+                fp.write('test')
+            os.utime(path, (test_time, test_time))
+            if name == valid_filename:
+                os.utime(path, None)
+        handled = clean_webserver_home(self.dummy_conf)
+        self.assertEqual(handled, 1)
+        self.assertFalse(os.path.exists(os.path.join(
+            self.dummy_conf.webserver_home, stale_filename)))
+        self.assertTrue(os.path.exists(os.path.join(
+            self.dummy_conf.webserver_home, valid_filename)))
+
+    def test_clean_no_job_helpers(self):
+        """Test clean dummy job helper files"""
+        dummy_job = os.path.join(self.dummy_conf.user_home,
+                                 "no_grid_jobs_in_grid_scheduler")
+        os.makedirs(dummy_job, exist_ok=True)
+        test_time = time.time() - EXPIRE_DUMMY_JOBS_DAYS * SECS_PER_DAY - 1
+        valid_filename = 'alive.txt'
+        stale_filename = 'expired.txt'
+        for name in [valid_filename, stale_filename]:
+            path = os.path.join(dummy_job, name)
+            with open(path, 'w') as fp:
+                fp.write('test')
+            os.utime(path, (test_time, test_time))
+            if name == valid_filename:
+                os.utime(path, None)
+        handled = clean_no_job_helpers(self.dummy_conf)
+        self.assertEqual(handled, 1)
+        self.assertFalse(os.path.exists(os.path.join(dummy_job,
+                                                     stale_filename)))
+        self.assertTrue(os.path.exists(os.path.join(dummy_job,
+                                                    valid_filename)))
+
+    def test_clean_twofactor_sessions(self):
+        """Test clean twofactor sessions"""
+        test_time = time.time() - EXPIRE_TWOFACTOR_DAYS * SECS_PER_DAY - 1
+        valid_filename = 'current'
+        stale_filename = 'expired'
+        for name in [valid_filename, stale_filename]:
+            path = os.path.join(self.dummy_conf.twofactor_home, name)
+            with open(path, 'w') as fp:
+                fp.write('test')
+            os.utime(path, (test_time, test_time))
+            if name == valid_filename:
+                os.utime(path, None)
+        handled = clean_twofactor_sessions(self.dummy_conf)
+        self.assertEqual(handled, 1)
+        self.assertFalse(os.path.exists(os.path.join(
+            self.dummy_conf.twofactor_home, stale_filename)))
+        self.assertTrue(os.path.exists(os.path.join(
+            self.dummy_conf.twofactor_home, valid_filename)))
+
+    def test_clean_sessid_to_mrls_link_home(self):
+        """Test clean session MRSL link files"""
+        test_time = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        valid_filename = 'active_session_link'
+        stale_filename = 'expired_session_link'
+        for name in [valid_filename, stale_filename]:
+            path = os.path.join(self.dummy_conf.sessid_to_mrsl_link_home, name)
+            with open(path, 'w') as fp:
+                fp.write('test')
+            os.utime(path, (test_time, test_time))
+            if name == valid_filename:
+                os.utime(path, None)
+        handled = clean_sessid_to_mrls_link_home(self.dummy_conf)
+        self.assertEqual(handled, 1)
+        self.assertFalse(os.path.exists(os.path.join(
+            self.dummy_conf.sessid_to_mrsl_link_home, stale_filename)))
+        self.assertTrue(os.path.exists(os.path.join(
+            self.dummy_conf.sessid_to_mrsl_link_home, valid_filename)))
+
+    def test_handle_state_cleanup(self):
+        """Test combined state cleanup"""
+        # Create a stale file in each location to clean up
+        test_time = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        mig_path = os.path.join(
+            self.dummy_conf.mig_system_files, 'tmpAbCd1234')
+        web_path = os.path.join(self.dummy_conf.webserver_home, 'stale.txt')
+        empty_job_path = os.path.join(
+            os.path.join(self.dummy_conf.user_home,
+                         "no_grid_jobs_in_grid_scheduler"),
+            'sleep.job'
+        )
+        for path in [mig_path, web_path, empty_job_path]:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, 'w') as fp:
+                fp.write('test')
+            os.utime(path, (test_time, test_time))
+
+        handled = handle_state_cleanup(self.dummy_conf)
+        self.assertEqual(handled, 3)
+
+    def test_handle_session_cleanup(self):
+        """Test combined session cleanup"""
+        test_time = time.time() - max(EXPIRE_STATE_DAYS,
+                                      EXPIRE_TWOFACTOR_DAYS) * SECS_PER_DAY - 1
+        session_path = os.path.join(
+            self.dummy_conf.sessid_to_mrsl_link_home, 'expired.txt')
+        twofactor_path = os.path.join(
+            self.dummy_conf.twofactor_home, 'expired.txt')
+        for path in [session_path, twofactor_path]:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, 'w') as fp:
+                fp.write('test')
+            os.utime(path, (test_time, test_time))
+
+        handled = handle_session_cleanup(self.dummy_conf)
+        self.assertEqual(handled, 2)
+
+    def test_manage_pending_user_request(self):
+        """Test pending user request management"""
+        req_id = 'req_id'
+        req_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'password_hash': DUMMY_MODERN_PW_PBKDF2,
+            'password': DUMMY_MODERN_PW,
+            'peers': [DUMMY_PEER_DN],
+            'email': DUMMY_EMAIL,
+        }
+        self.assertDirEmpty(self.dummy_conf.user_pending)
+        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        self.assertTrue(saved, "failed to save account req")
+        self.assertDirNotEmpty(self.dummy_conf.user_pending)
+        # Update mtime to make it ready for janitor
+        req_age = time.time() - MANAGE_TRIVIAL_REQ_MINUTES * SECS_PER_MINUTE - 1
+        os.utime(req_path, (req_age, req_age))
+
+        # Need user DB and path to simulate existing user
+        user_dir = os.path.join(self.dummy_conf.user_home, DUMMY_CLIENT_DIR)
+        os.makedirs(user_dir)
+        handled = manage_trivial_user_requests(self.dummy_conf)
+        self.assertEqual(handled, 1)
+
+    def test_expire_user_pending(self):
+        """Test pending user request expiration reminders"""
+        req_id = 'expired_req'
+        req_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'password': DUMMY_MODERN_PW,
+            'peers': [DUMMY_PEER_DN],
+            'email': DUMMY_EMAIL,
+        }
+        self.assertDirEmpty(self.dummy_conf.user_pending)
+        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        self.assertTrue(saved, "failed to save account req")
+        self.assertDirNotEmpty(self.dummy_conf.user_pending)
+        # Make request very old
+        req_age = time.time() - EXPIRE_REQ_DAYS * SECS_PER_DAY - 1
+        os.utime(req_path, (req_age, req_age))
+
+        # TODO: rework to handle expire before stale to avoid duplicate here
+        handled = remind_and_expire_user_pending(self.dummy_conf)
+        # self.assertEqual(handled, 1)
+        self.assertEqual(handled, 2)  # counted stale and expired (see above)
+
+    def test_handle_pending_requests(self):
+        """Test combined request handling"""
+        # Create requests (valid, expired)
+        valid_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'password_hash': DUMMY_MODERN_PW_PBKDF2,
+            'password': DUMMY_MODERN_PW,
+            'peers': [DUMMY_PEER_DN],
+            'email': DUMMY_EMAIL,
+        }
+        self.assertDirEmpty(self.dummy_conf.user_pending)
+        saved, valid_req_path = save_account_request(self.dummy_conf,
+                                                     valid_dict)
+        self.assertTrue(saved, "failed to save valid req")
+        self.assertDirNotEmpty(self.dummy_conf.user_pending)
+        valid_id = os.path.basename(valid_req_path)
+
+        expired_id = 'expired_req'
+        expired_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'password': DUMMY_MODERN_PW,
+            'peers': [DUMMY_PEER_DN],
+            'email': DUMMY_EMAIL,
+        }
+        saved, expired_req_path = save_account_request(
+            self.dummy_conf, expired_dict)
+        self.assertTrue(saved, "failed to save expired req")
+        expired_id = os.path.basename(expired_req_path)
+        # Make just one old enough to expire
+        expire_time = time.time() - EXPIRE_REQ_DAYS * SECS_PER_DAY - 1
+        os.utime(os.path.join(self.dummy_conf.user_pending, expired_id),
+                 (expire_time, expire_time))
+
+        # TODO: rework to handle expire before stale to avoid duplicate here
+        handled = handle_pending_requests(self.dummy_conf)
+        # self.assertEqual(handled, 2)  # 1 manage + 1 expire
+        self.assertEqual(handled, 3)  # 1 manage + 1 expire + 1 stale
+
+    def test_handle_janitor_tasks_full(self):
+        """Test full janitor task scheduler"""
+        # Prepare environment with pending tasks
+        mig_path = os.path.join(self.dummy_conf.mig_system_files, 'stale.txt')
+        with open(mig_path, 'w') as fp:
+            fp.write('test')
+        os.utime(mig_path,
+                 (time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1,
+                  time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1))
+
+        two_path = os.path.join(self.dummy_conf.twofactor_home, 'stale.txt')
+        with open(two_path, 'w') as fp:
+            fp.write('test')
+        os.utime(two_path,
+                 (time.time() - EXPIRE_TWOFACTOR_DAYS * SECS_PER_DAY - 1,
+                  time.time() - EXPIRE_TWOFACTOR_DAYS * SECS_PER_DAY - 1))
+
+        req_id = 'expired_request'
+        req_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'password': DUMMY_MODERN_PW,
+            'peers': [DUMMY_PEER_DN],
+            'email': DUMMY_EMAIL,
+        }
+        self.assertDirEmpty(self.dummy_conf.user_pending)
+        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        self.assertTrue(saved, "failed to save account req")
+        self.assertDirNotEmpty(self.dummy_conf.user_pending)
+        req_id = os.path.basename(req_path)
+        # Make request very old
+        req_age = time.time() - EXPIRE_REQ_DAYS * SECS_PER_DAY - 1
+        os.utime(os.path.join(self.dummy_conf.user_pending, req_id),
+                 (req_age, req_age))
+
+        dummy_job = os.path.join(self.dummy_conf.user_home,
+                                 "no_grid_jobs_in_grid_scheduler")
+        os.makedirs(dummy_job, exist_ok=True)
+
+        # Set no last run timestamps to trigger all tasks
+        now = time.time()
+        task_triggers["state-cleanup"] = -1
+        task_triggers["session-cleanup"] = -1
+        task_triggers["pending-reqs"] = -1
+        task_triggers["cache-updates"] = -1
+
+        # Run task handler and verify all tasks executed
+        # TODO: rework to handle expire before stale to avoid duplicate here
+        handled = handle_janitor_tasks(self.dummy_conf, now=now)
+        # self.assertEqual(handled, 3)  # state+session+requests
+        self.assertEqual(handled, 4)  # state (expired+stale)+session+requests

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -32,19 +32,19 @@ import pickle
 import time
 import unittest
 
-from tests.support import FakeConfiguration, MigTestCase, ensure_dirs_exist
+from mig.lib.janitor import EXPIRE_DUMMY_JOBS_DAYS, EXPIRE_REQ_DAYS, \
+    EXPIRE_STATE_DAYS, EXPIRE_TWOFACTOR_DAYS, MANAGE_TRIVIAL_REQ_MINUTES, \
+    REMIND_REQ_DAYS, SECS_PER_DAY, SECS_PER_HOUR, SECS_PER_MINUTE, \
+    _clean_stale_state_files, _lookup_last_run, _update_last_run, \
+    clean_mig_system_files, clean_no_job_helpers, \
+    clean_sessid_to_mrls_link_home, clean_twofactor_sessions, \
+    clean_webserver_home, handle_cache_updates, handle_janitor_tasks, \
+    handle_pending_requests, handle_session_cleanup, handle_state_cleanup, \
+    manage_single_req, manage_trivial_user_requests, \
+    remind_and_expire_user_pending, task_triggers
 from mig.shared.accountreq import save_account_request
 from mig.shared.base import distinguished_name_to_user
-from mig.lib.janitor import _clean_stale_state_files, \
-    _lookup_last_run, _update_last_run, SECS_PER_MINUTE, SECS_PER_HOUR, \
-    SECS_PER_DAY, EXPIRE_STATE_DAYS, EXPIRE_DUMMY_JOBS_DAYS, \
-    EXPIRE_TWOFACTOR_DAYS, EXPIRE_REQ_DAYS, MANAGE_TRIVIAL_REQ_MINUTES, \
-    REMIND_REQ_DAYS, clean_mig_system_files, clean_webserver_home, \
-    clean_no_job_helpers, clean_twofactor_sessions, handle_state_cleanup, \
-    clean_sessid_to_mrls_link_home, handle_session_cleanup, \
-    manage_trivial_user_requests, manage_single_req, \
-    remind_and_expire_user_pending, handle_pending_requests, \
-    handle_cache_updates, handle_janitor_tasks, task_triggers
+from tests.support import MigTestCase, ensure_dirs_exist
 
 DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.org'
 DUMMY_FULL_NAME = "Test User"
@@ -75,11 +75,9 @@ class MigLibJanitor(MigTestCase):
 
     def before_each(self):
         """Set up test configuration and reset state before each test"""
-        # Remap test configuration to dummy_conf for consistency
-        self.dummy_conf = self.configuration
-        self.dummy_conf.site_enable_jobs = True
+        self.configuration.site_enable_jobs = True
         # Prevent admin email during reject, etc.
-        self.dummy_conf.admin_email = DUMMY_SKIP_EMAIL
+        self.configuration.admin_email = DUMMY_SKIP_EMAIL
         # Create fake fs layout matching real systems
         ensure_dirs_exist(self.configuration.user_pending)
         ensure_dirs_exist(self.configuration.user_db_home)
@@ -94,12 +92,12 @@ class MigLibJanitor(MigTestCase):
         ensure_dirs_exist(self.configuration.sessid_to_mrsl_link_home)
         ensure_dirs_exist(self.configuration.mrsl_files_dir)
         ensure_dirs_exist(self.configuration.resource_pending)
-        dummy_job = os.path.join(self.dummy_conf.user_home,
+        dummy_job = os.path.join(self.configuration.user_home,
                                  "no_grid_jobs_in_grid_scheduler")
         ensure_dirs_exist(dummy_job)
 
         # Prepare user DB with a single dummy user for all tests
-        self.user_db_path = os.path.join(self.dummy_conf.user_db_home,
+        self.user_db_path = os.path.join(self.configuration.user_db_home,
                                          DUMMY_USERDB)
         user_dict = distinguished_name_to_user(DUMMY_USER_DN)
         self._write_user_db({DUMMY_USER_DN: user_dict})
@@ -111,13 +109,13 @@ class MigLibJanitor(MigTestCase):
     def test_last_run_bookkeeping(self):
         """Register a last run timestamp and check it"""
         expect = -1
-        stamp = _lookup_last_run(self.dummy_conf, 'janitor_task')
+        stamp = _lookup_last_run(self.configuration, 'janitor_task')
         self.assertEqual(stamp, expect)
         expect = 42
-        stamp = _update_last_run(self.dummy_conf, 'janitor_task', expect)
+        stamp = _update_last_run(self.configuration, 'janitor_task', expect)
         self.assertEqual(stamp, expect)
         expect = time.time()
-        stamp = _update_last_run(self.dummy_conf, 'janitor_task', expect)
+        stamp = _update_last_run(self.configuration, 'janitor_task', expect)
         self.assertEqual(stamp, expect)
 
     def test_clean_mig_system_files(self):
@@ -126,16 +124,16 @@ class MigLibJanitor(MigTestCase):
         valid_filenames = ['fresh.log', 'current.tmp']
         stale_filenames = ['tmp_expired.txt', 'no_grid_jobs.123']
         for name in valid_filenames + stale_filenames:
-            path = os.path.join(self.dummy_conf.mig_system_files, name)
+            path = os.path.join(self.configuration.mig_system_files, name)
             with open(path, 'w') as fp:
                 fp.write('test')
             os.utime(path, (test_time, test_time))
             if name in valid_filenames:
                 # Make one file fresh
                 os.utime(path, None)
-        handled = clean_mig_system_files(self.dummy_conf)
+        handled = clean_mig_system_files(self.configuration)
         self.assertEqual(handled, len(stale_filenames))
-        self.assertEqual(len(os.listdir(self.dummy_conf.mig_system_files)),
+        self.assertEqual(len(os.listdir(self.configuration.mig_system_files)),
                          len(valid_filenames))
 
     def test_clean_webserver_home(self):
@@ -144,22 +142,22 @@ class MigLibJanitor(MigTestCase):
         valid_filename = 'fresh.log'
         stale_filename = 'stale.log'
         for name in [valid_filename, stale_filename]:
-            path = os.path.join(self.dummy_conf.webserver_home, name)
+            path = os.path.join(self.configuration.webserver_home, name)
             with open(path, 'w') as fp:
                 fp.write('test')
             os.utime(path, (test_time, test_time))
             if name == valid_filename:
                 os.utime(path, None)
-        handled = clean_webserver_home(self.dummy_conf)
+        handled = clean_webserver_home(self.configuration)
         self.assertEqual(handled, 1)
         self.assertFalse(os.path.exists(os.path.join(
-            self.dummy_conf.webserver_home, stale_filename)))
+            self.configuration.webserver_home, stale_filename)))
         self.assertTrue(os.path.exists(os.path.join(
-            self.dummy_conf.webserver_home, valid_filename)))
+            self.configuration.webserver_home, valid_filename)))
 
     def test_clean_no_job_helpers(self):
         """Test clean dummy job helper files"""
-        dummy_job = os.path.join(self.dummy_conf.user_home,
+        dummy_job = os.path.join(self.configuration.user_home,
                                  "no_grid_jobs_in_grid_scheduler")
         test_time = time.time() - EXPIRE_DUMMY_JOBS_DAYS * SECS_PER_DAY - 1
         valid_filename = 'alive.txt'
@@ -171,7 +169,7 @@ class MigLibJanitor(MigTestCase):
             os.utime(path, (test_time, test_time))
             if name == valid_filename:
                 os.utime(path, None)
-        handled = clean_no_job_helpers(self.dummy_conf)
+        handled = clean_no_job_helpers(self.configuration)
         self.assertEqual(handled, 1)
         self.assertFalse(os.path.exists(os.path.join(dummy_job,
                                                      stale_filename)))
@@ -184,18 +182,18 @@ class MigLibJanitor(MigTestCase):
         valid_filename = 'current'
         stale_filename = 'expired'
         for name in [valid_filename, stale_filename]:
-            path = os.path.join(self.dummy_conf.twofactor_home, name)
+            path = os.path.join(self.configuration.twofactor_home, name)
             with open(path, 'w') as fp:
                 fp.write('test')
             os.utime(path, (test_time, test_time))
             if name == valid_filename:
                 os.utime(path, None)
-        handled = clean_twofactor_sessions(self.dummy_conf)
+        handled = clean_twofactor_sessions(self.configuration)
         self.assertEqual(handled, 1)
         self.assertFalse(os.path.exists(os.path.join(
-            self.dummy_conf.twofactor_home, stale_filename)))
+            self.configuration.twofactor_home, stale_filename)))
         self.assertTrue(os.path.exists(os.path.join(
-            self.dummy_conf.twofactor_home, valid_filename)))
+            self.configuration.twofactor_home, valid_filename)))
 
     def test_clean_sessid_to_mrls_link_home(self):
         """Test clean session MRSL link files"""
@@ -203,28 +201,29 @@ class MigLibJanitor(MigTestCase):
         valid_filename = 'active_session_link'
         stale_filename = 'expired_session_link'
         for name in [valid_filename, stale_filename]:
-            path = os.path.join(self.dummy_conf.sessid_to_mrsl_link_home, name)
+            path = os.path.join(
+                self.configuration.sessid_to_mrsl_link_home, name)
             with open(path, 'w') as fp:
                 fp.write('test')
             os.utime(path, (test_time, test_time))
             if name == valid_filename:
                 os.utime(path, None)
-        handled = clean_sessid_to_mrls_link_home(self.dummy_conf)
+        handled = clean_sessid_to_mrls_link_home(self.configuration)
         self.assertEqual(handled, 1)
         self.assertFalse(os.path.exists(os.path.join(
-            self.dummy_conf.sessid_to_mrsl_link_home, stale_filename)))
+            self.configuration.sessid_to_mrsl_link_home, stale_filename)))
         self.assertTrue(os.path.exists(os.path.join(
-            self.dummy_conf.sessid_to_mrsl_link_home, valid_filename)))
+            self.configuration.sessid_to_mrsl_link_home, valid_filename)))
 
     def test_handle_state_cleanup(self):
         """Test combined state cleanup"""
         # Create a stale file in each location to clean up
         test_time = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
         mig_path = os.path.join(
-            self.dummy_conf.mig_system_files, 'tmpAbCd1234')
-        web_path = os.path.join(self.dummy_conf.webserver_home, 'stale.txt')
+            self.configuration.mig_system_files, 'tmpAbCd1234')
+        web_path = os.path.join(self.configuration.webserver_home, 'stale.txt')
         empty_job_path = os.path.join(
-            os.path.join(self.dummy_conf.user_home,
+            os.path.join(self.configuration.user_home,
                          "no_grid_jobs_in_grid_scheduler"),
             'sleep.job'
         )
@@ -234,7 +233,7 @@ class MigLibJanitor(MigTestCase):
                 fp.write('test')
             os.utime(path, (test_time, test_time))
 
-        handled = handle_state_cleanup(self.dummy_conf)
+        handled = handle_state_cleanup(self.configuration)
         self.assertEqual(handled, 3)
 
     def test_handle_session_cleanup(self):
@@ -242,16 +241,16 @@ class MigLibJanitor(MigTestCase):
         test_time = time.time() - max(EXPIRE_STATE_DAYS,
                                       EXPIRE_TWOFACTOR_DAYS) * SECS_PER_DAY - 1
         session_path = os.path.join(
-            self.dummy_conf.sessid_to_mrsl_link_home, 'expired.txt')
+            self.configuration.sessid_to_mrsl_link_home, 'expired.txt')
         twofactor_path = os.path.join(
-            self.dummy_conf.twofactor_home, 'expired.txt')
+            self.configuration.twofactor_home, 'expired.txt')
         for path in [session_path, twofactor_path]:
             os.makedirs(os.path.dirname(path), exist_ok=True)
             with open(path, 'w') as fp:
                 fp.write('test')
             os.utime(path, (test_time, test_time))
 
-        handled = handle_session_cleanup(self.dummy_conf)
+        handled = handle_session_cleanup(self.configuration)
         self.assertEqual(handled, 2)
 
     def test_manage_pending_user_request(self):
@@ -269,18 +268,18 @@ class MigLibJanitor(MigTestCase):
             'email': DUMMY_EMAIL,
         }
 
-        self.assertDirEmpty(self.dummy_conf.user_pending)
-        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        self.assertDirEmpty(self.configuration.user_pending)
+        saved, req_path = save_account_request(self.configuration, req_dict)
         self.assertTrue(saved, "failed to save account req")
-        self.assertDirNotEmpty(self.dummy_conf.user_pending)
+        self.assertDirNotEmpty(self.configuration.user_pending)
         # Update mtime to make it ready for janitor
         req_age = time.time() - MANAGE_TRIVIAL_REQ_MINUTES * SECS_PER_MINUTE - 1
         os.utime(req_path, (req_age, req_age))
 
         # Need user DB and path to simulate existing user
-        user_dir = os.path.join(self.dummy_conf.user_home, DUMMY_CLIENT_DIR)
+        user_dir = os.path.join(self.configuration.user_home, DUMMY_CLIENT_DIR)
         os.makedirs(user_dir)
-        handled = manage_trivial_user_requests(self.dummy_conf)
+        handled = manage_trivial_user_requests(self.configuration)
         self.assertEqual(handled, 1)
 
     def test_expire_user_pending(self):
@@ -296,16 +295,16 @@ class MigLibJanitor(MigTestCase):
             'peers': [DUMMY_PEER_DN],
             'email': DUMMY_EMAIL,
         }
-        self.assertDirEmpty(self.dummy_conf.user_pending)
-        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        self.assertDirEmpty(self.configuration.user_pending)
+        saved, req_path = save_account_request(self.configuration, req_dict)
         self.assertTrue(saved, "failed to save account req")
-        self.assertDirNotEmpty(self.dummy_conf.user_pending)
+        self.assertDirNotEmpty(self.configuration.user_pending)
         # Make request very old
         req_age = time.time() - EXPIRE_REQ_DAYS * SECS_PER_DAY - 1
         os.utime(req_path, (req_age, req_age))
 
         # TODO: rework to handle expire before stale to avoid duplicate here
-        handled = remind_and_expire_user_pending(self.dummy_conf)
+        handled = remind_and_expire_user_pending(self.configuration)
         # self.assertEqual(handled, 1)
         self.assertEqual(handled, 2)  # counted stale and expired (see above)
 
@@ -323,11 +322,11 @@ class MigLibJanitor(MigTestCase):
             'peers': [DUMMY_PEER_DN],
             'email': DUMMY_EMAIL,
         }
-        self.assertDirEmpty(self.dummy_conf.user_pending)
-        saved, valid_req_path = save_account_request(self.dummy_conf,
+        self.assertDirEmpty(self.configuration.user_pending)
+        saved, valid_req_path = save_account_request(self.configuration,
                                                      valid_dict)
         self.assertTrue(saved, "failed to save valid req")
-        self.assertDirNotEmpty(self.dummy_conf.user_pending)
+        self.assertDirNotEmpty(self.configuration.user_pending)
         valid_id = os.path.basename(valid_req_path)
 
         expired_id = 'expired_req'
@@ -342,30 +341,31 @@ class MigLibJanitor(MigTestCase):
             'email': DUMMY_EMAIL,
         }
         saved, expired_req_path = save_account_request(
-            self.dummy_conf, expired_dict)
+            self.configuration, expired_dict)
         self.assertTrue(saved, "failed to save expired req")
         expired_id = os.path.basename(expired_req_path)
         # Make just one old enough to expire
         expire_time = time.time() - EXPIRE_REQ_DAYS * SECS_PER_DAY - 1
-        os.utime(os.path.join(self.dummy_conf.user_pending, expired_id),
+        os.utime(os.path.join(self.configuration.user_pending, expired_id),
                  (expire_time, expire_time))
 
         # TODO: rework to handle expire before stale to avoid duplicate here
-        handled = handle_pending_requests(self.dummy_conf)
+        handled = handle_pending_requests(self.configuration)
         # self.assertEqual(handled, 2)  # 1 manage + 1 expire
         self.assertEqual(handled, 3)  # 1 manage + 1 expire + 1 stale
 
     def test_handle_janitor_tasks_full(self):
         """Test full janitor task scheduler"""
         # Prepare environment with pending tasks
-        mig_path = os.path.join(self.dummy_conf.mig_system_files, 'stale.txt')
+        mig_path = os.path.join(
+            self.configuration.mig_system_files, 'stale.txt')
         with open(mig_path, 'w') as fp:
             fp.write('test')
         os.utime(mig_path,
                  (time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1,
                   time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1))
 
-        two_path = os.path.join(self.dummy_conf.twofactor_home, 'stale.txt')
+        two_path = os.path.join(self.configuration.twofactor_home, 'stale.txt')
         with open(two_path, 'w') as fp:
             fp.write('test')
         os.utime(two_path,
@@ -383,14 +383,14 @@ class MigLibJanitor(MigTestCase):
             'peers': [DUMMY_PEER_DN],
             'email': DUMMY_EMAIL,
         }
-        self.assertDirEmpty(self.dummy_conf.user_pending)
-        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        self.assertDirEmpty(self.configuration.user_pending)
+        saved, req_path = save_account_request(self.configuration, req_dict)
         self.assertTrue(saved, "failed to save account req")
-        self.assertDirNotEmpty(self.dummy_conf.user_pending)
+        self.assertDirNotEmpty(self.configuration.user_pending)
         req_id = os.path.basename(req_path)
         # Make request very old
         req_age = time.time() - EXPIRE_REQ_DAYS * SECS_PER_DAY - 1
-        os.utime(os.path.join(self.dummy_conf.user_pending, req_id),
+        os.utime(os.path.join(self.configuration.user_pending, req_id),
                  (req_age, req_age))
 
         # Set no last run timestamps to trigger all tasks
@@ -399,7 +399,7 @@ class MigLibJanitor(MigTestCase):
 
         # Run task handler and verify all tasks executed
         # TODO: rework to handle expire before stale to avoid duplicate here
-        handled = handle_janitor_tasks(self.dummy_conf, now=now)
+        handled = handle_janitor_tasks(self.configuration, now=now)
         # self.assertEqual(handled, 3)  # state+session+requests
         self.assertEqual(handled, 4)  # state (expired+stale)+session+requests
 
@@ -425,7 +425,7 @@ class MigLibJanitor(MigTestCase):
             os.utime(path, (mtime, mtime))
 
         handled = _clean_stale_state_files(
-            self.dummy_conf,
+            self.configuration,
             test_dir,
             patterns,
             EXPIRE_STATE_DAYS,
@@ -452,12 +452,12 @@ class MigLibJanitor(MigTestCase):
             # NOTE: disable email to prevent send failing on reject
             'email': DUMMY_SKIP_EMAIL,
         }
-        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        saved, req_path = save_account_request(self.configuration, req_dict)
         req_id = os.path.basename(req_path)
 
         with self.assertLogs(level='INFO') as log_capture:
             manage_single_req(
-                self.dummy_conf,
+                self.configuration,
                 req_id,
                 req_path,
                 self.user_db_path,
@@ -482,7 +482,7 @@ class MigLibJanitor(MigTestCase):
             'reset_token': 'INVALID_TOKEN',
             'expire': time.time() - SECS_PER_DAY,
         }
-        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        saved, req_path = save_account_request(self.configuration, req_dict)
         req_id = os.path.basename(req_path)
 
         user_dict = {'distinguished_name': DUMMY_USER_DN,
@@ -491,7 +491,7 @@ class MigLibJanitor(MigTestCase):
 
         with self.assertLogs(level='WARNING') as log_capture:
             manage_single_req(
-                self.dummy_conf,
+                self.configuration,
                 req_id,
                 req_path,
                 self.user_db_path,
@@ -505,7 +505,7 @@ class MigLibJanitor(MigTestCase):
     def test_manage_single_req_collision(self):
         """Test request handling with existing user collision"""
         # Setup existing user
-        user_dir = os.path.join(self.dummy_conf.user_home, DUMMY_CLIENT_DIR)
+        user_dir = os.path.join(self.configuration.user_home, DUMMY_CLIENT_DIR)
         os.makedirs(user_dir)
         # Create dummy user DB
         user_entry = {'distinguished_name': DUMMY_USER_DN}
@@ -524,12 +524,12 @@ class MigLibJanitor(MigTestCase):
             # NOTE: disable email to prevent send failing on reject
             'email': DUMMY_SKIP_EMAIL,
         }
-        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        saved, req_path = save_account_request(self.configuration, req_dict)
         req_id = os.path.basename(req_path)
 
         with self.assertLogs(level='WARNING') as log_capture:
             manage_single_req(
-                self.dummy_conf,
+                self.configuration,
                 req_id,
                 req_path,
                 self.user_db_path,
@@ -542,7 +542,7 @@ class MigLibJanitor(MigTestCase):
 
     def test_handle_cache_updates_stub(self):
         """Test handle_cache_updates placeholder returns zero"""
-        handled = handle_cache_updates(self.dummy_conf)
+        handled = handle_cache_updates(self.configuration)
         self.assertEqual(handled, 0)
 
     def test_janitor_update_timestamps(self):
@@ -551,15 +551,15 @@ class MigLibJanitor(MigTestCase):
         task = 'test-task'
 
         # Initial state
-        stamp = _lookup_last_run(self.dummy_conf, task)
+        stamp = _lookup_last_run(self.configuration, task)
         self.assertEqual(stamp, -1)
 
         # Update & verify
-        updated = _update_last_run(self.dummy_conf, task, now)
+        updated = _update_last_run(self.configuration, task, now)
         self.assertEqual(updated, now)
 
         # Check persistence (within process)
-        retrieved = _lookup_last_run(self.dummy_conf, task)
+        retrieved = _lookup_last_run(self.configuration, task)
         self.assertEqual(retrieved, now)
 
     def test__clean_stale_state_files_edge(self):
@@ -579,7 +579,7 @@ class MigLibJanitor(MigTestCase):
         os.makedirs(dir_path)
 
         handled = _clean_stale_state_files(
-            self.dummy_conf,
+            self.configuration,
             test_dir,
             ['*'],
             EXPIRE_STATE_DAYS,
@@ -590,7 +590,7 @@ class MigLibJanitor(MigTestCase):
 
         # Now include dotfiles
         handled = _clean_stale_state_files(
-            self.dummy_conf,
+            self.configuration,
             test_dir,
             ['*'],
             EXPIRE_STATE_DAYS,
@@ -604,13 +604,13 @@ class MigLibJanitor(MigTestCase):
     def test_manage_single_req_corrupted_file(self):
         """Test manage_single_req with corrupted request file"""
         req_id = 'corrupted_req'
-        req_path = os.path.join(self.dummy_conf.user_pending, req_id)
+        req_path = os.path.join(self.configuration.user_pending, req_id)
         with open(req_path, 'w') as fp:
             fp.write('invalid pickle content')
 
         with self.assertLogs(level='ERROR') as log_capture:
             manage_single_req(
-                self.dummy_conf,
+                self.configuration,
                 req_id,
                 req_path,
                 self.user_db_path,
@@ -632,7 +632,7 @@ class MigLibJanitor(MigTestCase):
             'password_hash': DUMMY_MODERN_PW_PBKDF2,
             'email': DUMMY_SKIP_EMAIL,
         }
-        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        saved, req_path = save_account_request(self.configuration, req_dict)
         req_id = os.path.basename(req_path)
 
         # Remove user database
@@ -640,7 +640,7 @@ class MigLibJanitor(MigTestCase):
 
         with self.assertLogs(level='ERROR') as log_capture:
             manage_single_req(
-                self.dummy_conf,
+                self.configuration,
                 req_id,
                 req_path,
                 self.user_db_path,
@@ -662,12 +662,12 @@ class MigLibJanitor(MigTestCase):
             'reset_token': 'INVALID_TOKEN_HERE',
             'expire': time.time() + SECS_PER_DAY,  # Future expiration
         }
-        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        saved, req_path = save_account_request(self.configuration, req_dict)
         req_id = os.path.basename(req_path)
 
         with self.assertLogs(level='WARNING') as log_capture:
             manage_single_req(
-                self.dummy_conf,
+                self.configuration,
                 req_id,
                 req_path,
                 self.user_db_path,
@@ -686,7 +686,7 @@ class MigLibJanitor(MigTestCase):
         ]
 
         for (req_id, mtime) in test_cases:
-            req_path = os.path.join(self.dummy_conf.user_pending, req_id)
+            req_path = os.path.join(self.configuration.user_pending, req_id)
             req_dict = {
                 'client_id': DUMMY_USER_DN,
                 'distinguished_name': DUMMY_USER_DN,
@@ -696,10 +696,11 @@ class MigLibJanitor(MigTestCase):
                 'password': DUMMY_MODERN_PW,
                 'email': DUMMY_EMAIL,
             }
-            saved, req_path = save_account_request(self.dummy_conf, req_dict)
+            saved, req_path = save_account_request(
+                self.configuration, req_dict)
             os.utime(req_path, (mtime, mtime))
 
-        handled = remind_and_expire_user_pending(self.dummy_conf, now=now)
+        handled = remind_and_expire_user_pending(self.configuration, now=now)
         # TODO: rework to handle expire before stale to avoid duplicates here
         # Should match exact_expire only
         # self.assertEqual(handled, 1)
@@ -710,13 +711,13 @@ class MigLibJanitor(MigTestCase):
         now = time.time()
 
         self.assertEqual(_lookup_last_run(
-            self.dummy_conf, "state-cleanup"), -1)
+            self.configuration, "state-cleanup"), -1)
         self.assertEqual(_lookup_last_run(
-            self.dummy_conf, "session-cleanup"), -1)
+            self.configuration, "session-cleanup"), -1)
         self.assertEqual(_lookup_last_run(
-            self.dummy_conf, "pending-reqs"), -1)
+            self.configuration, "pending-reqs"), -1)
         self.assertEqual(_lookup_last_run(
-            self.dummy_conf, "cache-updates"), -1)
+            self.configuration, "cache-updates"), -1)
         # Test all tasks EXCEPT cache-updates are past threshold
         last_state_cleanup = now - SECS_PER_DAY - 3
         last_session_cleanup = now - SECS_PER_HOUR - 3
@@ -727,35 +728,35 @@ class MigLibJanitor(MigTestCase):
                               'pending-reqs': last_pending_reqs,
                               'cache-updates': last_cache_update})
         self.assertEqual(_lookup_last_run(
-            self.dummy_conf, "state-cleanup"), last_state_cleanup)
+            self.configuration, "state-cleanup"), last_state_cleanup)
         self.assertEqual(_lookup_last_run(
-            self.dummy_conf, "session-cleanup"), last_session_cleanup)
+            self.configuration, "session-cleanup"), last_session_cleanup)
         self.assertEqual(_lookup_last_run(
-            self.dummy_conf, "cache-updates"), last_cache_update)
+            self.configuration, "cache-updates"), last_cache_update)
 
         # TODO: handled does NOT count no action runs - add dummies to handle?
-        handled = handle_janitor_tasks(self.dummy_conf, now=now)
+        handled = handle_janitor_tasks(self.configuration, now=now)
         # self.assertEqual(handled, 3)  # state + session + pending
         self.assertEqual(handled, 0)  # ran with nothing to do
 
         # Verify last run timestamps updated
         self.assertEqual(_lookup_last_run(
-            self.dummy_conf, "state-cleanup"), now)
+            self.configuration, "state-cleanup"), now)
         self.assertEqual(_lookup_last_run(
-            self.dummy_conf, "session-cleanup"), now)
+            self.configuration, "session-cleanup"), now)
         self.assertEqual(_lookup_last_run(
-            self.dummy_conf, "pending-reqs"), now)
+            self.configuration, "pending-reqs"), now)
         self.assertEqual(_lookup_last_run(
-            self.dummy_conf, "cache-updates"), last_cache_update)
+            self.configuration, "cache-updates"), last_cache_update)
 
     # TODO: adjust tested function to allow enabling the next test
     @unittest.skipIf(True, "requires improved cleaner error handling")
     def test_clean_stale_files_nonexistent_dir(self):
         """Test state cleaner with invalid directory path"""
-        target_dir = os.path.join(self.dummy_conf.mig_system_files,
+        target_dir = os.path.join(self.configuration.mig_system_files,
                                   "non_existing_dir")
         handled = _clean_stale_state_files(
-            self.dummy_conf,
+            self.configuration,
             target_dir,
             ["*"],
             EXPIRE_STATE_DAYS,
@@ -780,7 +781,7 @@ class MigLibJanitor(MigTestCase):
 
         with self.assertLogs(level='ERROR'):
             handled = _clean_stale_state_files(
-                self.dummy_conf,
+                self.configuration,
                 test_dir,
                 ["*"],
                 EXPIRE_STATE_DAYS,
@@ -794,14 +795,14 @@ class MigLibJanitor(MigTestCase):
     def test_handle_empty_pending_dir(self):
         """Test operations with empty pending requests directory"""
         # Empty directory completely
-        for filename in os.listdir(self.dummy_conf.user_pending):
-            path = os.path.join(self.dummy_conf.user_pending, filename)
+        for filename in os.listdir(self.configuration.user_pending):
+            path = os.path.join(self.configuration.user_pending, filename)
             os.remove(path)
 
-        handled = manage_trivial_user_requests(self.dummy_conf)
+        handled = manage_trivial_user_requests(self.configuration)
         self.assertEqual(handled, 0)
 
-        handled = remind_and_expire_user_pending(self.dummy_conf)
+        handled = remind_and_expire_user_pending(self.configuration)
         self.assertEqual(handled, 0)
 
     def test_janitor_task_cleanup_after_reject(self):
@@ -815,14 +816,14 @@ class MigLibJanitor(MigTestCase):
             'organization': DUMMY_ORGANIZATION,
             'email': DUMMY_SKIP_EMAIL,
         }
-        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        saved, req_path = save_account_request(self.configuration, req_dict)
         req_id = os.path.basename(req_path)
 
         # Verify initial existence
         self.assertTrue(os.path.exists(req_path))
 
         manage_single_req(
-            self.dummy_conf,
+            self.configuration,
             req_id,
             req_path,
             self.user_db_path,

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -741,9 +741,8 @@ class MigLibJanitor(MigTestCase):
         # Verify last run timestamps updated
         self.assertEqual(_lookup_last_run(
             self.dummy_conf, "state-cleanup"), now)
-        # TODO: fix copy/paste bug in tested function and enable next
-        # self.assertEqual(_lookup_last_run(
-        #    self.dummy_conf, "session-cleanup"), now)
+        self.assertEqual(_lookup_last_run(
+            self.dummy_conf, "session-cleanup"), now)
         self.assertEqual(_lookup_last_run(
             self.dummy_conf, "pending-reqs"), now)
         self.assertEqual(_lookup_last_run(

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -604,8 +604,7 @@ class MigLibJanitor(MigTestCase):
         )
         self.assertEqual(handled, 1)
 
-    # TODO: adjust tested function to allow enabling the next test
-    @unittest.skipIf(True, "requires improved unpickling error handling")
+    @unittest.skip("TODO: enable once unpickling error handling is improved")
     def test_manage_single_req_corrupted_file(self):
         """Test manage_single_req with corrupted request file"""
         req_id = 'corrupted_req'
@@ -623,6 +622,7 @@ class MigLibJanitor(MigTestCase):
             )
 
         self.assertTrue(any('Failed to load request from' in msg
+                            or 'Could not load saved request' in msg
                             for msg in log_capture.output))
         self.assertFalse(os.path.exists(req_path))
 
@@ -682,6 +682,7 @@ class MigLibJanitor(MigTestCase):
             )
 
         self.assertTrue(any('bad token' in msg.lower()
+                            or 'password reset' in msg.lower()
                             for msg in log_capture.output))
 
     def test_remind_and_expire_edge_cases(self):
@@ -756,8 +757,7 @@ class MigLibJanitor(MigTestCase):
         self.assertEqual(_lookup_last_run(
             self.configuration, "cache-updates"), last_cache_update)
 
-    # TODO: adjust tested function to allow enabling the next test
-    @unittest.skipIf(True, "requires improved cleaner error handling")
+    @unittest.skip("TODO: enable once cleaner has improved error handling")
     def test_clean_stale_files_nonexistent_dir(self):
         """Test state cleaner with invalid directory path"""
         target_dir = os.path.join(self.configuration.mig_system_files,
@@ -771,8 +771,7 @@ class MigLibJanitor(MigTestCase):
         )
         self.assertEqual(handled, 0)
 
-    # TODO: adjust tested function to allow enabling the next test
-    @unittest.skipIf(True, "requires improved cleaner error handling")
+    @unittest.skip("TODO: enable once cleaner has improved error handling")
     def test_clean_stale_files_permission_error(self):
         """Test state cleaner handles permission errors gracefully"""
         test_dir = self.temppath("readonly_dir", ensure_dir=True)
@@ -840,3 +839,54 @@ class MigLibJanitor(MigTestCase):
 
         # Verify post-execution cleanup
         self.assertFalse(os.path.exists(req_path))
+
+    def test_cleaner_with_multiple_patterns(self):
+        """Test state cleaner with multiple filename patterns"""
+        test_dir = self.temppath('multi_pattern_test', ensure_dir=True)
+        clean_patterns = ['*.tmp', '*.log', 'temp*']
+        clean_pairs = [
+            ('should_keep_recent.log', EXPIRE_STATE_DAYS - 1),
+            ('should_remove_stale.tmp', EXPIRE_STATE_DAYS + 1),
+            ('should_keep_other.pck', EXPIRE_STATE_DAYS + 1)
+        ]
+
+        for (name, age_days) in clean_pairs:
+            path = os.path.join(test_dir, name)
+            with open(path, 'w') as fp:
+                fp.write('test')
+            mtime = time.time() - age_days * SECS_PER_DAY
+            os.utime(path, (mtime, mtime))
+
+        self.assertTrue(os.path.exists(
+            os.path.join(test_dir, 'should_keep_recent.log')))
+        self.assertTrue(os.path.exists(
+            os.path.join(test_dir, 'should_remove_stale.tmp')))
+        self.assertTrue(os.path.exists(
+            os.path.join(test_dir, 'should_keep_other.pck')))
+
+        handled = _clean_stale_state_files(
+            self.configuration,
+            test_dir,
+            clean_patterns,
+            EXPIRE_STATE_DAYS,
+            time.time()
+        )
+        self.assertEqual(handled, 1)
+        self.assertTrue(os.path.exists(
+            os.path.join(test_dir, 'should_keep_recent.log')))
+        self.assertFalse(os.path.exists(
+            os.path.join(test_dir, 'should_remove_stale.tmp')))
+        self.assertTrue(os.path.exists(
+            os.path.join(test_dir, 'should_keep_other.pck')))
+
+    def test_absent_jobs_flag(self):
+        """Test clean_no_job_helpers with site_enable_jobs disabled"""
+        self.configuration.site_enable_jobs = False
+        handled = clean_no_job_helpers(self.configuration)
+        self.assertEqual(handled, 0)
+
+    def test_clean_sessions_jobs_disabled(self):
+        """Test session cleanup with jobs disabled"""
+        self.configuration.site_enable_jobs = False
+        handled = clean_sessid_to_mrls_link_home(self.configuration)
+        self.assertEqual(handled, 0)

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -79,6 +79,12 @@ class MigLibJanitor(MigTestCase):
         user_dict = distinguished_name_to_user(user_id)
         self._write_user_db({user_id: user_dict})
 
+    def _prepare_test_file(self, path, times=None, content='test'):
+        """Prepare file in path with optional times for timestamp"""
+        with open(path, 'w') as fp:
+            fp.write(content)
+        os.utime(path, times)
+
     def before_each(self):
         """Set up test configuration and reset state before each test"""
         self.configuration.site_enable_jobs = True
@@ -130,100 +136,97 @@ class MigLibJanitor(MigTestCase):
         stale_filenames = ['tmp_expired.txt', 'no_grid_jobs.123']
         for name in valid_filenames + stale_filenames:
             path = os.path.join(self.configuration.mig_system_files, name)
-            with open(path, 'w') as fp:
-                fp.write('test')
-            os.utime(path, (test_time, test_time))
-            if name in valid_filenames:
-                # Make one file fresh
-                os.utime(path, None)
+            self._prepare_test_file(path, (test_time, test_time))
+            self.assertTrue(os.path.exists(path))
+
         handled = clean_mig_system_files(self.configuration)
         self.assertEqual(handled, len(stale_filenames))
         self.assertEqual(len(os.listdir(self.configuration.mig_system_files)),
                          len(valid_filenames))
+        for name in valid_filenames:
+            path = os.path.join(self.configuration.mig_system_files, name)
+            self.assertTrue(os.path.exists(path))
+        for name in stale_filenames:
+            path = os.path.join(self.configuration.mig_system_files, name)
+            self.assertFalse(os.path.exists(path))
 
     def test_clean_webserver_home(self):
         """Test clean webserver files helper"""
-        test_time = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        stale_stamp = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        test_dir = self.configuration.webserver_home
         valid_filename = 'fresh.log'
         stale_filename = 'stale.log'
-        for name in [valid_filename, stale_filename]:
-            path = os.path.join(self.configuration.webserver_home, name)
-            with open(path, 'w') as fp:
-                fp.write('test')
-            os.utime(path, (test_time, test_time))
-            if name == valid_filename:
-                os.utime(path, None)
+        valid_path = os.path.join(test_dir, valid_filename)
+        stale_path = os.path.join(test_dir, stale_filename)
+        self._prepare_test_file(valid_path)
+        self._prepare_test_file(stale_path, (stale_stamp, stale_stamp))
+
+        self.assertTrue(os.path.exists(valid_path))
+        self.assertTrue(os.path.exists(stale_path))
         handled = clean_webserver_home(self.configuration)
         self.assertEqual(handled, 1)
-        self.assertFalse(os.path.exists(os.path.join(
-            self.configuration.webserver_home, stale_filename)))
-        self.assertTrue(os.path.exists(os.path.join(
-            self.configuration.webserver_home, valid_filename)))
+        self.assertTrue(os.path.exists(valid_path))
+        self.assertFalse(os.path.exists(stale_path))
 
     def test_clean_no_job_helpers(self):
         """Test clean dummy job helper files"""
-        dummy_job = os.path.join(self.configuration.user_home,
-                                 "no_grid_jobs_in_grid_scheduler")
-        test_time = time.time() - EXPIRE_DUMMY_JOBS_DAYS * SECS_PER_DAY - 1
+        stale_stamp = time.time() - EXPIRE_DUMMY_JOBS_DAYS * SECS_PER_DAY - 1
+        test_dir = os.path.join(self.configuration.user_home,
+                                "no_grid_jobs_in_grid_scheduler")
         valid_filename = 'alive.txt'
         stale_filename = 'expired.txt'
-        for name in [valid_filename, stale_filename]:
-            path = os.path.join(dummy_job, name)
-            with open(path, 'w') as fp:
-                fp.write('test')
-            os.utime(path, (test_time, test_time))
-            if name == valid_filename:
-                os.utime(path, None)
+        valid_path = os.path.join(test_dir, valid_filename)
+        stale_path = os.path.join(test_dir, stale_filename)
+        self._prepare_test_file(valid_path)
+        self._prepare_test_file(stale_path, (stale_stamp, stale_stamp))
+
+        self.assertTrue(os.path.exists(stale_path))
+        self.assertTrue(os.path.exists(valid_path))
         handled = clean_no_job_helpers(self.configuration)
         self.assertEqual(handled, 1)
-        self.assertFalse(os.path.exists(os.path.join(dummy_job,
-                                                     stale_filename)))
-        self.assertTrue(os.path.exists(os.path.join(dummy_job,
-                                                    valid_filename)))
+        self.assertFalse(os.path.exists(stale_path))
+        self.assertTrue(os.path.exists(valid_path))
 
     def test_clean_twofactor_sessions(self):
         """Test clean twofactor sessions"""
-        test_time = time.time() - EXPIRE_TWOFACTOR_DAYS * SECS_PER_DAY - 1
+        stale_stamp = time.time() - EXPIRE_TWOFACTOR_DAYS * SECS_PER_DAY - 1
+        test_dir = self.configuration.twofactor_home
         valid_filename = 'current'
         stale_filename = 'expired'
-        for name in [valid_filename, stale_filename]:
-            path = os.path.join(self.configuration.twofactor_home, name)
-            with open(path, 'w') as fp:
-                fp.write('test')
-            os.utime(path, (test_time, test_time))
-            if name == valid_filename:
-                os.utime(path, None)
+        valid_path = os.path.join(test_dir, valid_filename)
+        stale_path = os.path.join(test_dir, stale_filename)
+        self._prepare_test_file(valid_path)
+        self._prepare_test_file(stale_path, (stale_stamp, stale_stamp))
+
+        self.assertTrue(os.path.exists(stale_path))
+        self.assertTrue(os.path.exists(valid_path))
         handled = clean_twofactor_sessions(self.configuration)
         self.assertEqual(handled, 1)
-        self.assertFalse(os.path.exists(os.path.join(
-            self.configuration.twofactor_home, stale_filename)))
-        self.assertTrue(os.path.exists(os.path.join(
-            self.configuration.twofactor_home, valid_filename)))
+        self.assertFalse(os.path.exists(stale_path))
+        self.assertTrue(os.path.exists(valid_path))
 
     def test_clean_sessid_to_mrls_link_home(self):
         """Test clean session MRSL link files"""
-        test_time = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        stale_stamp = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        test_dir = self.configuration.sessid_to_mrsl_link_home
         valid_filename = 'active_session_link'
         stale_filename = 'expired_session_link'
-        for name in [valid_filename, stale_filename]:
-            path = os.path.join(
-                self.configuration.sessid_to_mrsl_link_home, name)
-            with open(path, 'w') as fp:
-                fp.write('test')
-            os.utime(path, (test_time, test_time))
-            if name == valid_filename:
-                os.utime(path, None)
+        valid_path = os.path.join(test_dir, valid_filename)
+        stale_path = os.path.join(test_dir, stale_filename)
+        self._prepare_test_file(valid_path)
+        self._prepare_test_file(stale_path, (stale_stamp, stale_stamp))
+
+        self.assertTrue(os.path.exists(stale_path))
+        self.assertTrue(os.path.exists(valid_path))
         handled = clean_sessid_to_mrls_link_home(self.configuration)
         self.assertEqual(handled, 1)
-        self.assertFalse(os.path.exists(os.path.join(
-            self.configuration.sessid_to_mrsl_link_home, stale_filename)))
-        self.assertTrue(os.path.exists(os.path.join(
-            self.configuration.sessid_to_mrsl_link_home, valid_filename)))
+        self.assertFalse(os.path.exists(stale_path))
+        self.assertTrue(os.path.exists(valid_path))
 
     def test_handle_state_cleanup(self):
         """Test combined state cleanup"""
         # Create a stale file in each location to clean up
-        test_time = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        stale_stamp = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
         mig_path = os.path.join(
             self.configuration.mig_system_files, 'tmpAbCd1234')
         web_path = os.path.join(self.configuration.webserver_home, 'stale.txt')
@@ -232,31 +235,35 @@ class MigLibJanitor(MigTestCase):
                          "no_grid_jobs_in_grid_scheduler"),
             'sleep.job'
         )
-        for path in [mig_path, web_path, empty_job_path]:
+        stale_paths = [mig_path, web_path, empty_job_path]
+        for path in stale_paths:
             os.makedirs(os.path.dirname(path), exist_ok=True)
-            with open(path, 'w') as fp:
-                fp.write('test')
-            os.utime(path, (test_time, test_time))
+            self._prepare_test_file(path, (stale_stamp, stale_stamp))
+            self.assertTrue(os.path.exists(path))
 
         handled = handle_state_cleanup(self.configuration)
         self.assertEqual(handled, 3)
+        for path in stale_paths:
+            self.assertFalse(os.path.exists(path))
 
     def test_handle_session_cleanup(self):
         """Test combined session cleanup"""
-        test_time = time.time() - max(EXPIRE_STATE_DAYS,
-                                      EXPIRE_TWOFACTOR_DAYS) * SECS_PER_DAY - 1
+        stale_stamp = time.time() - max(EXPIRE_STATE_DAYS,
+                                        EXPIRE_TWOFACTOR_DAYS) * SECS_PER_DAY - 1
         session_path = os.path.join(
             self.configuration.sessid_to_mrsl_link_home, 'expired.txt')
         twofactor_path = os.path.join(
             self.configuration.twofactor_home, 'expired.txt')
-        for path in [session_path, twofactor_path]:
+        test_paths = [session_path, twofactor_path]
+        for path in test_paths:
             os.makedirs(os.path.dirname(path), exist_ok=True)
-            with open(path, 'w') as fp:
-                fp.write('test')
-            os.utime(path, (test_time, test_time))
+            self._prepare_test_file(path, (stale_stamp, stale_stamp))
+            self.assertTrue(os.path.exists(path))
 
         handled = handle_session_cleanup(self.configuration)
         self.assertEqual(handled, 2)
+        for path in test_paths:
+            self.assertFalse(os.path.exists(path))
 
     def test_manage_pending_user_request(self):
         """Test pending user request management"""
@@ -361,21 +368,16 @@ class MigLibJanitor(MigTestCase):
 
     def test_handle_janitor_tasks_full(self):
         """Test full janitor task scheduler"""
-        # Prepare environment with pending tasks
-        mig_path = os.path.join(
-            self.configuration.mig_system_files, 'stale.txt')
-        with open(mig_path, 'w') as fp:
-            fp.write('test')
-        os.utime(mig_path,
-                 (time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1,
-                  time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1))
-
+        # Prepare environment with pending tasks of each kind
+        mig_stamp = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        mig_path = os.path.join(self.configuration.mig_system_files,
+                                'tmp-stale.txt')
         two_path = os.path.join(self.configuration.twofactor_home, 'stale.txt')
-        with open(two_path, 'w') as fp:
-            fp.write('test')
-        os.utime(two_path,
-                 (time.time() - EXPIRE_TWOFACTOR_DAYS * SECS_PER_DAY - 1,
-                  time.time() - EXPIRE_TWOFACTOR_DAYS * SECS_PER_DAY - 1))
+        two_stamp = time.time() - EXPIRE_TWOFACTOR_DAYS * SECS_PER_DAY - 1
+        stale_tests = ((mig_path, mig_stamp), (two_path, two_stamp), )
+        for (stale_path, stale_stamp) in stale_tests:
+            self._prepare_test_file(stale_path, (stale_stamp, stale_stamp))
+            self.assertTrue(os.path.exists(stale_path))
 
         req_id = 'expired_request'
         req_dict = {
@@ -403,10 +405,12 @@ class MigLibJanitor(MigTestCase):
         task_triggers.clear()
 
         # Run task handler and verify all tasks executed
-        # TODO: rework to handle expire before stale to avoid duplicate here
+        # TODO: rework to handle expire before stale to avoid req tripled here
         handled = handle_janitor_tasks(self.configuration, now=now)
         # self.assertEqual(handled, 3)  # state+session+requests
-        self.assertEqual(handled, 4)  # state (expired+stale)+session+requests
+        self.assertEqual(handled, 5)  # state+session+3*request
+        for (stale_path, _) in stale_tests:
+            self.assertFalse(os.path.exists(stale_path), stale_path)
 
     def test__clean_stale_state_files(self):
         """Test core stale state file cleaner helper"""
@@ -414,20 +418,21 @@ class MigLibJanitor(MigTestCase):
         patterns = ['tmp_*', 'session_*']
 
         # Create test files (fresh, expired, unexpired, non-matching)
-        test_files = [
-            ('tmp_fresh.txt', -1),
+        test_remove = [
             ('tmp_expired.txt', EXPIRE_STATE_DAYS * SECS_PER_DAY + 1),
-            ('session_valid.dat', 0),
             ('session_old.dat', EXPIRE_STATE_DAYS * SECS_PER_DAY + 1),
+        ]
+        test_keep = [
+            ('tmp_fresh.txt', -1),
+            ('session_valid.dat', 0),
             ('other_file.log', EXPIRE_STATE_DAYS * SECS_PER_DAY + 1),
         ]
 
-        for (name, age_diff) in test_files:
+        for (name, age_diff) in test_keep + test_remove:
             path = os.path.join(test_dir, name)
-            with open(path, 'w') as fp:
-                fp.write('test')
-            mtime = time.time() - age_diff
-            os.utime(path, (mtime, mtime))
+            stamp = time.time() - age_diff
+            self._prepare_test_file(path, (stamp, stamp))
+            self.assertTrue(os.path.exists(path))
 
         handled = _clean_stale_state_files(
             self.configuration,
@@ -438,12 +443,12 @@ class MigLibJanitor(MigTestCase):
             include_dotfiles=False
         )
         self.assertEqual(handled, 2)  # tmp_expired.txt + session_old.dat
-        self.assertTrue(os.path.exists(os.path.join(test_dir,
-                                                    'tmp_fresh.txt')))
-        self.assertFalse(os.path.exists(os.path.join(test_dir,
-                                                     'tmp_expired.txt')))
-        self.assertTrue(os.path.exists(os.path.join(test_dir,
-                                                    'other_file.log')))
+        for (name, _) in test_keep:
+            path = os.path.join(test_dir, name)
+            self.assertTrue(os.path.exists(path))
+        for (name, _) in test_remove:
+            path = os.path.join(test_dir, name)
+            self.assertFalse(os.path.exists(path))
 
     def test_manage_single_req_invalid(self):
         """Test request handling for invalid request"""
@@ -573,11 +578,8 @@ class MigLibJanitor(MigTestCase):
 
         # Dot file
         dot_path = os.path.join(test_dir, '.hidden.tmp')
-        with open(dot_path, 'w') as fp:
-            fp.write('test')
-        os.utime(dot_path,
-                 (time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1,
-                  time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1))
+        stamp = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        self._prepare_test_file(dot_path, (stamp, stamp))
 
         # Directory
         dir_path = os.path.join(test_dir, 'subdir')
@@ -604,7 +606,7 @@ class MigLibJanitor(MigTestCase):
         )
         self.assertEqual(handled, 1)
 
-    @unittest.skip("TODO: enable once unpickling error handling is improved")
+    @ unittest.skip("TODO: enable once unpickling error handling is improved")
     def test_manage_single_req_corrupted_file(self):
         """Test manage_single_req with corrupted request file"""
         req_id = 'corrupted_req'
@@ -757,7 +759,7 @@ class MigLibJanitor(MigTestCase):
         self.assertEqual(_lookup_last_run(
             self.configuration, "cache-updates"), last_cache_update)
 
-    @unittest.skip("TODO: enable once cleaner has improved error handling")
+    @ unittest.skip("TODO: enable once cleaner has improved error handling")
     def test_clean_stale_files_nonexistent_dir(self):
         """Test state cleaner with invalid directory path"""
         target_dir = os.path.join(self.configuration.mig_system_files,
@@ -771,19 +773,15 @@ class MigLibJanitor(MigTestCase):
         )
         self.assertEqual(handled, 0)
 
-    @unittest.skip("TODO: enable once cleaner has improved error handling")
+    @ unittest.skip("TODO: enable once cleaner has improved error handling")
     def test_clean_stale_files_permission_error(self):
         """Test state cleaner handles permission errors gracefully"""
         test_dir = self.temppath("readonly_dir", ensure_dir=True)
         os.chmod(test_dir, 0o444)  # Read-only
 
-        test_file = os.path.join(test_dir, "test.txt")
-        with open(test_file, "w") as fh:
-            fh.write("content")
-
-        # Make file appear expired
-        old_time = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
-        os.utime(test_file, (old_time, old_time))
+        test_path = os.path.join(test_dir, "test.txt")
+        stamp = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        self._prepare_test_file(test_path, (stamp, stamp))
 
         with self.assertLogs(level='ERROR'):
             handled = _clean_stale_state_files(
@@ -852,17 +850,9 @@ class MigLibJanitor(MigTestCase):
 
         for (name, age_days) in clean_pairs:
             path = os.path.join(test_dir, name)
-            with open(path, 'w') as fp:
-                fp.write('test')
-            mtime = time.time() - age_days * SECS_PER_DAY
-            os.utime(path, (mtime, mtime))
-
-        self.assertTrue(os.path.exists(
-            os.path.join(test_dir, 'should_keep_recent.log')))
-        self.assertTrue(os.path.exists(
-            os.path.join(test_dir, 'should_remove_stale.tmp')))
-        self.assertTrue(os.path.exists(
-            os.path.join(test_dir, 'should_keep_other.pck')))
+            stamp = time.time() - age_days * SECS_PER_DAY
+            self._prepare_test_file(path, (stamp, stamp))
+            self.assertTrue(os.path.exists(path))
 
         handled = _clean_stale_state_files(
             self.configuration,

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -30,21 +30,21 @@
 import os
 import pickle
 import time
+import unittest
 
 from tests.support import FakeConfiguration, MigTestCase, ensure_dirs_exist
 from mig.shared.accountreq import save_account_request
 from mig.shared.base import distinguished_name_to_user
-from mig.lib.janitor import task_triggers, _clean_stale_state_files, \
-    _lookup_last_run, _update_last_run, \
-    SECS_PER_MINUTE, SECS_PER_HOUR, SECS_PER_DAY, \
-    EXPIRE_STATE_DAYS, EXPIRE_DUMMY_JOBS_DAYS, EXPIRE_TWOFACTOR_DAYS, \
-    EXPIRE_REQ_DAYS, MANAGE_TRIVIAL_REQ_MINUTES, REMIND_REQ_DAYS, \
-    clean_mig_system_files, clean_webserver_home, clean_no_job_helpers, \
-    clean_twofactor_sessions, handle_state_cleanup, \
+from mig.lib.janitor import _clean_stale_state_files, \
+    _lookup_last_run, _update_last_run, SECS_PER_MINUTE, SECS_PER_HOUR, \
+    SECS_PER_DAY, EXPIRE_STATE_DAYS, EXPIRE_DUMMY_JOBS_DAYS, \
+    EXPIRE_TWOFACTOR_DAYS, EXPIRE_REQ_DAYS, MANAGE_TRIVIAL_REQ_MINUTES, \
+    REMIND_REQ_DAYS, clean_mig_system_files, clean_webserver_home, \
+    clean_no_job_helpers, clean_twofactor_sessions, handle_state_cleanup, \
     clean_sessid_to_mrls_link_home, handle_session_cleanup, \
     manage_trivial_user_requests, manage_single_req, \
     remind_and_expire_user_pending, handle_pending_requests, \
-    handle_cache_updates, handle_janitor_tasks
+    handle_cache_updates, handle_janitor_tasks, task_triggers
 
 DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.org'
 DUMMY_FULL_NAME = "Test User"
@@ -75,7 +75,12 @@ class MigLibJanitor(MigTestCase):
 
     def before_each(self):
         """Set up test configuration and reset state before each test"""
-        # Create fake configuration matching real systems
+        # Remap test configuration to dummy_conf for consistency
+        self.dummy_conf = self.configuration
+        self.dummy_conf.site_enable_jobs = True
+        # Prevent admin email during reject, etc.
+        self.dummy_conf.admin_email = DUMMY_SKIP_EMAIL
+        # Create fake fs layout matching real systems
         ensure_dirs_exist(self.configuration.user_pending)
         ensure_dirs_exist(self.configuration.user_db_home)
         ensure_dirs_exist(self.configuration.user_home)
@@ -89,11 +94,9 @@ class MigLibJanitor(MigTestCase):
         ensure_dirs_exist(self.configuration.sessid_to_mrsl_link_home)
         ensure_dirs_exist(self.configuration.mrsl_files_dir)
         ensure_dirs_exist(self.configuration.resource_pending)
-        # Remap test configuration to dummy_conf for consistency
-        self.dummy_conf = self.configuration
-        self.dummy_conf.site_enable_jobs = True
-        # Prevent admin email during reject, etc.
-        self.dummy_conf.admin_email = DUMMY_SKIP_EMAIL
+        dummy_job = os.path.join(self.dummy_conf.user_home,
+                                 "no_grid_jobs_in_grid_scheduler")
+        ensure_dirs_exist(dummy_job)
 
         # Prepare user DB with a single dummy user for all tests
         self.user_db_path = os.path.join(self.dummy_conf.user_db_home,
@@ -103,7 +106,7 @@ class MigLibJanitor(MigTestCase):
 
         # Reset task triggers
         global task_triggers
-        task_triggers = {}
+        task_triggers.clear()
 
     def test_last_run_bookkeeping(self):
         """Register a last run timestamp and check it"""
@@ -158,7 +161,6 @@ class MigLibJanitor(MigTestCase):
         """Test clean dummy job helper files"""
         dummy_job = os.path.join(self.dummy_conf.user_home,
                                  "no_grid_jobs_in_grid_scheduler")
-        os.makedirs(dummy_job, exist_ok=True)
         test_time = time.time() - EXPIRE_DUMMY_JOBS_DAYS * SECS_PER_DAY - 1
         valid_filename = 'alive.txt'
         stale_filename = 'expired.txt'
@@ -391,16 +393,9 @@ class MigLibJanitor(MigTestCase):
         os.utime(os.path.join(self.dummy_conf.user_pending, req_id),
                  (req_age, req_age))
 
-        dummy_job = os.path.join(self.dummy_conf.user_home,
-                                 "no_grid_jobs_in_grid_scheduler")
-        os.makedirs(dummy_job, exist_ok=True)
-
         # Set no last run timestamps to trigger all tasks
         now = time.time()
-        task_triggers["state-cleanup"] = -1
-        task_triggers["session-cleanup"] = -1
-        task_triggers["pending-reqs"] = -1
-        task_triggers["cache-updates"] = -1
+        task_triggers.clear()
 
         # Run task handler and verify all tasks executed
         # TODO: rework to handle expire before stale to avoid duplicate here
@@ -603,3 +598,237 @@ class MigLibJanitor(MigTestCase):
             include_dotfiles=True
         )
         self.assertEqual(handled, 1)
+
+    # TODO: adjust tested function to allow enabling the next test
+    @unittest.skipIf(True, "requires improved unpickling error handling")
+    def test_manage_single_req_corrupted_file(self):
+        """Test manage_single_req with corrupted request file"""
+        req_id = 'corrupted_req'
+        req_path = os.path.join(self.dummy_conf.user_pending, req_id)
+        with open(req_path, 'w') as fp:
+            fp.write('invalid pickle content')
+
+        with self.assertLogs(level='ERROR') as log_capture:
+            manage_single_req(
+                self.dummy_conf,
+                req_id,
+                req_path,
+                self.user_db_path,
+                time.time()
+            )
+
+        self.assertTrue(any('Failed to load request from' in msg
+                            for msg in log_capture.output))
+        self.assertFalse(os.path.exists(req_path))
+
+    def test_manage_single_req_nonexistent_userdb(self):
+        """Test manage_single_req with missing user database"""
+        req_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'organization': DUMMY_ORGANIZATION,
+            'password_hash': DUMMY_MODERN_PW_PBKDF2,
+            'email': DUMMY_SKIP_EMAIL,
+        }
+        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        req_id = os.path.basename(req_path)
+
+        # Remove user database
+        os.remove(self.user_db_path)
+
+        with self.assertLogs(level='ERROR') as log_capture:
+            manage_single_req(
+                self.dummy_conf,
+                req_id,
+                req_path,
+                self.user_db_path,
+                time.time()
+            )
+
+        self.assertTrue(any('Failed to load user DB' in msg
+                            for msg in log_capture.output))
+
+    def test_verify_reset_token_failure_logging(self):
+        """Test token verification failure creates proper log entries"""
+        req_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'organization': DUMMY_ORGANIZATION,
+            'email': DUMMY_SKIP_EMAIL,
+            'reset_token': 'INVALID_TOKEN_HERE',
+            'expire': time.time() + SECS_PER_DAY,  # Future expiration
+        }
+        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        req_id = os.path.basename(req_path)
+
+        with self.assertLogs(level='WARNING') as log_capture:
+            manage_single_req(
+                self.dummy_conf,
+                req_id,
+                req_path,
+                self.user_db_path,
+                time.time()
+            )
+
+        self.assertTrue(any('bad token' in msg.lower()
+                            for msg in log_capture.output))
+
+    def test_remind_and_expire_edge_cases(self):
+        """Test request expiration with exact boundary timestamps"""
+        now = time.time()
+        test_cases = [
+            ('exact_remind', now - REMIND_REQ_DAYS * SECS_PER_DAY),
+            ('exact_expire', now - EXPIRE_REQ_DAYS * SECS_PER_DAY),
+        ]
+
+        for (req_id, mtime) in test_cases:
+            req_path = os.path.join(self.dummy_conf.user_pending, req_id)
+            req_dict = {
+                'client_id': DUMMY_USER_DN,
+                'distinguished_name': DUMMY_USER_DN,
+                'auth': [DUMMY_AUTH],
+                'full_name': DUMMY_FULL_NAME,
+                'organization': DUMMY_ORGANIZATION,
+                'password': DUMMY_MODERN_PW,
+                'email': DUMMY_EMAIL,
+            }
+            saved, req_path = save_account_request(self.dummy_conf, req_dict)
+            os.utime(req_path, (mtime, mtime))
+
+        handled = remind_and_expire_user_pending(self.dummy_conf, now=now)
+        # TODO: rework to handle expire before stale to avoid duplicates here
+        # Should match exact_expire only
+        # self.assertEqual(handled, 1)
+        self.assertEqual(handled, 3)  # expire + 2 stale
+
+    def test_handle_janitor_tasks_time_thresholds(self):
+        """Test janitor task frequency thresholds"""
+        now = time.time()
+
+        self.assertEqual(_lookup_last_run(
+            self.dummy_conf, "state-cleanup"), -1)
+        self.assertEqual(_lookup_last_run(
+            self.dummy_conf, "session-cleanup"), -1)
+        self.assertEqual(_lookup_last_run(
+            self.dummy_conf, "pending-reqs"), -1)
+        self.assertEqual(_lookup_last_run(
+            self.dummy_conf, "cache-updates"), -1)
+        # Test all tasks EXCEPT cache-updates are past threshold
+        last_state_cleanup = now - SECS_PER_DAY - 3
+        last_session_cleanup = now - SECS_PER_HOUR - 3
+        last_pending_reqs = now - SECS_PER_MINUTE - 3
+        last_cache_update = now - SECS_PER_MINUTE + 10  # Not expired
+        task_triggers.update({'state-cleanup': last_state_cleanup,
+                              'session-cleanup': last_session_cleanup,
+                              'pending-reqs': last_pending_reqs,
+                              'cache-updates': last_cache_update})
+        self.assertEqual(_lookup_last_run(
+            self.dummy_conf, "state-cleanup"), last_state_cleanup)
+        self.assertEqual(_lookup_last_run(
+            self.dummy_conf, "session-cleanup"), last_session_cleanup)
+        self.assertEqual(_lookup_last_run(
+            self.dummy_conf, "cache-updates"), last_cache_update)
+
+        # TODO: handled does NOT count no action runs - add dummies to handle?
+        handled = handle_janitor_tasks(self.dummy_conf, now=now)
+        # self.assertEqual(handled, 3)  # state + session + pending
+        self.assertEqual(handled, 0)  # ran with nothing to do
+
+        # Verify last run timestamps updated
+        self.assertEqual(_lookup_last_run(
+            self.dummy_conf, "state-cleanup"), now)
+        # TODO: fix copy/paste bug in tested function and enable next
+        # self.assertEqual(_lookup_last_run(
+        #    self.dummy_conf, "session-cleanup"), now)
+        self.assertEqual(_lookup_last_run(
+            self.dummy_conf, "pending-reqs"), now)
+        self.assertEqual(_lookup_last_run(
+            self.dummy_conf, "cache-updates"), last_cache_update)
+
+    # TODO: adjust tested function to allow enabling the next test
+    @unittest.skipIf(True, "requires improved cleaner error handling")
+    def test_clean_stale_files_nonexistent_dir(self):
+        """Test state cleaner with invalid directory path"""
+        target_dir = os.path.join(self.dummy_conf.mig_system_files,
+                                  "non_existing_dir")
+        handled = _clean_stale_state_files(
+            self.dummy_conf,
+            target_dir,
+            ["*"],
+            EXPIRE_STATE_DAYS,
+            time.time()
+        )
+        self.assertEqual(handled, 0)
+
+    # TODO: adjust tested function to allow enabling the next test
+    @unittest.skipIf(True, "requires improved cleaner error handling")
+    def test_clean_stale_files_permission_error(self):
+        """Test state cleaner handles permission errors gracefully"""
+        test_dir = self.temppath("readonly_dir", ensure_dir=True)
+        os.chmod(test_dir, 0o444)  # Read-only
+
+        test_file = os.path.join(test_dir, "test.txt")
+        with open(test_file, "w") as fh:
+            fh.write("content")
+
+        # Make file appear expired
+        old_time = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
+        os.utime(test_file, (old_time, old_time))
+
+        with self.assertLogs(level='ERROR'):
+            handled = _clean_stale_state_files(
+                self.dummy_conf,
+                test_dir,
+                ["*"],
+                EXPIRE_STATE_DAYS,
+                time.time()
+            )
+            self.assertEqual(handled, 0)
+
+        # Restore permissions to allow cleanup
+        os.chmod(test_dir, 0o755)
+
+    def test_handle_empty_pending_dir(self):
+        """Test operations with empty pending requests directory"""
+        # Empty directory completely
+        for filename in os.listdir(self.dummy_conf.user_pending):
+            path = os.path.join(self.dummy_conf.user_pending, filename)
+            os.remove(path)
+
+        handled = manage_trivial_user_requests(self.dummy_conf)
+        self.assertEqual(handled, 0)
+
+        handled = remind_and_expire_user_pending(self.dummy_conf)
+        self.assertEqual(handled, 0)
+
+    def test_janitor_task_cleanup_after_reject(self):
+        """Verify proper cleanup after request rejection"""
+        req_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'invalid': ['Test intentional invalid'],
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'organization': DUMMY_ORGANIZATION,
+            'email': DUMMY_SKIP_EMAIL,
+        }
+        saved, req_path = save_account_request(self.dummy_conf, req_dict)
+        req_id = os.path.basename(req_path)
+
+        # Verify initial existence
+        self.assertTrue(os.path.exists(req_path))
+
+        manage_single_req(
+            self.dummy_conf,
+            req_id,
+            req_path,
+            self.user_db_path,
+            time.time()
+        )
+
+        # Verify post-execution cleanup
+        self.assertFalse(os.path.exists(req_path))

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -46,12 +46,12 @@ from mig.shared.accountreq import save_account_request
 from mig.shared.base import distinguished_name_to_user
 from tests.support import MigTestCase, ensure_dirs_exist
 
-DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.org'
+DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com'
 DUMMY_FULL_NAME = "Test User"
 DUMMY_ORGANIZATION = "Test Org"
-DUMMY_EMAIL = "test@example.org"
+DUMMY_EMAIL = "test@example.com"
 DUMMY_SKIP_EMAIL = ''
-DUMMY_CLIENT_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.org'
+DUMMY_CLIENT_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.com'
 DUMMY_AUTH = 'migcert'
 DUMMY_USERDB = 'MiG-users.db'
 DUMMY_PEER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=peer@example.com'
@@ -73,11 +73,19 @@ class MigLibJanitor(MigTestCase):
         with open(self.user_db_path, 'wb') as udb:
             udb.write(pickle.dumps(user_db_dict))
 
+    # TODO: migrate or remove this helper if no longer needed
+    def _init_test_user_db(self, user_id=DUMMY_USER_DN):
+        """Write a user_db_dict to user database - truncating any contents"""
+        user_dict = distinguished_name_to_user(user_id)
+        self._write_user_db({user_id: user_dict})
+
     def before_each(self):
         """Set up test configuration and reset state before each test"""
         self.configuration.site_enable_jobs = True
         # Prevent admin email during reject, etc.
         self.configuration.admin_email = DUMMY_SKIP_EMAIL
+        self.user_db_path = os.path.join(self.configuration.user_db_home,
+                                         DUMMY_USERDB)
         # Create fake fs layout matching real systems
         ensure_dirs_exist(self.configuration.user_pending)
         ensure_dirs_exist(self.configuration.user_db_home)
@@ -97,10 +105,7 @@ class MigLibJanitor(MigTestCase):
         ensure_dirs_exist(dummy_job)
 
         # Prepare user DB with a single dummy user for all tests
-        self.user_db_path = os.path.join(self.configuration.user_db_home,
-                                         DUMMY_USERDB)
-        user_dict = distinguished_name_to_user(DUMMY_USER_DN)
-        self._write_user_db({DUMMY_USER_DN: user_dict})
+        self._provision_test_user(self, DUMMY_USER_DN)
 
         # Reset task triggers
         global task_triggers
@@ -278,7 +283,7 @@ class MigLibJanitor(MigTestCase):
 
         # Need user DB and path to simulate existing user
         user_dir = os.path.join(self.configuration.user_home, DUMMY_CLIENT_DIR)
-        os.makedirs(user_dir)
+        os.makedirs(user_dir, exist_ok=True)
         handled = manage_trivial_user_requests(self.configuration)
         self.assertEqual(handled, 1)
 
@@ -506,7 +511,7 @@ class MigLibJanitor(MigTestCase):
         """Test request handling with existing user collision"""
         # Setup existing user
         user_dir = os.path.join(self.configuration.user_home, DUMMY_CLIENT_DIR)
-        os.makedirs(user_dir)
+        os.makedirs(user_dir, exist_ok=True)
         # Create dummy user DB
         user_entry = {'distinguished_name': DUMMY_USER_DN}
         self._write_user_db({DUMMY_USER_DN: user_entry})
@@ -630,6 +635,7 @@ class MigLibJanitor(MigTestCase):
             'full_name': DUMMY_FULL_NAME,
             'organization': DUMMY_ORGANIZATION,
             'password_hash': DUMMY_MODERN_PW_PBKDF2,
+            # NOTE: disable email to prevent send failing on reject
             'email': DUMMY_SKIP_EMAIL,
         }
         saved, req_path = save_account_request(self.configuration, req_dict)
@@ -658,6 +664,7 @@ class MigLibJanitor(MigTestCase):
             'auth': [DUMMY_AUTH],
             'full_name': DUMMY_FULL_NAME,
             'organization': DUMMY_ORGANIZATION,
+            # NOTE: disable email to prevent send failing on reject
             'email': DUMMY_SKIP_EMAIL,
             'reset_token': 'INVALID_TOKEN_HERE',
             'expire': time.time() + SECS_PER_DAY,  # Future expiration
@@ -814,6 +821,7 @@ class MigLibJanitor(MigTestCase):
             'auth': [DUMMY_AUTH],
             'full_name': DUMMY_FULL_NAME,
             'organization': DUMMY_ORGANIZATION,
+            # NOTE: disable email to prevent send failing on reject
             'email': DUMMY_SKIP_EMAIL,
         }
         saved, req_path = save_account_request(self.configuration, req_dict)


### PR DESCRIPTION
Add improved unit test coverage of `mig/lib/janitor.py` to cover the full range of functions with complete workflow test and edge cases.

There are a few tests with TODOs about adjusting the order in which stale and expired requests are handled in `mig/lib/janitor.py` to avoid counting expired ones both as stale and as expired. That is a nice-to-have and can be left as a follow-up.

~Please note that the PR currently modifies the code in `mig/shared/useradm.py` but that test-only exception should evaporate once PR #368 is merged. So that should be done before merging this one.~