### PR TITLE
WiP: switch e.g. html/javascript template strings with embedded escape codes to `raw` string

### DIFF
--- a/mig/server/checkconf.py
+++ b/mig/server/checkconf.py
@@ -115,7 +115,7 @@ def check_conf(conf_file):
 
     # Search object attributes for possible paths
 
-    path_re = re.compile('(' + os.sep + "[\w\._-]*)+$")
+    path_re = re.compile(r'(%s[\w\._-]*)+$' % os.sep)
 
     _logger = conf.logger
     _logger.info('Checking configuration paths in %s ...', conf_file)

--- a/mig/server/checkconf.py
+++ b/mig/server/checkconf.py
@@ -173,16 +173,18 @@ def check_conf(conf_file):
             missing_paths.sort()
 
             for path in missing_paths:
-                default_path_type = 'D'
-                # We're past NO so ask on YES or use default path_type for AUTO
-                if YES == answer:
+                # Initialise path_type to a bogus value
+                path_type = False
+                if ALWAYS == answer:
+
+                    # 'always' answer results in default type for all missing entries
+
+                    path_type = None
+                elif YES == answer:
                     path_type = \
                         ask_reply('Create %s as a (d)irectory, (f)ile or (p)ipe? [D/f/p] '
-                                  % path) or default_path_type
-                else:
-                    path_type = default_path_type
-
-                if 'D' == path_type.upper():
+                                  % path)
+                if path_type is None or 'D' == path_type.upper():
                     try:
                         os.makedirs(path)
                         print('created directory %s' % path)

--- a/mig/server/checkconf.py
+++ b/mig/server/checkconf.py
@@ -173,18 +173,16 @@ def check_conf(conf_file):
             missing_paths.sort()
 
             for path in missing_paths:
-                # Initialise path_type to a bogus value
-                path_type = False
-                if ALWAYS == answer:
-
-                    # 'always' answer results in default type for all missing entries
-
-                    path_type = None
-                elif YES == answer:
+                default_path_type = 'D'
+                # We're past NO so ask on YES or use default path_type for AUTO
+                if YES == answer:
                     path_type = \
                         ask_reply('Create %s as a (d)irectory, (f)ile or (p)ipe? [D/f/p] '
-                                  % path)
-                if path_type is None or 'D' == path_type.upper():
+                                  % path) or default_path_type
+                else:
+                    path_type = default_path_type
+
+                if 'D' == path_type.upper():
                     try:
                         os.makedirs(path)
                         print('created directory %s' % path)

--- a/mig/server/chksidroot.py
+++ b/mig/server/chksidroot.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # chksidroot - Simple Apache httpd SID chroot helper daemon
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -98,7 +99,7 @@ unless it is available in mig/server/MiGserver.conf
     chksidroot_stdin = sys.stdin
 
     addr_path_pattern = re.compile(
-        "^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})::(/.*)$")
+        r"^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})::(/.*)$")
     keep_running = True
     if verbose:
         print('Reading commands from sys stdin')

--- a/mig/server/chkuserroot.py
+++ b/mig/server/chkuserroot.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # chkuserroot - Simple Apache httpd user chroot helper daemon
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -99,7 +100,7 @@ unless it is available in mig/server/MiGserver.conf
     chkuserroot_stdin = sys.stdin
 
     addr_path_pattern = re.compile(
-        "^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})::(/.*)$")
+        r"^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})::(/.*)$")
     keep_running = True
     if verbose:
         print('Reading commands from sys stdin')

--- a/mig/server/genjobscriptpython.py
+++ b/mig/server/genjobscriptpython.py
@@ -711,12 +711,11 @@ if not os.environ.get("MIG_JOBDIR", ""):
         successcode='0',
         msg='ERROR: unexpected exit code!',
     ):
-        """Print msg unless last command exitted with successcode"""
+        """Print msg unless last command exited with successcode"""
 
-        cmd = r'''
-if %s != %s:
-    print("WARNING: %r \(" + %s + "\)")
-''' % (result, successcode, msg, result)
+        cmd = 'if ' + result + ' != ' + successcode + ':\n'
+        cmd += '\tprint "WARNING: ' + msg + '(" + ' + result + ' + ")"\n'
+        cmd += '\n'
         return cmd
 
     def log_on_error(

--- a/mig/server/genjobscriptpython.py
+++ b/mig/server/genjobscriptpython.py
@@ -713,9 +713,10 @@ if not os.environ.get("MIG_JOBDIR", ""):
     ):
         """Print msg unless last command exitted with successcode"""
 
-        cmd = 'if ' + result + ' != ' + successcode + ':\n'
-        cmd += '\tprint "WARNING: ' + msg + "\(\" + " + result + " + \"\)\"\n"
-        cmd += '\n'
+        cmd = r'''
+if %s != %s:
+    print("WARNING: %r \(" + %s + "\)")
+''' % (result, successcode, msg, result)
         return cmd
 
     def log_on_error(

--- a/mig/server/genjobscriptsh.py
+++ b/mig/server/genjobscriptsh.py
@@ -1105,11 +1105,9 @@ class GenJobScriptSh(object):
     ):
         """Print msg unless result contains success code"""
 
-        cmd = r'''
-if [ $%s -ne %s ]; then
-    echo "WARNING: %r \($%s\)"
-fi
-''' % (result, successcode, msg, result)
+        cmd = 'if [ $' + result + ' -ne ' + successcode + ' ]; then\n'
+        cmd += '\techo "WARNING: ' + msg + '($' + result + ')"\n'
+        cmd += 'fi\n'
         return cmd
 
     def log_on_error(

--- a/mig/server/genjobscriptsh.py
+++ b/mig/server/genjobscriptsh.py
@@ -1105,9 +1105,11 @@ class GenJobScriptSh(object):
     ):
         """Print msg unless result contains success code"""
 
-        cmd = 'if [ $' + result + ' -ne ' + successcode + ' ]; then\n'
-        cmd += '\techo "WARNING: ' + msg + "\($" + result + "\)\"\n"
-        cmd += 'fi\n'
+        cmd = r'''
+if [ $%s -ne %s ]; then
+    echo "WARNING: %r \($%s\)"
+fi
+''' % (result, successcode, msg, result)
         return cmd
 
     def log_on_error(

--- a/mig/server/grid_openid.py
+++ b/mig/server/grid_openid.py
@@ -131,7 +131,7 @@ cert_field_aliases = {}
 
 # NOTE: response may contain password on the form
 # (<Symbol Bare namespace>, 'password'): 'S3cr3tP4ssw0rd'
-pw_pattern = "\(<Symbol Bare namespace>, 'password'\): '(.+)'"
+pw_pattern = r"\(<Symbol Bare namespace>, 'password'\): '(.+)'"
 pw_regexp = re.compile(pw_pattern)
 
 

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -507,7 +507,7 @@ def account_request_template(configuration, password=True, default_values={}):
   </div>
         """
 
-    email_text_pattern = '.*[^ ]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+.*'
+    email_text_pattern = r'.*[^ ]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+.*'
     if configuration.site_peers_explicit_fields:
         # NOTE: dedicated peers field(s) instead of legacy Comment use
         comment_add = ''

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -80,7 +80,7 @@ def account_js_helpers(configuration, fields):
 <script type="text/javascript" src="/images/js/jquery.form.js"></script>
 <script type="text/javascript" src="/images/js/jquery.accountform.js"></script>
     '''
-    add_init = """
+    add_init = r"""
   /* Helper to define countries for which State field makes sense */
   var enable_state = ['US', 'CA', 'AU'];
   var peers_mandatory = %(peers_mandatory)s;
@@ -529,7 +529,7 @@ def account_request_template(configuration, password=True, default_values={}):
         comment_pattern = ''
 
     if 'full_name' in configuration.site_peers_explicit_fields:
-        html += """
+        html += r"""
   <div class='form-row single-entry %(show_peers_full_name)s'>
     <div class='col-md-12 mb-3 form-cell'>
       <!-- NOTE: this simple form control just looks for one or more full names.
@@ -546,7 +546,7 @@ def account_request_template(configuration, password=True, default_values={}):
   </div>
         """
     if 'email' in configuration.site_peers_explicit_fields:
-        html += """
+        html += r"""
   <div class='form-row single-entry %(show_peers_email)s'>
     <div class='col-md-12 mb-3 form-cell'>
       <!-- NOTE: this simple form control just looks for one or more emails.

--- a/mig/shared/functionality/datatransfer.py
+++ b/mig/shared/functionality/datatransfer.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # datatransfer - import and export data in the backgroud
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -56,8 +57,8 @@ edit_fields = ['transfer_id', 'protocol', 'fqdn', 'port', 'username',
 get_actions = ['show', 'fillimport', 'fillexport']
 transfer_actions = ['import', 'export', 'deltransfer', 'redotransfer']
 # TODO: add these internal data shuffling targets on a separate tab without
-#address and creds
-#shuffling_actions = ['move', 'copy', 'unpack', 'pack', 'remove']
+# address and creds
+# shuffling_actions = ['move', 'copy', 'unpack', 'pack', 'remove']
 shuffling_actions = []
 key_actions = ['generatekey', 'delkey']
 post_actions = transfer_actions + shuffling_actions + key_actions
@@ -596,7 +597,7 @@ into.<br/>
                 selected = ''
             transfer_html += '<option %s value="%s">%s</option>' % \
                              (selected, key, val)
-        transfer_html += '''
+        transfer_html += r'''
 </select>
 </td></tr>
 <tr><td>

--- a/mig/shared/functionality/docs.py
+++ b/mig/shared/functionality/docs.py
@@ -215,7 +215,7 @@ The MiG software license follows below:<br />
     lic_text = ''.join(lic_lines[2:-1])
     output_objects.append({'object_type': 'html_form', 'text':
                            '<code>%s</code><br />' %
-                           lic_text.replace('\n', '<br \>')})
+                           lic_text.replace('\n', '<br />')})
 
     output_objects.append(
         {'object_type': 'header', 'text': 'Acknowledgements'})

--- a/mig/shared/functionality/fileman.py
+++ b/mig/shared/functionality/fileman.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # fileman - File manager UI for browsing and manipulating files and folders
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -463,7 +464,7 @@ def js_tmpl_parts(configuration,
             ('%s' % (configuration.site_enable_transfers and legacy_buttons)).lower(),
         'enable_gdp':
             ('%s' % configuration.site_enable_gdp).lower(),
-        'max_stream_size': 64*1024*1024
+        'max_stream_size': 64 * 1024 * 1024
     }
 
     js_import = '''
@@ -480,7 +481,7 @@ var csrf_map = {};
         js_import += '''
 csrf_map["%s"] = "%s";
 ''' % (target_op, token)
-    js_import += '''
+    js_import += r'''
 </script>
 <script type="text/javascript" src="/images/js/jquery.filemanager.js"></script>
 <script type="text/javascript" src="/images/js/jquery.tablesorter.js"></script>

--- a/mig/shared/functionality/reqjupyterservice.py
+++ b/mig/shared/functionality/reqjupyterservice.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # reqjupyterservice - Redirect the user to a backend jupyter service host
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -41,6 +42,7 @@ Finally the user is redirected to the jupyterhub home page where a new notebook
 server can be instantiated and mount the users linked homedrive with the passed
 keyset.
 """
+
 from __future__ import print_function
 from __future__ import absolute_import
 
@@ -116,7 +118,7 @@ def to_unix_account(input_str):
     if not isinstance(input_str, basestring) or not input_str:
         return None
     input_str = input_str.lower()
-    valid_unix_name = "".join(re.findall('[a-z0-9_.\-]+', input_str))
+    valid_unix_name = "".join(re.findall(r'[a-z0-9_.\-]+', input_str))
     if not valid_unix_name:
         return None
     return valid_unix_name[:32]
@@ -135,8 +137,9 @@ def mig_to_mount_adapt(mig):
     if "@" in mount_string and ":" in mount_string:
         # Expects that the mount_string is in the format
         # @mount_url:mount_path
-        target_host = mount_string[mount_string.index("@")+1:mount_string.index(":")]
-        target_path = mount_string[mount_string.index(":")+1:]        
+        target_host = mount_string[mount_string.index(
+            "@") + 1:mount_string.index(":")]
+        target_path = mount_string[mount_string.index(":") + 1:]
 
     mount = {
         'targetHost': target_host,
@@ -228,6 +231,7 @@ def get_newest_mount(jupyter_mounts):
         else:
             old_mounts.append(mount)
     return latest, old_mounts
+
 
 @__require_requests
 def get_host_from_service(configuration, service, base_url=None):
@@ -352,6 +356,7 @@ def signature():
     }
     return ['', defaults]
 
+
 @__require_requests
 def main(client_id, user_arguments_dict):
     """Main function used by front end"""
@@ -410,7 +415,8 @@ def main(client_id, user_arguments_dict):
         )
         return (output_objects, returnvalues.SYSTEM_ERROR)
 
-    host = get_host_from_service(configuration, service, base_url="/%s" % service["service_name"])
+    host = get_host_from_service(configuration, service, base_url="/%s" %
+                                 service["service_name"])
     # Get an active jupyterhost
     if not host:
         logger.error("No active jupyterhub host could be found")
@@ -526,8 +532,8 @@ def main(client_id, user_arguments_dict):
                 workflow_session_id = get_workflow_session_id(configuration,
                                                               client_id)
                 if not workflow_session_id:
-                    workflow_session_id = create_workflow_session_id(configuration,
-                                                                     client_id)
+                    workflow_session_id = create_workflow_session_id(
+                        configuration, client_id)
                 # TODO get these dynamically
                 workflows_url = configuration.migserver_https_sid_url + \
                     '/cgi-sid/jsoninterface.py?output_format=json'
@@ -543,10 +549,12 @@ def main(client_id, user_arguments_dict):
             # Refresh cookies
             session.get(url_hub)
             # Authenticate and submit data
-            response = jupyterhub_session_post_request(session, url_auth, headers=auth_header)
+            response = jupyterhub_session_post_request(session, url_auth,
+                                                       headers=auth_header)
             if response.status_code == 200:
                 for user_data_type, user_data in user_post_data.items():
-                    response = jupyterhub_session_post_request(session, url_data, json={user_data_type: user_data})
+                    response = jupyterhub_session_post_request(
+                        session, url_data, json={user_data_type: user_data})
                     if response.status_code != 200:
                         logger.error(
                             "Jupyter: User %s failed to submit data %s to %s"
@@ -562,7 +570,7 @@ def main(client_id, user_arguments_dict):
 
     # Create a new keyset
     # Create login session id
-    session_id = generate_random_ascii(2*session_id_bytes,
+    session_id = generate_random_ascii(2 * session_id_bytes,
                                        charset='0123456789abcdef')
 
     # Generate private/public keys
@@ -654,13 +662,15 @@ def main(client_id, user_arguments_dict):
         # Refresh cookies
         session.get(url_hub)
         # Authenticate
-        response = jupyterhub_session_post_request(session, url_auth, headers=auth_header)
+        response = jupyterhub_session_post_request(session, url_auth,
+                                                   headers=auth_header)
         if response.status_code == 200:
             for user_data_type, user_data in user_post_data.items():
-                response = jupyterhub_session_post_request(session, url_data, json={user_data_type: user_data})
+                response = jupyterhub_session_post_request(
+                    session, url_data, json={user_data_type: user_data})
                 if response.status_code != 200:
                     logger.error("Jupyter: User %s failed to submit data %s to %s"
-                                % (client_id, user_data, url_data))
+                                 % (client_id, user_data, url_data))
         else:
             logger.error("Jupyter: User %s failed to authenticate against %s"
                          % (client_id, url_auth))

--- a/mig/shared/functionality/resedit.py
+++ b/mig/shared/functionality/resedit.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # resedit - Resource editor back end
-# Copyright (C) 2003-2019  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,14 +20,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
 
-# Martin Rehr martin@rehr.dk August 2005
-
 """Display resource editor"""
+
 from __future__ import print_function
 from __future__ import absolute_import
 
@@ -199,7 +199,7 @@ description, you can likely just leave the field alone.''' % configuration.short
              conf[field])
         })
     else:
-        output_objects.append({'object_type': 'html_form', 'text': """<br />
+        output_objects.append({'object_type': 'html_form', 'text': r"""<br />
 <b>%s:</b>&nbsp;<a class='infolink iconspace' href='resedithelp.py#res-%s'>help</a><br />
 <input class='fillwidth padspace' type='text' name='%s' size='%d' value='%s'
     required pattern='[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+'

--- a/mig/shared/functionality/vgridworkflows.py
+++ b/mig/shared/functionality/vgridworkflows.py
@@ -101,7 +101,7 @@ def read_trigger_log(configuration, vgrid_name, flags):
 
     if not verbose(flags):
         # Strip system trigger lines containing '.meta/EXT.last_modified'
-        system_pattern = '[0-9 ,:-]* [A-Z]* .*/\.meta/.*\.last_modified.*\n'
+        system_pattern = r'[0-9 ,:-]* [A-Z]* .*/\.meta/.*\.last_modified.*\n'
         log_content = re.sub(system_pattern, '', log_content)
 
     return log_content

--- a/mig/shared/functionality/vgridworkflows.py
+++ b/mig/shared/functionality/vgridworkflows.py
@@ -101,7 +101,7 @@ def read_trigger_log(configuration, vgrid_name, flags):
 
     if not verbose(flags):
         # Strip system trigger lines containing '.meta/EXT.last_modified'
-        system_pattern = r'[0-9 ,:-]* [A-Z]* .*/\.meta/.*\.last_modified.*\n'
+        system_pattern = r'[0-9 ,:-]* [A-Z]* .*/\.meta/.*\.last_modified.*' + '\n'
         log_content = re.sub(system_pattern, '', log_content)
 
     return log_content

--- a/mig/shared/htmlgen.py
+++ b/mig/shared/htmlgen.py
@@ -904,7 +904,7 @@ def fancy_upload_js(configuration, callback=None, share_id='', csrf_token='',
     if not callback:
         callback = 'function() { return false; }'
     # TODO: migrate to assets
-    add_import = '''
+    add_import = r'''
 <!--  Filemanager is only needed for fancy upload init wrapper -->
 <script type="text/javascript" src="/assets/vendor/jquery.form/js/jquery.form.js"></script>
 <script type="text/javascript" src="/images/js/jquery.filemanager.js"></script>

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -180,7 +180,7 @@ def fill_template(template_file, output_file, settings, eat_trailing_space=[],
     for (variable, value) in settings.items():
         suffix = ''
         if variable in eat_trailing_space:
-            suffix = '\s{0,1}'
+            suffix = r'\s{0,1}'
         try:
             contents = re.sub(variable + suffix, value, contents)
         except Exception as exc:

--- a/mig/shared/publicscriptgen.py
+++ b/mig/shared/publicscriptgen.py
@@ -417,7 +417,7 @@ def auth_check_init(lang):
     """Init all auth variables"""
     s = ''
     if lang == 'sh':
-        s += """
+        s += r"""
     declare -a ca_check
     if [ -z \"$ca_cert_file\" ]; then
         ca_check=(\"--insecure\")
@@ -535,7 +535,7 @@ def curl_perform(
 
     s = ''
     if lang == 'sh':
-        s += """
+        s += r"""
     # https://blogs.gnome.org/shaunm/2009/12/05/urlencode-and-urldecode-in-sh/
     urlquote() {
         LANG=C
@@ -822,7 +822,7 @@ def curl_chain_login_steps(
         return ''
 
     if lang == 'sh':
-        s += """
+        s += r"""
     # NOTE: curl_post_flex sets return val in $exit_code 
     #       and curl output to stdout
     out=$(curl_post_flex \"$user_conf\" \\
@@ -1401,7 +1401,7 @@ script_dir=`dirname $script_path`
     elif lang == 'python':
         s += comment(lang, '=== Main ===')
 
-        s += """
+        s += r"""
 verbose = 0
 conf = os.path.expanduser(\"~/.mig/miguser.conf\")
 auth_redir=""
@@ -1444,7 +1444,7 @@ def parse_options(lang, extra_opts, extra_opts_handler):
 """
         if extra_opts_handler:
             s += extra_opts_handler
-        s += """
+        s += r"""
         \?)  # unknown flag
              usage
              exit 1;;

--- a/mig/shared/resadm.py
+++ b/mig/shared/resadm.py
@@ -1122,8 +1122,7 @@ def resource_fe_action(
             # Try pkill if ordinary kill doesn't work (-PGID not
             # always supported)
 
-            command = 'kill -9 -' + pgid + ' || pkill -9 -g ' + pgid\
-                + " \.\*"
+            command = r'kill -9 -%s || pkill -9 -g %s \.\*' % (pgid, pgid)
             (exit_code, executed_command) = \
                 execute_on_resource(command, False, resource_config,
                                     logger)

--- a/tests/test_mig_shared_functionality_datatransfer.py
+++ b/tests/test_mig_shared_functionality_datatransfer.py
@@ -108,6 +108,17 @@ class MigSharedFunctionalityDataTransfer(MigTestCase):
         text_objects = _only_output_objects(output_objects, with_object_type="text")
         self.assertEqual(len(text_objects), 0)
 
+        # We expect 10 html snippets here
+        html_objects = _only_output_objects(output_objects,
+                                            with_object_type="html_form")
+        self.assertEqual(len(html_objects), 10)
+        # NOTE: next bit verifies the correct switch to an r-string
+        found_pattern = False
+        for entry in html_objects:
+            if entry['text'].find(r'="[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)+"') != -1:
+                found_pattern = True
+        self.assertTrue(found_pattern)
+
     def test_deltransfer_without_transfer_id(self):
         non_existing_transfer_id = "non-existing-transfer-id"
         payload = {"action": ["deltransfer"], "transfer_id": [non_existing_transfer_id]}


### PR DESCRIPTION
Switch e.g. html/javascript template strings with embedded escapes in them to raw strings like `r"bla\*" in order to avoid `DeprecationWarning` (on python3.6+) or `SyntaxError` (python3.12+).

Tools like `bandit` will warn about the existence of such strings when scanned so it can be used to locate all relevant occurrences in our code base.

It's important to validate that the raw string wrapping does not change the meaning of the code. They typically remove the need for one level of escaping as in
```
 > python
Python 3.12.3 (main, Nov  6 2025, 13:44:16) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> r'\.'
'\\.'
```

Integrates #609 to prevent the corresponding old lint errors in existing code. So it's best to merge that one first.

Still pending some verification that none of the updates actually change the resulting strings. Manually verified for `server/*.py` and `shared/functionality/*.py` modules so far.

We should add unit tests to verify the correct output of the individual functions or the entire page. Since it overlaps with #612, #613 and #614 it may be best to merge those first and rebase here.