### PR TITLE
Rework `refresh_vgrid_map` in order to address a potential race and missing field init

### DIFF
--- a/mig/shared/vgridaccess.py
+++ b/mig/shared/vgridaccess.py
@@ -451,7 +451,8 @@ def refresh_vgrid_map(configuration, clean=False):
         conf_path = os.path.join(configuration.resource_home, res, "config")
         if not os.path.isfile(conf_path):
             continue
-        if os.path.getmtime(conf_path) >= map_stamp:
+        if res not in vgrid_map[RESOURCES] or \
+                os.path.getmtime(conf_path) >= map_stamp:
             # Read maps of exe name to vgrid list and of store name to vgrid
             # list. Save them separately to be able to distinguish them in
             # exe / store access and visibility
@@ -562,7 +563,7 @@ def refresh_vgrid_map(configuration, clean=False):
         else:
             conf_mtime = -1
             user_conf = {}
-        if conf_mtime >= map_stamp:
+        if user not in vgrid_map[USERS] or conf_mtime >= map_stamp:
             vgrid_map[USERS][user] = user_conf
             vgrid_map[USERS][user][ASSIGN] = vgrid_map[USERS][user].get(ASSIGN,
                                                                         [])

--- a/mig/shared/vgridaccess.py
+++ b/mig/shared/vgridaccess.py
@@ -401,18 +401,18 @@ def refresh_vgrid_map(configuration, clean=False):
     optional_conf = [SETTINGS, ]
 
     for vgrid in all_vgrids:
+        # Make sure vgrid dict exists before filling it
+        vgrid_map[VGRIDS][vgrid] = vgrid_map[VGRIDS].get(vgrid, {})
         for (field, name, list_call) in conf_read:
             conf_path = os.path.join(configuration.vgrid_home, vgrid, name)
             if not os.path.isfile(conf_path):
-                # Make sure vgrid dict exists before filling it
-                vgrid_map[VGRIDS][vgrid] = vgrid_map[VGRIDS].get(vgrid, {})
                 vgrid_map[VGRIDS][vgrid][field] = []
                 if vgrid != default_vgrid and field not in optional_conf:
                     _logger.warning('missing file: %s' %
                                     conf_path)
                     dirty[VGRIDS] = dirty.get(VGRIDS, []) + [vgrid]
 
-            elif vgrid not in vgrid_map[VGRIDS] or \
+            elif field not in vgrid_map[VGRIDS][vgrid] or \
                     os.path.getmtime(conf_path) >= map_stamp:
                 (status, entries) = list_call(vgrid, configuration,
                                               recursive=False)
@@ -425,6 +425,8 @@ def refresh_vgrid_map(configuration, clean=False):
                 vgrid_map[VGRIDS][vgrid] = map_entry
                 vgrid_map[VGRIDS][vgrid][field] = entries
                 dirty[VGRIDS] = dirty.get(VGRIDS, []) + [vgrid]
+            else:
+                _logger.debug("caching %s for %s in vgrid map" % (name, vgrid))
     # Remove any missing vgrids from map
     missing_vgrids = [vgrid for vgrid in vgrid_map[VGRIDS]
                       if not vgrid in all_vgrids]
@@ -853,7 +855,6 @@ def check_vgrid_access(configuration, client_id, vgrid_name, recursive=True,
     the vgrid module and should replace that one everywhere that only vgrid map
     (cached) lookups are needed.
     """
-    vgrid_access = [default_vgrid]
     vgrid_map = get_vgrid_map(configuration, recursive, caching)
     vgrid_entry = vgrid_map.get(VGRIDS, {}).get(
         vgrid_name, {OWNERS: [], MEMBERS: []})


### PR DESCRIPTION
Rework `refresh_vgrid_map` in order to init all vgrid entries in `VGRIDS` early and to never skip init of the individual fields in those vgrid dicts, even if the source file for the corresponding field (like `owners` or `members`) is older than the map timestamp of the current vgrid map file. That _should_ address a potential race when vgrids are modified during long-running refresh calls and any other causes for those fields missing in the existing map.
Extend the same idea to cover the `RESOURCES` and `USERS` update in the same function to make sure all parts of the vgrid map get properly initialized in such corner cases.

Remove an unused leftover variable in check_vgrid_access while at it.

These issues were discovered during unit test implementation in PR #372 and appears to be the source of the spurious CI failures about missing vgrid map `__owners__` in that PR e.g. seen in
https://github.com/ucphhpc/migrid-sync/actions/runs/19012212737/job/54294834829?pr=372
Similarly the extension to also cover `RESOURCES` and `USERS` appears to address the spurious CI failures about the `RESOURCES` part of the vgrid map sometimes incorrectly left empty e.g. in
https://github.com/ucphhpc/migrid-sync/actions/runs/19012954138/job/54296573680?pr=372#step:6:126

Especially the former may also be involved in issue #121 where similar mechanics could explain the intermittent loss of owner access.