### PR TITLE
python-c-ext-sanity-check: Added 'PATHS_IGNORE_SPLINT'

### DIFF
--- a/.github/workflows/python-c-ext-sanity-check.yml
+++ b/.github/workflows/python-c-ext-sanity-check.yml
@@ -78,17 +78,17 @@ jobs:
     steps:
       - name: Update packages
         run: |
-          DEBIAN_FRONTEND='noninteractive' apt update -y
+          DEBIAN_FRONTEND='noninteractive' sudo apt update -y
       - name: Set up latest stable python 3.x
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Set up git, findutils and make with apt
         run: |
-          DEBIAN_FRONTEND='noninteractive' apt install -y git findutils make
+          DEBIAN_FRONTEND='noninteractive' sudo apt install -y git findutils make
       - name: Install dependencies
         run: |
-          DEBIAN_FRONTEND='noninteractive' apt install -y libnss3-dev libpam-dev splint
+          DEBIAN_FRONTEND='noninteractive' sudo apt install -y libnss3-dev libpam-dev splint
       # We may need git installed to get a full repo clone rather than unpacked archive
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -111,13 +111,13 @@ jobs:
     steps:
       - name: Update packages
         run: |
-          DEBIAN_FRONTEND='noninteractive' apt update -y
+          DEBIAN_FRONTEND='noninteractive' sudo apt update -y
       - name: Set up git, findutils and make with apt
         run: |
-          DEBIAN_FRONTEND='noninteractive' apt install -y git findutils make
+          DEBIAN_FRONTEND='noninteractive' sudo apt install -y git findutils make
       - name: Install dependencies
         run: |
-          DEBIAN_FRONTEND='noninteractive' apt install -y python3-dev libnss3-dev libpam-dev splint
+          DEBIAN_FRONTEND='noninteractive' sudo apt install -y python3-dev libnss3-dev libpam-dev splint
       # We may need git installed to get a full repo clone rather than unpacked archive
       - name: Check out source repository
         uses: actions/checkout@v4

--- a/.github/workflows/python-c-ext-sanity-check.yml
+++ b/.github/workflows/python-c-ext-sanity-check.yml
@@ -5,6 +5,11 @@
 
 name: Python C-Extension Sanity Checks
 
+# Ignore the following paths
+# Format: PATH1|PATH2|PATH3
+env:
+  PATHS_IGNORE_SPLINT: mig/src/lustreclient/.*$
+
 on:
   # Triggers the workflow on push or pull request events but only for this git branch
   push:
@@ -71,16 +76,19 @@ jobs:
     if: ${{ false }} # Disabled until we figure out how to fix system headers
     runs-on: ubuntu-latest
     steps:
+      - name: Update packages
+        run: |
+          DEBIAN_FRONTEND='noninteractive' apt update -y
       - name: Set up latest stable python 3.x
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Set up git, findutils and make with apt
         run: |
-          sudo apt install -y git findutils make
+          DEBIAN_FRONTEND='noninteractive' apt install -y git findutils make
       - name: Install dependencies
         run: |
-          sudo apt install -y libnss3-dev libpam-dev splint
+          DEBIAN_FRONTEND='noninteractive' apt install -y libnss3-dev libpam-dev splint
       # We may need git installed to get a full repo clone rather than unpacked archive
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -90,9 +98,9 @@ jobs:
         run: |
           # NOTE: we only run splint error check for changed C files to limit noise
           # NOTE: point splint to Ubuntu's custom /usr/include/python3.x for Python.h
-          echo "Lint changed code files: $(git diff --diff-filter=ACMRTB --name-only HEAD^1 -- | grep -E '\.c$')"
+          echo "Lint changed code files: $(git diff --diff-filter=ACMRTB --name-only HEAD^1 -- | grep -Ev '${{ env.PATHS_IGNORE_SPLINT }}' | grep -E '\.c$')"
           # NOTE: show splint warnings but don't fail unless it found critical errors
-          git diff --diff-filter=ACMRTB --name-only HEAD^1 -- | grep -E '\.c$' | xargs -r splint +posixlib -D__gnuc_va_list=va_list $(python3-config --includes) &> splint.log || true
+          git diff --diff-filter=ACMRTB --name-only HEAD^1 -- | grep -Ev '${{ env.PATHS_IGNORE_SPLINT }}' | grep -E '\.c$' | xargs -r splint +posixlib -D__gnuc_va_list=va_list $(python3-config --includes) &> splint.log || true
           [ ! -e splint.log ] || cat splint.log
           [ ! -e splint.log ] || ! grep -q ' Cannot continue' splint.log
 
@@ -101,12 +109,15 @@ jobs:
     name: Sanity check c-extension module code in latest Ubuntu LTS python3
     runs-on: ubuntu-24.04
     steps:
+      - name: Update packages
+        run: |
+          DEBIAN_FRONTEND='noninteractive' apt update -y
       - name: Set up git, findutils and make with apt
         run: |
-          sudo apt install -y git findutils make
+          DEBIAN_FRONTEND='noninteractive' apt install -y git findutils make
       - name: Install dependencies
         run: |
-          sudo apt install -y python3-dev libnss3-dev libpam-dev splint
+          DEBIAN_FRONTEND='noninteractive' apt install -y python3-dev libnss3-dev libpam-dev splint
       # We may need git installed to get a full repo clone rather than unpacked archive
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -116,10 +127,10 @@ jobs:
         run: |
           # NOTE: we only run splint error check for changed C files to limit noise
           # NOTE: point splint to Ubuntu's custom /usr/include/python3.x for Python.h
-          echo "Lint changed code files: $(git diff --diff-filter=ACMRTB --name-only HEAD^1 -- | grep -E '\.c$')"
+          echo "Lint changed code files: $(git diff --diff-filter=ACMRTB --name-only HEAD^1 -- | grep -Ev '${{ env.PATHS_IGNORE_SPLINT }}' | grep -E '\.c$')"
           # NOTE: splint complains about NATIVE_TSS_KEY_T in system header here
           # NOTE: show splint warnings but don't fail unless it found critical errors
-          git diff --diff-filter=ACMRTB --name-only HEAD^1 -- | grep -E '\.c$' | xargs -r splint +posixlib -D__gnuc_va_list=va_list -DNATIVE_TSS_KEY_T=char $(python3-config --includes) &> splint.log || true
+          git diff --diff-filter=ACMRTB --name-only HEAD^1 -- | grep -Ev '${{ env.PATHS_IGNORE_SPLINT }}' | grep -E '\.c$' | xargs -r splint +posixlib -D__gnuc_va_list=va_list -DNATIVE_TSS_KEY_T=char $(python3-config --includes) &> splint.log || true
           [ ! -e splint.log ] || cat splint.log
           [ ! -e splint.log ] || ! grep -q ' Cannot continue' splint.log
 
@@ -135,6 +146,9 @@ jobs:
     container:
       image: rockylinux/rockylinux:9
     steps:
+      - name: Update packages
+        run: |
+          dnf update -y
       - name: Set up git, findutils, make and python3 with dnf and make the latter default
         run: |
           dnf install -y git findutils make python3 python3-pip python-unversioned-command
@@ -156,10 +170,10 @@ jobs:
           # NOTE: perms are not right inside container so repeat what checkout module does.
           git config --global --add safe.directory "$PWD"
           # NOTE: we only run splint error check for changed C files to limit noise
-          echo "Lint changed code files: $(git diff --diff-filter=ACMRTB --name-only HEAD^1 -- | grep -E '\.c$')"
+          echo "Lint changed code files: $(git diff --diff-filter=ACMRTB --name-only HEAD^1 -- | grep -Ev '${{ env.PATHS_IGNORE_SPLINT }}' | grep -E '\.c$')"
           echo "with splint from $(which splint)"
           ls -l /bin/splint
           # NOTE: show splint warnings but don't fail unless it found critical errors
-          git diff --diff-filter=ACMRTB --name-only HEAD^1 -- | grep -E '\.c$' | xargs -r splint +posixlib -D__gnuc_va_list=va_list &> splint.log || true
+          git diff --diff-filter=ACMRTB --name-only HEAD^1 -- | grep -Ev '${{ env.PATHS_IGNORE_SPLINT }}' | grep -E '\.c$' | xargs -r splint +posixlib -D__gnuc_va_list=va_list &> splint.log || true
           [ ! -e splint.log ] || cat splint.log
           [ ! -e splint.log ] || ! grep -q ' Cannot continue' splint.log


### PR DESCRIPTION
The 'paths-ignore' isn't enough, if we wan't to ignore specific C files then we need to filter them out in the splint run like we already filter out non-C files.
