### PR TITLE
migcheckssl: Enable error handling

### DIFF
--- a/mig/install/migcheckssl-template.sh.cronjob
+++ b/mig/install/migcheckssl-template.sh.cronjob
@@ -16,6 +16,8 @@
 
 # Force bash to handle uninitialized variables and errors
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+# NOTE: 'set -eE' exits on failure, good for debug but we want to handle errors
+#set -eEuo pipefail
 set -eEuo pipefail
 
 # Send output to another email address

--- a/mig/install/migcheckssl-template.sh.cronjob
+++ b/mig/install/migcheckssl-template.sh.cronjob
@@ -14,10 +14,12 @@
 # This is a limitation on the run-parts wrapper used by cron
 # (see man run-parts for the rationale behind this).
 
-# Force bash to handle uninitialized variables and errors
+# By default bash silently ignores and continues on most errors but we can set
+# options to e.g. catch uninitialized variables and errors as explained in:
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
-# NOTE: 'set -eE' exits on failure, good for debug but we want to handle errors
-#set -eEuo pipefail
+# NOTE: 'set -eE' exits on non-zero exit codes to add safety and as recommended
+# best-practice (CWE-252, CWE-248, ...), yet, in some cases it hurts more to
+# exit midway, so it can be a trade-off.
 set -uo pipefail
 
 # Send output to another email address

--- a/mig/install/migcheckssl-template.sh.cronjob
+++ b/mig/install/migcheckssl-template.sh.cronjob
@@ -18,7 +18,7 @@
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
 # NOTE: 'set -eE' exits on failure, good for debug but we want to handle errors
 #set -eEuo pipefail
-set -eEuo pipefail
+set -uo pipefail
 
 # Send output to another email address
 #MAILTO="root"

--- a/tests/fixture/confs-stdlocal/migcheckssl
+++ b/tests/fixture/confs-stdlocal/migcheckssl
@@ -16,7 +16,9 @@
 
 # Force bash to handle uninitialized variables and errors
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
-set -eEuo pipefail
+# NOTE: 'set -eE' exits on failure, good for debug but we want to handle errors
+#set -eEuo pipefail
+set -uo pipefail
 
 # Send output to another email address
 #MAILTO="root"

--- a/tests/fixture/confs-stdlocal/migcheckssl
+++ b/tests/fixture/confs-stdlocal/migcheckssl
@@ -14,10 +14,12 @@
 # This is a limitation on the run-parts wrapper used by cron
 # (see man run-parts for the rationale behind this).
 
-# Force bash to handle uninitialized variables and errors
+# By default bash silently ignores and continues on most errors but we can set
+# options to e.g. catch uninitialized variables and errors as explained in:
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
-# NOTE: 'set -eE' exits on failure, good for debug but we want to handle errors
-#set -eEuo pipefail
+# NOTE: 'set -eE' exits on non-zero exit codes to add safety and as recommended
+# best-practice (CWE-252, CWE-248, ...), yet, in some cases it hurts more to
+# exit midway, so it can be a trade-off.
 set -uo pipefail
 
 # Send output to another email address


### PR DESCRIPTION
migcheckssl fails to handle subscript errors which result in abnormal exist when checking for running services.

FIxes issue #381
