### PR TITLE
Prevent concurrent edit user account interference 

### DIFF
--- a/mig/shared/defaults.py
+++ b/mig/shared/defaults.py
@@ -218,7 +218,7 @@ peers_expire_max_days = 3652
 # for caching account status using integer timestamps outside user DB.
 # IMPORTANT: generally do NOT rearrange order, and ONLY append new values
 #            unless also purging ALL status filemarks in the process.
-valid_account_status = ['active', 'temporal', 'suspended', 'retired']
+valid_account_status = ['active', 'temporal', 'suspended', 'retired', 'locked']
 
 auth_openid_mig_db = 'mod_auth_openid-mig-users.db'
 auth_openid_ext_db = 'mod_auth_openid-ext-users.db'

--- a/mig/shared/useradm.py
+++ b/mig/shared/useradm.py
@@ -566,6 +566,11 @@ def create_user_in_db(configuration, db_path, client_id, user, now, authorized,
             _logger.debug("proceed with %s account during edit user" %
                           account_status)
         else:
+            if do_lock:
+                unlock_user_db(flock)
+            if verbose:
+                print('Refusing to renew %s account for %r' % (account_status,
+                                                               client_id))
             raise Exception('refusing to renew %s account! (%s)' %
                             (account_status, accepted_peer_list))
         if reset_token and not new_expire:

--- a/mig/shared/useradm.py
+++ b/mig/shared/useradm.py
@@ -1316,7 +1316,7 @@ def edit_user(client_id, changes, removes, conf_path, db_path, force=False,
                     unlock_user_db(flock)
                 raise Exception("Edit aborted: new user already exists!")
             # Keep track of updates in status to prevent concurrent changes
-            if old_user.get('status', None) == 'locked':
+            if old_user.get('status', 'active') == 'locked':
                 if do_lock:
                     unlock_user_db(flock)
                 raise Exception("Edit aborted: concurrent user update active!")
@@ -1566,7 +1566,13 @@ def edit_user(client_id, changes, removes, conf_path, db_path, force=False,
     mark_user_modified(configuration, new_id)
     _logger.info("Force new user renew to fix access and restore %s status" %
                  saved_status)
-    user_dict['status'] = saved_status
+    if saved_status is None:
+        if verbose:
+            print('unexpectedly got no saved status after edit %r' % client_id)
+        _logger.error("something failed in edit user %r - delay unlocking" %
+                      client_id)
+    else:
+        user_dict['status'] = saved_status
     # NOTE: only backup user DB here if we didn't already do so in call above
     create_user(user_dict, conf_path, db_path, force, verbose,
                 ask_renew=False, default_renew=True, from_edit_user=True,

--- a/mig/shared/useradm.py
+++ b/mig/shared/useradm.py
@@ -51,7 +51,7 @@ from mig.shared.base import client_id_dir, client_dir_id, client_alias, \
     force_native_str_rec, native_str_escape, native_args
 from mig.shared.conf import get_configuration_object
 from mig.shared.configuration import Configuration
-from mig.shared.defaults import keyword_auto, keyword_updating, ssh_conf_dir, \
+from mig.shared.defaults import user_db_filename, keyword_auto, ssh_conf_dir, \
     davs_conf_dir, ftps_conf_dir, htaccess_filename, welcome_filename, \
     settings_filename, profile_filename, default_css_filename, \
     widgets_filename, seafile_ro_dirname, authkeys_filename, \
@@ -59,7 +59,7 @@ from mig.shared.defaults import keyword_auto, keyword_updating, ssh_conf_dir, \
     twofactor_filename, peers_filename, gdp_distinguished_field, \
     unique_id_length, unique_id_charset, X509_USER_ID_FORMAT, \
     UUID_USER_ID_FORMAT, valid_user_id_formats, user_id_alias_dir, \
-    expire_marks_dir, status_marks_dir, user_db_filename
+    expire_marks_dir, status_marks_dir
 from mig.shared.fileio import filter_pickled_list, filter_pickled_dict, \
     make_symlink, delete_symlink, read_file, write_file, remove_dir, \
     remove_rec, makedirs_rec, listdir, move
@@ -1316,12 +1316,12 @@ def edit_user(client_id, changes, removes, conf_path, db_path, force=False,
                     unlock_user_db(flock)
                 raise Exception("Edit aborted: new user already exists!")
             # Keep track of updates in status to prevent concurrent changes
-            if old_user.get('status', None) == keyword_updating:
+            if old_user.get('status', None) == 'locked':
                 if do_lock:
                     unlock_user_db(flock)
                 raise Exception("Edit aborted: concurrent user update active!")
-            saved_status = user_dict.get('status', None)
-            old_user['status'] = user_dict['status'] = keyword_updating
+            saved_status = user_dict.get('status', 'active')
+            old_user['status'] = user_dict['status'] = 'locked'
             _logger.info("Force old user update to also fix any missing files")
             create_user(old_user, conf_path, db_path, force, verbose,
                         ask_renew=False, default_renew=True, do_lock=False,
@@ -1566,10 +1566,7 @@ def edit_user(client_id, changes, removes, conf_path, db_path, force=False,
     mark_user_modified(configuration, new_id)
     _logger.info("Force new user renew to fix access and restore %s status" %
                  saved_status)
-    if saved_status is None:
-        del user_dict['status']
-    else:
-        user_dict['status'] = saved_status
+    user_dict['status'] = saved_status
     # NOTE: only backup user DB here if we didn't already do so in call above
     create_user(user_dict, conf_path, db_path, force, verbose,
                 ask_renew=False, default_renew=True, from_edit_user=True,

--- a/mig/shared/useradm.py
+++ b/mig/shared/useradm.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # useradm - user administration functions
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -51,7 +51,7 @@ from mig.shared.base import client_id_dir, client_dir_id, client_alias, \
     force_native_str_rec, native_str_escape, native_args
 from mig.shared.conf import get_configuration_object
 from mig.shared.configuration import Configuration
-from mig.shared.defaults import user_db_filename, keyword_auto, ssh_conf_dir, \
+from mig.shared.defaults import keyword_auto, keyword_updating, ssh_conf_dir, \
     davs_conf_dir, ftps_conf_dir, htaccess_filename, welcome_filename, \
     settings_filename, profile_filename, default_css_filename, \
     widgets_filename, seafile_ro_dirname, authkeys_filename, \
@@ -59,7 +59,7 @@ from mig.shared.defaults import user_db_filename, keyword_auto, ssh_conf_dir, \
     twofactor_filename, peers_filename, gdp_distinguished_field, \
     unique_id_length, unique_id_charset, X509_USER_ID_FORMAT, \
     UUID_USER_ID_FORMAT, valid_user_id_formats, user_id_alias_dir, \
-    expire_marks_dir, status_marks_dir
+    expire_marks_dir, status_marks_dir, user_db_filename
 from mig.shared.fileio import filter_pickled_list, filter_pickled_dict, \
     make_symlink, delete_symlink, read_file, write_file, remove_dir, \
     remove_rec, makedirs_rec, listdir, move
@@ -1297,6 +1297,7 @@ def edit_user(client_id, changes, removes, conf_path, db_path, force=False,
 
     user_dict = {}
     new_id = ''
+    saved_status = None
     try:
         old_user = user_db[client_id]
         user_dict.update(old_user)
@@ -1314,7 +1315,14 @@ def edit_user(client_id, changes, removes, conf_path, db_path, force=False,
                 if do_lock:
                     unlock_user_db(flock)
                 raise Exception("Edit aborted: new user already exists!")
-            _logger.info("Force old user renew to fix any missing files")
+            # Keep track of updates in status to prevent concurrent changes
+            if old_user.get('status', None) == keyword_updating:
+                if do_lock:
+                    unlock_user_db(flock)
+                raise Exception("Edit aborted: concurrent user update active!")
+            saved_status = user_dict.get('status', None)
+            old_user['status'] = user_dict['status'] = keyword_updating
+            _logger.info("Force old user update to also fix any missing files")
             create_user(old_user, conf_path, db_path, force, verbose,
                         ask_renew=False, default_renew=True, do_lock=False,
                         from_edit_user=True, create_backup=True)
@@ -1556,7 +1564,12 @@ def edit_user(client_id, changes, removes, conf_path, db_path, force=False,
 
     _logger.info("Renamed user %s to %s" % (client_id, new_id))
     mark_user_modified(configuration, new_id)
-    _logger.info("Force new user renew to fix access")
+    _logger.info("Force new user renew to fix access and restore %s status" %
+                 saved_status)
+    if saved_status is None:
+        del user_dict['status']
+    else:
+        user_dict['status'] = saved_status
     # NOTE: only backup user DB here if we didn't already do so in call above
     create_user(user_dict, conf_path, db_path, force, verbose,
                 ask_renew=False, default_renew=True, from_edit_user=True,

--- a/tests/test_mig_shared_useradm.py
+++ b/tests/test_mig_shared_useradm.py
@@ -3,7 +3,7 @@
 # --- BEGIN_HEADER ---
 #
 # test_mig_shared_useradm - unit test of the corresponding mig shared module
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -97,7 +97,8 @@ class TestMigSharedUsedadm_create_user(MigTestCase,
 
         _ensure_dirs_needed_for_userdb(self.configuration)
 
-        self.expected_user_db_home = os.path.normpath(configuration.user_db_home)
+        self.expected_user_db_home = os.path.normpath(
+            configuration.user_db_home)
         self.expected_user_db_file = os.path.join(
             self.expected_user_db_home, 'MiG-users.db')
 
@@ -159,8 +160,10 @@ class TestMigSharedUsedadm_create_user(MigTestCase,
 
         # TODO: remove resetting the handful of keys here
         #       this is done to allow the comparision to succeed
-        actual_user_object = _adjust_user_dict_for_compare(pickled[expected_user_id])
-        expected_user_object = _adjust_user_dict_for_compare(prepared.fixture_data[expected_user_id])
+        actual_user_object = _adjust_user_dict_for_compare(
+            pickled[expected_user_id])
+        expected_user_object = _adjust_user_dict_for_compare(
+            prepared.fixture_data[expected_user_id])
 
         self.maxDiff = None
         self.assertEqual(actual_user_object, expected_user_object)
@@ -188,6 +191,60 @@ class TestMigSharedUsedadm_create_user(MigTestCase,
         except:
             self.assertFalse(True, "should not be reached")
 
+    def test_user_creation_and_renew_records_a_user(self):
+        user_dict = {}
+        user_dict['full_name'] = "Test User"
+        user_dict['organization'] = "Test Org"
+        user_dict['state'] = "NA"
+        user_dict['country'] = "DK"
+        user_dict['email'] = "test@example.com"
+        user_dict['comment'] = "This is the create comment"
+        user_dict['locality'] = ""
+        user_dict['organizational_unit'] = ""
+        user_dict['password'] = ""
+        user_dict['password_hash'] = self.TEST_USER_PASSWORD_HASH
+        # explicitly setting set a DN suffixed user DN to force GDP
+        user_dict['distinguished_name'] = self.TEST_USER_DN_GDP
+        user_dict['status'] = "active"
+
+        try:
+            create_user(user_dict, self.configuration, keyword_auto,
+                        default_renew=True, ask_renew=False)
+        except:
+            self.assertFalse(True, "should not be reached")
+
+        try:
+            create_user(user_dict, self.configuration, keyword_auto,
+                        default_renew=True, ask_renew=False)
+        except:
+            self.assertFalse(True, "should not be reached")
+
+    def test_user_creation_fails_in_renew_when_locked(self):
+        user_dict = {}
+        user_dict['full_name'] = "Test User"
+        user_dict['organization'] = "Test Org"
+        user_dict['state'] = "NA"
+        user_dict['country'] = "DK"
+        user_dict['email'] = "test@example.com"
+        user_dict['comment'] = "This is the create comment"
+        user_dict['locality'] = ""
+        user_dict['organizational_unit'] = ""
+        user_dict['password'] = ""
+        user_dict['password_hash'] = self.TEST_USER_PASSWORD_HASH
+        # explicitly setting set a DN suffixed user DN to force GDP
+        user_dict['distinguished_name'] = self.TEST_USER_DN_GDP
+        user_dict['status'] = "locked"
+
+        try:
+            create_user(user_dict, self.configuration, keyword_auto,
+                        default_renew=True, ask_renew=False)
+        except:
+            self.assertFalse(True, "should not be reached")
+
+        with self.assertRaises(Exception):
+            create_user(user_dict, self.configuration, keyword_auto,
+                        default_renew=True, ask_renew=False)
+
 
 class MigSharedUseradm__assure_current_htaccess(MigTestCase):
     """Coverage of useradm behaviours around htaccess."""
@@ -211,8 +268,6 @@ class MigSharedUseradm__assure_current_htaccess(MigTestCase):
             with io.open(generated) as htaccess_file:
                 generated = htaccess_file.read()
 
-        #print("DEBUG: generated htaccess:\n%s" % generated)
-
         generated_lines = generated.split('\n')
         if not expected in generated_lines:
             raise AssertionError("no such require user line: %s" % expected)
@@ -229,7 +284,6 @@ class MigSharedUseradm__assure_current_htaccess(MigTestCase):
             # File should not exist here at all
             self.assertNotEqual(path_kind, "file")
         except OSError as ignore_oserr:
-            #print("DEBUG: oserror found as expected: %s" % ignore_oserr)
             pass
 
     def test_creates_missing_htaccess_file(self):


### PR DESCRIPTION
Temporarily mark user account as 'locked' in user database during the entire `edit_user` handling when the edit includes ID changes, to make sure that any concurrent attempts to renew or edit the same user are prevented (see #401). This marking covers not only the (already locked) user database update itself but also resulting filesystem updates in that case.
Similarly the function now first checks that the status is not 'locked' when trying to edit an existing user, unless it's a meta-only edit. In the latter case the plain user database locking already prevents concurrent edits so that should be safe.
Setting the status to 'locked' also prevents any new user login attempts so we don't risk letting actively edited users in until the edit is complete.

NOTE: fixes a missing database unlock in `useradm` on rejecting renewal due to blocking account status.