### PR TITLE
Follow-up to PR406 finding regarding missing unlocks upon failure in create user.

### DIFF
--- a/mig/shared/useradm.py
+++ b/mig/shared/useradm.py
@@ -719,6 +719,8 @@ change."""
                               mask_creds(user))
             elif renew:
                 # NOTE: bail out here on edit/renewal as IDs are not unique
+                if do_lock:
+                    unlock_user_db(flock)
                 raise ValueError("unique ID for %s (%r) has a collission!" %
                                  (client_id, user['unique_id']))
             else:
@@ -727,6 +729,8 @@ change."""
             user['unique_id'] = generate_random_ascii(unique_id_length,
                                                       unique_id_charset)
         if not found_unique:
+            if do_lock:
+                unlock_user_db(flock)
             if verbose:
                 print('Failed to generate a unique id for %s - bailing out!' %
                       client_id)

--- a/tests/test_mig_shared_useradm.py
+++ b/tests/test_mig_shared_useradm.py
@@ -203,9 +203,6 @@ class TestMigSharedUsedadm_create_user(MigTestCase,
         user_dict['organizational_unit'] = ""
         user_dict['password'] = ""
         user_dict['password_hash'] = self.TEST_USER_PASSWORD_HASH
-        # explicitly setting set a DN suffixed user DN to force GDP
-        user_dict['distinguished_name'] = self.TEST_USER_DN_GDP
-        user_dict['status'] = "active"
 
         try:
             create_user(user_dict, self.configuration, keyword_auto,
@@ -241,6 +238,26 @@ class TestMigSharedUsedadm_create_user(MigTestCase,
         except:
             self.assertFalse(True, "should not be reached")
 
+    def test_user_creation_with_id_collission_fails(self):
+        user_dict = {}
+        user_dict['full_name'] = "Test User"
+        user_dict['organization'] = "Test Org"
+        user_dict['state'] = "NA"
+        user_dict['country'] = "DK"
+        user_dict['email'] = "user@example.com"
+        user_dict['comment'] = "This is the create comment"
+        user_dict['password'] = "password"
+        user_dict['distinguished_name'] = self.TEST_USER_DN
+
+        try:
+            create_user(user_dict, self.configuration,
+                        keyword_auto, default_renew=True)
+        except:
+            self.assertFalse(True, "should not be reached")
+
+        # NOTE: reset distinguished_name name and introduce a conflict
+        del user_dict['distinguished_name']
+        user_dict['organization'] = "Another Org"
         with self.assertRaises(Exception):
             create_user(user_dict, self.configuration, keyword_auto,
                         default_renew=True, ask_renew=False)

--- a/tests/test_mig_shared_useradm.py
+++ b/tests/test_mig_shared_useradm.py
@@ -255,7 +255,7 @@ class TestMigSharedUsedadm_create_user(MigTestCase,
         except:
             self.assertFalse(True, "should not be reached")
 
-        # NOTE: reset distinguished_name name and introduce a conflict
+        # NOTE: reset distinguished_name and introduce an ID conflict to test
         del user_dict['distinguished_name']
         user_dict['organization'] = "Another Org"
         with self.assertRaises(Exception):


### PR DESCRIPTION
Follow-up to #406 finding regarding missing unlock for the failed account status check. Add two additional missing userdb unlock operations before similar exceptions in other create user corner cases.
Add a regression unit test to verify one of them fixed. The other one is very similar but involves long random string collisions, so it is cumbersome to test.