### PR TITLE
Integrate apache mod reqtimeout use if requested

### DIFF
--- a/mig/install/apache-MiG-template.conf
+++ b/mig/install/apache-MiG-template.conf
@@ -181,6 +181,12 @@ Alias /status-events.json "__MIG_STATE__/wwwpublic/status-events.json"
     </FilesMatch>
 </IfModule>
 
+# Optional resource hogging prevention with default request timeouts.
+# Helps protect against slowloris-style attacks gradually depleting resources
+<IfModule mod_reqtimeout.c>
+    RequestReadTimeout header=20-40,MinRate=500 body=20,MinRate=500
+</IfModule>
+
 <IfModule mod_mime.c>
     # NOTE: workaround for broken double gzip decompression e.g. in Firefox.
     #       The bam files are in fact already gzip files and require care:

--- a/mig/install/apache-mimic-deb-template.conf
+++ b/mig/install/apache-mimic-deb-template.conf
@@ -81,7 +81,7 @@ __JUPYTER_COMMENTED__ LoadModule lbmethod_byrequests_module modules/mod_lbmethod
 __HSTS_COMMENTED__ LoadModule headers_module modules/mod_headers.so
 
 # Optional resource hogging prevention if requested (for mod reqtimeout)
-__REQTIMEOUT_COMMENTED__ LoadModule reqtimeout_module modules/mod_reqtimeout.so
+__ANTISLOWLORIS_COMMENTED__ LoadModule reqtimeout_module modules/mod_reqtimeout.so
 
 # Apparently we need this mime setup on Redhat to just run apache
 TypesConfig /etc/mime.types

--- a/mig/install/apache-mimic-deb-template.conf
+++ b/mig/install/apache-mimic-deb-template.conf
@@ -80,6 +80,9 @@ __JUPYTER_COMMENTED__ LoadModule lbmethod_byrequests_module modules/mod_lbmethod
 # Optional Header mangling if requested (for HSTS)
 __HSTS_COMMENTED__ LoadModule headers_module modules/mod_headers.so
 
+# Optional resource hogging prevention if requested (for mod reqtimeout)
+__REQTIMEOUT_COMMENTED__ LoadModule reqtimeout_module modules/mod_reqtimeout.so
+
 # Apparently we need this mime setup on Redhat to just run apache
 TypesConfig /etc/mime.types
 MIMEMagicFile conf/magic

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -382,7 +382,7 @@ def generate_confs(
     enable_jupyter=False,
     enable_cloud=False,
     enable_hsts=True,
-    enable_reqtimeout=False,
+    enable_antislowloris=False,
     enable_vhost_certs=False,
     enable_verify_certs=False,
     enable_seafile=False,
@@ -712,7 +712,7 @@ def _generate_confs_prepare(
     enable_jupyter,
     enable_cloud,
     enable_hsts,
-    enable_reqtimeout,
+    enable_antislowloris,
     enable_vhost_certs,
     enable_verify_certs,
     enable_seafile,
@@ -972,7 +972,7 @@ def _generate_confs_prepare(
     user_dict['__ENABLE_JUPYTER__'] = "%s" % enable_jupyter
     user_dict['__ENABLE_CLOUD__'] = "%s" % enable_cloud
     user_dict['__ENABLE_HSTS__'] = "%s" % enable_hsts
-    user_dict['__ENABLE_REQTIMEOUT__'] = "%s" % enable_reqtimeout
+    user_dict['__ENABLE_ANTISLOWLORIS__'] = "%s" % enable_antislowloris
     user_dict['__ENABLE_VHOST_CERTS__'] = "%s" % enable_vhost_certs
     user_dict['__ENABLE_VERIFY_CERTS__'] = "%s" % enable_verify_certs
     user_dict['__ENABLE_SEAFILE__'] = "%s" % enable_seafile
@@ -1368,11 +1368,11 @@ cert, oid and sid based https!
     else:
         user_dict['__HSTS_COMMENTED__'] = '#'
 
-    # Enable reqtimeout module to limit resource use if explicitly requested
-    if user_dict['__ENABLE_REQTIMEOUT__'].lower() == 'true':
-        user_dict['__REQTIMEOUT_COMMENTED__'] = ''
+    # Enable apache reqtimeouts to kick idle clients if explicitly requested
+    if user_dict['__ENABLE_ANTISLOWLORIS__'].lower() == 'true':
+        user_dict['__ANTISLOWLORIS_COMMENTED__'] = ''
     else:
-        user_dict['__REQTIMEOUT_COMMENTED__'] = '#'
+        user_dict['__ANTISLOWLORIS_COMMENTED__'] = '#'
 
     # Enable vhost-specific certificates only if explicitly requested
     if user_dict['__ENABLE_VHOST_CERTS__'].lower() == 'true':

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -382,6 +382,7 @@ def generate_confs(
     enable_jupyter=False,
     enable_cloud=False,
     enable_hsts=True,
+    enable_reqtimeout=False,
     enable_vhost_certs=False,
     enable_verify_certs=False,
     enable_seafile=False,
@@ -711,6 +712,7 @@ def _generate_confs_prepare(
     enable_jupyter,
     enable_cloud,
     enable_hsts,
+    enable_reqtimeout,
     enable_vhost_certs,
     enable_verify_certs,
     enable_seafile,
@@ -970,6 +972,7 @@ def _generate_confs_prepare(
     user_dict['__ENABLE_JUPYTER__'] = "%s" % enable_jupyter
     user_dict['__ENABLE_CLOUD__'] = "%s" % enable_cloud
     user_dict['__ENABLE_HSTS__'] = "%s" % enable_hsts
+    user_dict['__ENABLE_REQTIMEOUT__'] = "%s" % enable_reqtimeout
     user_dict['__ENABLE_VHOST_CERTS__'] = "%s" % enable_vhost_certs
     user_dict['__ENABLE_VERIFY_CERTS__'] = "%s" % enable_verify_certs
     user_dict['__ENABLE_SEAFILE__'] = "%s" % enable_seafile
@@ -1364,6 +1367,12 @@ cert, oid and sid based https!
         user_dict['__HSTS_COMMENTED__'] = ''
     else:
         user_dict['__HSTS_COMMENTED__'] = '#'
+
+    # Enable reqtimeout module to limit resource use if explicitly requested
+    if user_dict['__ENABLE_REQTIMEOUT__'].lower() == 'true':
+        user_dict['__REQTIMEOUT_COMMENTED__'] = ''
+    else:
+        user_dict['__REQTIMEOUT_COMMENTED__'] = '#'
 
     # Enable vhost-specific certificates only if explicitly requested
     if user_dict['__ENABLE_VHOST_CERTS__'].lower() == 'true':

--- a/tests/fixture/confs-stdlocal/MiG.conf
+++ b/tests/fixture/confs-stdlocal/MiG.conf
@@ -181,6 +181,12 @@ Alias /status-events.json "/home/mig/state/wwwpublic/status-events.json"
     </FilesMatch>
 </IfModule>
 
+# Optional resource hogging prevention with default request timeouts.
+# Helps protect against slowloris-style attacks gradually depleting resources
+<IfModule mod_reqtimeout.c>
+    RequestReadTimeout header=20-40,MinRate=500 body=20,MinRate=500
+</IfModule>
+
 <IfModule mod_mime.c>
     # NOTE: workaround for broken double gzip decompression e.g. in Firefox.
     #       The bam files are in fact already gzip files and require care:

--- a/tests/fixture/confs-stdlocal/mimic-deb.conf
+++ b/tests/fixture/confs-stdlocal/mimic-deb.conf
@@ -80,6 +80,9 @@ LoadModule wsgi_module modules/mod_wsgi.so
 # Optional Header mangling if requested (for HSTS)
 LoadModule headers_module modules/mod_headers.so
 
+# Optional resource hogging prevention if requested (for mod reqtimeout)
+#LoadModule reqtimeout_module modules/mod_reqtimeout.so
+
 # Apparently we need this mime setup on Redhat to just run apache
 TypesConfig /etc/mime.types
 MIMEMagicFile conf/magic


### PR DESCRIPTION
Integrate apache mod reqtimeout use if requested to enable various default request timeouts in order to help foil slowloris-style attacks where all workers and resources are gradually depleted by attacker or busy-idling clients of other sorts. Matches modern Debian/Ubuntu and RHEL/Rocky Apache installation defaults, but requires explicit enabling until further tested.