### PR TITLE
Adjust and expand `safeinput` unit tests to follow issue #35 example more closely

### DIFF
--- a/tests/test_mig_shared_safeinput.py
+++ b/tests/test_mig_shared_safeinput.py
@@ -164,6 +164,43 @@ class TestMigSharedSafeInput(MigTestCase):
 
     # NOTE: indirect tests for __valid_contents using some of its wrappers
 
+    def test_valid_printable_lengths(self):
+        """Test printable character validation"""
+        # Valid cases
+        valid_printable(self.PRINTABLE_CHARS, min_length=5)
+
+        # Length violations
+        with self.assertRaises(InputException):
+            valid_printable("a", min_length=2)
+
+        with self.assertRaises(InputException):
+            valid_printable("a" * 201, max_length=200)
+
+    def test_valid_alphanumeric_with_extras(self):
+        """Test alphanumeric validation with extra characters"""
+        # Valid cases
+        valid_alphanumeric(self.VALID_EXTRA_CHARS_NAME, extra_chars="-_")
+
+        # Invalid characters
+        with self.assertRaises(InputException):
+            valid_alphanumeric(self.INVALID_DOLLAR_NAME)
+
+    def test_valid_commonname_accent_handling(self):
+        """Test accented character handling validation"""
+        # Common accents should pass with COMMON_ACCENTED
+        valid_commonname(self.ACCENTED_VALID)
+
+        # Exotic accents should fail with NO_ACCENTED
+        with self.assertRaises(InputException):
+            valid_printable(self.ACCENTED_INVALID_EXOTIC)
+
+    def test_valid_path_unicode_normalization(self):
+        """Test unicode decomposition handling"""
+        # Make sure unicode normalization doesn't raise exception
+        result = valid_path(self.DECOMPOSED_UNICODE)
+        self.assertEqual(result, None)
+
+
 class TestMigSharedSafeInput__legacy(MigTestCase):
     """Legacy tests for safeinput module self-checks"""
 

--- a/tests/test_mig_shared_safeinput.py
+++ b/tests/test_mig_shared_safeinput.py
@@ -153,7 +153,7 @@ class TestMigSharedSafeInput(MigTestCase):
         self.assertEqual(result, self.APOSTROPHE_FULL_NAME_HEX)
 
 
-class TestMigSharedBase__legacy(MigTestCase):
+class TestMigSharedSafeInput__legacy(MigTestCase):
     """Run mig.shared.safeinput legacy self-test"""
 
     # TODO: migrate all legacy self-check functionality into the above?

--- a/tests/test_mig_shared_safeinput.py
+++ b/tests/test_mig_shared_safeinput.py
@@ -2,8 +2,8 @@
 #
 # --- BEGIN_HEADER ---
 #
-# addheader - add license header to all code modules.
-# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+# test_mig_shared_base - unit tests for shared base helpers
+# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -27,9 +27,8 @@
 
 """Unit tests for the migrid module pointed to in the filename"""
 
+import base64
 import codecs
-import importlib
-import os
 import sys
 from past.builtins import basestring, unicode
 
@@ -53,23 +52,26 @@ def is_string_of_unicode(value):
     return type(value) == type(u'')
 
 
-class MigSharedSafeinput(MigTestCase):
+def _hex_wrap(val):
+    """Insert a clearly marked hex representation of val"""
+    # Please keep aligned with helper in mig/shared/functionality/autocreate.py
+    return ".X%s" % base64.b16encode(val.encode('utf8')).decode('utf8')
 
-    def test_existing_main(self):
-        def raise_on_error_exit(exit_code):
-            if exit_code != 0:
-                if raise_on_error_exit.last_print is not None:
-                    identifying_message = raise_on_error_exit.last_print
-                else:
-                    identifying_message = 'unknown'
-                raise AssertionError(
-                    'failure in unittest/testcore: %s' % (identifying_message,))
-        raise_on_error_exit.last_print = None
 
-        def record_last_print(value):
-            raise_on_error_exit.last_print = value
+class TestMigSharedSafeInput(MigTestCase):
+    """Test mig.shared.safeinput functions"""
 
-        safeinput_main(_exit=raise_on_error_exit, _print=record_last_print)
+    def _provide_configuration(self):
+        """Set up isolated test configuration and logger for the tests"""
+        return 'testconfig'
+
+    def before_each(self):
+        """Setup fake configuration before each test."""
+        return
+
+    APOSTROPHE_FULL_NAME = "John O'Connor"
+    APOSTROPHE_FULL_NAME_SKIP = "John OConnor"
+    APOSTROPHE_FULL_NAME_HEX = "John O.X27Connor"
 
     COMMONNAME_PERMITTED = (
         'Firstname Lastname',
@@ -85,6 +87,7 @@ class MigSharedSafeinput(MigTestCase):
         'Test HTML Invalid <code/>')
 
     def test_commonname_valid(self):
+        """Test commonname_valid with on set of test users"""
         for test_cn in self.COMMONNAME_PERMITTED:
             saw_raise = False
             try:
@@ -102,6 +105,7 @@ class MigSharedSafeinput(MigTestCase):
             self.assertTrue(saw_raise)
 
     def test_commonname_filter(self):
+        """Test filter_commonname on the set of test users"""
         for test_cn in self.COMMONNAME_PERMITTED:
             test_cn_unicode = as_string_of_unicode(test_cn)
             filtered_cn = filter_commonname(test_cn)
@@ -111,6 +115,65 @@ class MigSharedSafeinput(MigTestCase):
             test_cn_unicode = as_string_of_unicode(test_cn)
             filtered_cn = filter_commonname(test_cn)
             self.assertNotEqual(filtered_cn, test_cn_unicode)
+            self.assertTrue(len(filtered_cn) < len(test_cn_unicode))
+            # With default skip all chars in filtered_cn must be in original
+            overlap = [i for i in filtered_cn if i in test_cn_unicode]
+            self.assertEqual(''.join(overlap), filtered_cn)
+
+    def test_commonname_filter_hexlify_illegal(self):
+        """Test filter_commonname on the set of test users with hexlify"""
+        for test_cn in self.COMMONNAME_PERMITTED:
+            test_cn_unicode = as_string_of_unicode(test_cn)
+            filtered_cn = filter_commonname(test_cn, illegal_handler=_hex_wrap)
+            # Valid should remain unchanged with hexlify illegal_handler
+            self.assertEqual(filtered_cn, test_cn_unicode)
+
+        for test_cn in self.COMMONNAME_PROHIBITED:
+            test_cn_unicode = as_string_of_unicode(test_cn)
+            filtered_cn = filter_commonname(test_cn, illegal_handler=_hex_wrap)
+            # Invalid should be replaced with hexlify illegal_handler
+            self.assertNotEqual(filtered_cn, test_cn_unicode)
+            self.assertIn('.X', filtered_cn)
+            self.assertTrue(len(filtered_cn) > len(test_cn_unicode))
+
+    def test_filter_commonname_apostrophe_name_skip_illegal(self):
+        """Test filter_commonname with skip and apostrophe in name"""
+        result = filter_commonname(self.APOSTROPHE_FULL_NAME,
+                                   illegal_handler=None)
+        self.assertNotEqual(result, self.APOSTROPHE_FULL_NAME)
+        self.assertNotIn("'", result)
+        self.assertEqual(result, self.APOSTROPHE_FULL_NAME_SKIP)
+
+    def test_filter_commonname_apostrophe_name_hexlify_illegal(self):
+        """Test filter_commonname with hexlify and apostrophe in name"""
+        result = filter_commonname(self.APOSTROPHE_FULL_NAME,
+                                   illegal_handler=_hex_wrap)
+        self.assertNotEqual(result, self.APOSTROPHE_FULL_NAME)
+        self.assertNotIn("'", result)
+        self.assertEqual(result, self.APOSTROPHE_FULL_NAME_HEX)
+
+
+class TestMigSharedBase__legacy(MigTestCase):
+    """Run mig.shared.safeinput legacy self-test"""
+
+    # TODO: migrate all legacy self-check functionality into the above?
+    def test_existing_main(self):
+        """Run built-in self-tests and check output"""
+        def raise_on_error_exit(exit_code):
+            if exit_code != 0:
+                if raise_on_error_exit.last_print is not None:
+                    identifying_message = raise_on_error_exit.last_print
+                else:
+                    identifying_message = 'unknown'
+                raise AssertionError(
+                    'failure in unittest/testcore: %s' % (identifying_message,))
+        raise_on_error_exit.last_print = None
+
+        def record_last_print(value):
+            """Keep track of printed output"""
+            raise_on_error_exit.last_print = value
+
+        safeinput_main(_exit=raise_on_error_exit, _print=record_last_print)
 
 
 if __name__ == '__main__':

--- a/tests/test_mig_shared_safeinput.py
+++ b/tests/test_mig_shared_safeinput.py
@@ -2,7 +2,7 @@
 #
 # --- BEGIN_HEADER ---
 #
-# test_mig_shared_base - unit tests for shared base helpers
+# test_mig_shared_safeinput - unit tests for shared safeinput validation
 # Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
@@ -35,7 +35,8 @@ from past.builtins import basestring, unicode
 from tests.support import MigTestCase, testmain
 
 from mig.shared.safeinput import main as safeinput_main, InputException, \
-    filter_commonname, valid_commonname
+    filter_commonname, valid_alphanumeric, valid_commonname, valid_path, \
+    valid_printable, VALID_NAME_CHARACTERS
 
 PY2 = sys.version_info[0] == 2
 
@@ -61,14 +62,15 @@ def _hex_wrap(val):
 class TestMigSharedSafeInput(MigTestCase):
     """Test mig.shared.safeinput functions"""
 
-    def _provide_configuration(self):
-        """Set up isolated test configuration and logger for the tests"""
-        return 'testconfig'
+    # Core functionality test constants
+    INVALID_DOLLAR_NAME = "invalid$name"
+    VALID_EXTRA_CHARS_NAME = "user-name_123"
+    PRINTABLE_CHARS = "abc123!@#"
+    ACCENTED_VALID = "Renée Müller"
+    ACCENTED_INVALID_EXOTIC = "Źaćâř"
+    DECOMPOSED_UNICODE = u"å"  # a + combining ring above
 
-    def before_each(self):
-        """Setup fake configuration before each test."""
-        return
-
+    # Commonname specific test constants
     APOSTROPHE_FULL_NAME = "John O'Connor"
     APOSTROPHE_FULL_NAME_SKIP = "John OConnor"
     APOSTROPHE_FULL_NAME_HEX = "John O.X27Connor"
@@ -86,8 +88,16 @@ class TestMigSharedSafeInput(MigTestCase):
         'Test Invalid ?',
         'Test HTML Invalid <code/>')
 
+    def _provide_configuration(self):
+        """Provide test configuration"""
+        return 'testconfig'
+
+    def before_each(self):
+        """Test case setup handler"""
+        return
+
     def test_commonname_valid(self):
-        """Test commonname_valid with on set of test users"""
+        """Test valid_commonname with acceptable and prohibited names"""
         for test_cn in self.COMMONNAME_PERMITTED:
             saw_raise = False
             try:
@@ -105,7 +115,7 @@ class TestMigSharedSafeInput(MigTestCase):
             self.assertTrue(saw_raise)
 
     def test_commonname_filter(self):
-        """Test filter_commonname on the set of test users"""
+        """Test filter_commonname name sanitization"""
         for test_cn in self.COMMONNAME_PERMITTED:
             test_cn_unicode = as_string_of_unicode(test_cn)
             filtered_cn = filter_commonname(test_cn)
@@ -121,7 +131,7 @@ class TestMigSharedSafeInput(MigTestCase):
             self.assertEqual(''.join(overlap), filtered_cn)
 
     def test_commonname_filter_hexlify_illegal(self):
-        """Test filter_commonname on the set of test users with hexlify"""
+        """Test filter_commonname with hex encoding of illegal chars"""
         for test_cn in self.COMMONNAME_PERMITTED:
             test_cn_unicode = as_string_of_unicode(test_cn)
             filtered_cn = filter_commonname(test_cn, illegal_handler=_hex_wrap)
@@ -137,7 +147,7 @@ class TestMigSharedSafeInput(MigTestCase):
             self.assertTrue(len(filtered_cn) > len(test_cn_unicode))
 
     def test_filter_commonname_apostrophe_name_skip_illegal(self):
-        """Test filter_commonname with skip and apostrophe in name"""
+        """Test apostrophe handling with skip illegal_handler"""
         result = filter_commonname(self.APOSTROPHE_FULL_NAME,
                                    illegal_handler=None)
         self.assertNotEqual(result, self.APOSTROPHE_FULL_NAME)
@@ -145,16 +155,17 @@ class TestMigSharedSafeInput(MigTestCase):
         self.assertEqual(result, self.APOSTROPHE_FULL_NAME_SKIP)
 
     def test_filter_commonname_apostrophe_name_hexlify_illegal(self):
-        """Test filter_commonname with hexlify and apostrophe in name"""
+        """Test apostrophe handling with hex encode illegal_handler"""
         result = filter_commonname(self.APOSTROPHE_FULL_NAME,
                                    illegal_handler=_hex_wrap)
         self.assertNotEqual(result, self.APOSTROPHE_FULL_NAME)
         self.assertNotIn("'", result)
         self.assertEqual(result, self.APOSTROPHE_FULL_NAME_HEX)
 
+    # NOTE: indirect tests for __valid_contents using some of its wrappers
 
 class TestMigSharedSafeInput__legacy(MigTestCase):
-    """Run mig.shared.safeinput legacy self-test"""
+    """Legacy tests for safeinput module self-checks"""
 
     # TODO: migrate all legacy self-check functionality into the above?
     def test_existing_main(self):

--- a/tests/test_mig_shared_safeinput.py
+++ b/tests/test_mig_shared_safeinput.py
@@ -92,10 +92,6 @@ class TestMigSharedSafeInput(MigTestCase):
         """Provide test configuration"""
         return 'testconfig'
 
-    def before_each(self):
-        """Test case setup handler"""
-        return
-
     def test_commonname_valid(self):
         """Test valid_commonname with acceptable and prohibited names"""
         for test_cn in self.COMMONNAME_PERMITTED:
@@ -167,7 +163,12 @@ class TestMigSharedSafeInput(MigTestCase):
     def test_valid_printable_lengths(self):
         """Test printable character validation"""
         # Valid cases
-        valid_printable(self.PRINTABLE_CHARS, min_length=5)
+        saw_raise = False
+        try:
+            valid_printable(self.PRINTABLE_CHARS, min_length=5)
+        except InputException:
+            saw_raise = True
+        self.assertFalse(saw_raise)
 
         # Length violations
         with self.assertRaises(InputException):
@@ -179,7 +180,12 @@ class TestMigSharedSafeInput(MigTestCase):
     def test_valid_alphanumeric_with_extras(self):
         """Test alphanumeric validation with extra characters"""
         # Valid cases
-        valid_alphanumeric(self.VALID_EXTRA_CHARS_NAME, extra_chars="-_")
+        saw_raise = False
+        try:
+            valid_alphanumeric(self.VALID_EXTRA_CHARS_NAME, extra_chars="-_")
+        except InputException:
+            saw_raise = True
+        self.assertFalse(saw_raise)
 
         # Invalid characters
         with self.assertRaises(InputException):
@@ -188,7 +194,12 @@ class TestMigSharedSafeInput(MigTestCase):
     def test_valid_commonname_accent_handling(self):
         """Test accented character handling validation"""
         # Common accents should pass with COMMON_ACCENTED
-        valid_commonname(self.ACCENTED_VALID)
+        saw_raise = False
+        try:
+            valid_commonname(self.ACCENTED_VALID)
+        except InputException:
+            saw_raise = True
+        self.assertFalse(saw_raise)
 
         # Exotic accents should fail with NO_ACCENTED
         with self.assertRaises(InputException):

--- a/tests/test_mig_shared_safeinput.py
+++ b/tests/test_mig_shared_safeinput.py
@@ -197,8 +197,7 @@ class TestMigSharedSafeInput(MigTestCase):
     def test_valid_path_unicode_normalization(self):
         """Test unicode decomposition handling"""
         # Make sure unicode normalization doesn't raise exception
-        result = valid_path(self.DECOMPOSED_UNICODE)
-        self.assertEqual(result, None)
+        self.assertEqual(valid_path(self.DECOMPOSED_UNICODE), None)
 
 
 class TestMigSharedSafeInput__legacy(MigTestCase):


### PR DESCRIPTION
Restructure `safeinput` unit tests to be more like recent `base` module unit tests and expand tests to explicitly cover the code path underpinning the issue #35 example.
Tighten asserts in existing tests. Fix some copy/paste comments and add some missing docstrings. Clean up unused imports.