### PR TITLE
Comment-only change to cronjobs to clarify our general error checking strategy in relation to PR382

### DIFF
--- a/mig/install/migcheckssl-template.sh.cronjob
+++ b/mig/install/migcheckssl-template.sh.cronjob
@@ -20,6 +20,10 @@
 # NOTE: 'set -eE' exits on non-zero exit codes to add safety and as recommended
 # best-practice (CWE-252, CWE-248, ...), yet, in some cases it hurts more to
 # exit midway, so it can be a trade-off.
+# IMPORTANT: we currently opt for manual exit code checks here since we deem
+# the consequences of an early script exit worse.
+# TODO: introduce individual exit code checks and re-enable '-eE' below?
+#set -eEuo pipefail
 set -uo pipefail
 
 # Send output to another email address

--- a/mig/install/migimportdoi-template.sh.cronjob
+++ b/mig/install/migimportdoi-template.sh.cronjob
@@ -2,9 +2,12 @@
 #
 # run importdoi as mig user
 
-# Force bash to handle uninitialized variables and errors
+# By default bash silently ignores and continues on most errors but we can set
+# options to e.g. catch uninitialized variables and errors as explained in:
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
-# NOTE: 'set -eE' exits on failure, which is good when we handle all errors
+# NOTE: 'set -eE' exits on non-zero exit codes to add safety and as recommended
+# best-practice (CWE-252, CWE-248, ...), yet, in some cases it hurts more to
+# exit midway, so it can be a trade-off.
 set -eEuo pipefail
 
 # Add any custom domains to lookup DOIs for here and format according to

--- a/mig/install/migindexdoi-template.sh.cronjob
+++ b/mig/install/migindexdoi-template.sh.cronjob
@@ -2,9 +2,12 @@
 #
 # run indexdoi as mig user
 
-# Force bash to handle uninitialized variables and errors
+# By default bash silently ignores and continues on most errors but we can set
+# options to e.g. catch uninitialized variables and errors as explained in:
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
-# NOTE: 'set -eE' exits on failure, which is good when we handle all errors
+# NOTE: 'set -eE' exits on non-zero exit codes to add safety and as recommended
+# best-practice (CWE-252, CWE-248, ...), yet, in some cases it hurts more to
+# exit midway, so it can be a trade-off.
 set -eEuo pipefail
 
 

--- a/mig/install/migverifyarchives-template.sh.cronjob
+++ b/mig/install/migverifyarchives-template.sh.cronjob
@@ -7,9 +7,15 @@
 # any effect. Basically the ready-finalized-YYYYMMDD.txt files in archivestaging
 # must be filled with root paths of pending archives to check.
 
-# Force bash to handle uninitialized variables and errors
+# By default bash silently ignores and continues on most errors but we can set
+# options to e.g. catch uninitialized variables and errors as explained in:
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
-# NOTE: 'set -eE' exits on failure, good for debug but we want to handle errors
+# NOTE: 'set -eE' exits on non-zero exit codes to add safety and as recommended
+# best-practice (CWE-252, CWE-248, ...), yet, in some cases it hurts more to
+# exit midway, so it can be a trade-off.
+# IMPORTANT: we currently opt for manual exit code checks here since we deem
+# the consequences of an early script exit worse.
+# TODO: introduce individual exit code checks and re-enable '-eE' below?
 #set -eEuo pipefail
 set -uo pipefail
 

--- a/tests/fixture/confs-stdlocal/migcheckssl
+++ b/tests/fixture/confs-stdlocal/migcheckssl
@@ -20,6 +20,10 @@
 # NOTE: 'set -eE' exits on non-zero exit codes to add safety and as recommended
 # best-practice (CWE-252, CWE-248, ...), yet, in some cases it hurts more to
 # exit midway, so it can be a trade-off.
+# IMPORTANT: we currently opt for manual exit code checks here since we deem
+# the consequences of an early script exit worse.
+# TODO: introduce individual exit code checks and re-enable '-eE' below?
+#set -eEuo pipefail
 set -uo pipefail
 
 # Send output to another email address

--- a/tests/fixture/confs-stdlocal/migimportdoi
+++ b/tests/fixture/confs-stdlocal/migimportdoi
@@ -2,9 +2,12 @@
 #
 # run importdoi as mig user
 
-# Force bash to handle uninitialized variables and errors
+# By default bash silently ignores and continues on most errors but we can set
+# options to e.g. catch uninitialized variables and errors as explained in:
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
-# NOTE: 'set -eE' exits on failure, which is good when we handle all errors
+# NOTE: 'set -eE' exits on non-zero exit codes to add safety and as recommended
+# best-practice (CWE-252, CWE-248, ...), yet, in some cases it hurts more to
+# exit midway, so it can be a trade-off.
 set -eEuo pipefail
 
 # Add any custom domains to lookup DOIs for here and format according to

--- a/tests/fixture/confs-stdlocal/migindexdoi
+++ b/tests/fixture/confs-stdlocal/migindexdoi
@@ -2,9 +2,12 @@
 #
 # run indexdoi as mig user
 
-# Force bash to handle uninitialized variables and errors
+# By default bash silently ignores and continues on most errors but we can set
+# options to e.g. catch uninitialized variables and errors as explained in:
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
-# NOTE: 'set -eE' exits on failure, which is good when we handle all errors
+# NOTE: 'set -eE' exits on non-zero exit codes to add safety and as recommended
+# best-practice (CWE-252, CWE-248, ...), yet, in some cases it hurts more to
+# exit midway, so it can be a trade-off.
 set -eEuo pipefail
 
 

--- a/tests/fixture/confs-stdlocal/miglustrequota
+++ b/tests/fixture/confs-stdlocal/miglustrequota
@@ -23,7 +23,7 @@ set -eEuo pipefail
 # Send output to another email address
 #MAILTO="root"
 
-MIG_CONF=__MIG_CODE__/server/MiGserver.conf
+MIG_CONF=/home/mig/mig/server/MiGserver.conf
 
 # Specify if migrid runs natively or inside containers with lustre at host.
 # Value is the container manager (docker, podman, or empty string for none)

--- a/tests/fixture/confs-stdlocal/migverifyarchives
+++ b/tests/fixture/confs-stdlocal/migverifyarchives
@@ -7,9 +7,15 @@
 # any effect. Basically the ready-finalized-YYYYMMDD.txt files in archivestaging
 # must be filled with root paths of pending archives to check.
 
-# Force bash to handle uninitialized variables and errors
+# By default bash silently ignores and continues on most errors but we can set
+# options to e.g. catch uninitialized variables and errors as explained in:
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
-# NOTE: 'set -eE' exits on failure, good for debug but we want to handle errors
+# NOTE: 'set -eE' exits on non-zero exit codes to add safety and as recommended
+# best-practice (CWE-252, CWE-248, ...), yet, in some cases it hurts more to
+# exit midway, so it can be a trade-off.
+# IMPORTANT: we currently opt for manual exit code checks here since we deem
+# the consequences of an early script exit worse.
+# TODO: introduce individual exit code checks and re-enable '-eE' below?
 #set -eEuo pipefail
 set -uo pipefail
 


### PR DESCRIPTION
Comment-only change to cronjobs to clarify our general error checking strategy and explain why we sometimes choose to deviate from it. Tries to capture the central points from a longer internal discussion in relation to issue #381 and the fix in PR #382.

Adds the missing fixture for the existing miglustrequota cronjob.