### PR TITLE
Eliminate system_filter argument to resolve the issue described in #396

### DIFF
--- a/mig/shared/functionality/vgridworkflows.py
+++ b/mig/shared/functionality/vgridworkflows.py
@@ -270,7 +270,7 @@ access the workflows.'''
             'trigger',
             'vgridtrigger',
             configuration,
-            extra_fields + optional_fields
+            extra_fields=extra_fields + optional_fields
         )
         if not init_status:
             output_objects.append({'object_type': 'error_text', 'text':

--- a/mig/shared/functionality/vgridworkflows.py
+++ b/mig/shared/functionality/vgridworkflows.py
@@ -264,16 +264,13 @@ access the workflows.'''
         optional_fields = [('rate_limit', None), ('settle_time', None)]
 
         # Only include system triggers in verbose mode
-        if verbose(flags):
-            system_filter = []
         (init_status, oobjs) = vgrid_add_remove_table(
             client_id,
             vgrid_name,
             'trigger',
             'vgridtrigger',
             configuration,
-            extra_fields + optional_fields,
-            filter_items=system_filter
+            extra_fields + optional_fields
         )
         if not init_status:
             output_objects.append({'object_type': 'error_text', 'text':


### PR DESCRIPTION
As described in #396 the removal of the deprecated imagepreview functionality removed the necessity/reason for the system_filter argument.