### PR TITLE
Give code within containers standard privileges as the user "migtest".

### DIFF
--- a/envhelp/docker/Dockerfile.py3
+++ b/envhelp/docker/Dockerfile.py3
@@ -1,9 +1,16 @@
 # NOTE: we use upstream python-3.9 image to mimic the version on RHEL/Rocky 9
 FROM python:3.9
 
+ARG CONTAINER_USER_NAME=migtest
+# the following value is required to be overridden via a --build-arg
+ARG CONTAINER_USER_UID=-42
+
 WORKDIR /usr/src/app
 
 COPY requirements.txt local-requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt -r local-requirements.txt
+
+RUN useradd --uid ${CONTAINER_USER_UID} ${CONTAINER_USER_NAME}
+USER ${CONTAINER_USER_NAME}
 
 CMD [ "python", "--version" ]

--- a/envhelp/docker/Dockerfile.pyver
+++ b/envhelp/docker/Dockerfile.pyver
@@ -1,9 +1,16 @@
 ARG pyver
 FROM python:${pyver}
 
+ARG CONTAINER_USER_NAME=migtest
+# the following value is required to be overridden via a --build-arg
+ARG CONTAINER_USER_UID=-42
+
 WORKDIR /usr/src/app
 
 COPY requirements.txt local-requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt -r local-requirements.txt
+
+RUN useradd --uid ${CONTAINER_USER_UID} ${CONTAINER_USER_NAME}
+USER ${CONTAINER_USER_NAME}
 
 CMD [ "python", "--version" ]

--- a/envhelp/dpython
+++ b/envhelp/dpython
@@ -30,13 +30,16 @@ set -e
 SCRIPT_PATH=$(realpath "$0")
 SCRIPT_BASE=$(dirname -- "$SCRIPT_PATH")
 MIG_BASE=$(realpath "$SCRIPT_BASE/..")
+LOCAL_USER_UID=$(id -u $USER)
 
 if [ -n "${PYVER}" ]; then
     PYTHON_SUFFIX="pyver_$PYVER"
+    DISPLAY_PYVER="$PYVER"
     DOCKER_FILE_SUFFIX="pyver"
 else
     echo "No specific python version chosen - defaulting to supported baseline"
-    PYVER="3 (default)"
+    PYVER="3"
+    DISPLAY_PYVER="3 (default)"
     PYTHON_SUFFIX="py3"
     DOCKER_FILE_SUFFIX="py3"
 fi
@@ -48,7 +51,7 @@ DOCKER_PYTHON_BIN=${DOCKER_PYTHON_BIN:-"python3"}
 # NOTE: portable dynamic lookup with docker as default and fallback to podman
 DOCKER_BIN=$(command -v docker || command -v podman || echo "")
 if [ -z "${DOCKER_BIN}" ]; then
-    echo "No docker binary found - cannot use for python $PYVER tests"
+    echo "No docker binary found - cannot use for python $DISPLAY_PYVER tests"
     exit 1
 fi
 
@@ -64,12 +67,12 @@ MIG_ENV=${MIG_ENV:-'docker'}
 PYTHONPYCACHEPREFIX="$PYTHONPATH/envhelp/output/__pycache.${PYTHON_SUFFIX}__"
 
 # determine if the image has changed
-echo -n "validating python $PYVER container.. "
+echo -n "validating python $DISPLAY_PYVER container.. "
 
 # load a previously written docker image id if present
 IMAGEID_STORED=$(cat "$DOCKER_IMAGEID_FILE" 2>/dev/null || echo "")
 
-IMAGEID=$(${DOCKER_BIN} build -f "$DOCKER_FILE" . -q --build-arg "pyver=$PYVER")
+IMAGEID=$(${DOCKER_BIN} build -f "$DOCKER_FILE" . -q --build-arg "pyver=$PYVER" --build-arg "CONTAINER_USER_UID=$LOCAL_USER_UID")
 if [ "$IMAGEID" != "$IMAGEID_STORED" ]; then
     echo "rebuilt for changes"
 

--- a/envhelp/makeconfig.py
+++ b/envhelp/makeconfig.py
@@ -32,6 +32,7 @@ from __future__ import print_function
 
 import os
 import sys
+from types import SimpleNamespace
 
 _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 _LOCAL_MIG_BASE = os.path.normpath(os.path.join(_SCRIPT_DIR, ".."))
@@ -45,6 +46,7 @@ _LOCAL_ENVHELP_OUTPUT_DIR = os.path.join(_LOCAL_MIG_BASE, "envhelp/output")
 _MAKECONFIG_ALLOWED = ["local", "test"]
 _USERADM_PATH_KEYS = ('user_cache', 'user_db_home', 'user_home',
                       'user_settings', 'mrsl_files_dir', 'resource_pending')
+_CONTAINER_USER_NAME = 'migtest'
 
 
 def _at(sequence, index=-1, default=None):
@@ -94,6 +96,28 @@ def write_testconfig(env_name, is_docker=False):
         'mig_certs': os.path.join(conf_dir_path, 'certs'),
         'mig_state': os.path.join(conf_dir_path, 'state'),
     })
+
+    if is_docker:
+        # The generate_confs function makes assumptions that it is run _on_ the
+        # host for which it is configuring mig - one such assumption is that
+        # it can call getpwnam() and expect to get a result. This is not true
+        # here because we are generating a config ahead of time and the user
+        # does not yet exist; neither does the container within which the user
+        # will be made.  So, work around this by arranging a getpwnam() result
+        # with the values matching what will be set inside the container.
+        def _getpwnam(_):
+            local_user_uid = os.getuid()
+
+            return SimpleNamespace(
+                pw_uid=local_user_uid,
+                pw_gid=local_user_uid,
+            )
+
+        overrides.update(**{
+            '_getpwnam': _getpwnam,
+            'user': _CONTAINER_USER_NAME,
+            'group': _CONTAINER_USER_NAME,
+        })
 
     print('generating "%s" configuration ...' % (confs_name,))
 


### PR DESCRIPTION
Mostly what it says on the tin. Couple small changes to the two Dockerfiles that define the test containers, an extra argument added to the shell script that executes them (`dpython` i.e. docker python) and changes to `makeconfig.py` so the in-container config has the right values.

Note to reviewer: what is needed is to verify both `make test` and `make PYVER=3.11 test` (or some version 3.9 or above) both work on an independent dev machine. Best way to prepare for doing so is `rm -rf ./envhelp/output` - given the earlier use of root inside the container you may need sudo to fully clean up. With this PR, the __pycache.*__ directories inside ./envhelp/output should all be owned by your local user.