### PR TITLE
Disable graphviz integration in Trac to fix macros

### DIFF
--- a/mig/server/trac-py3.ini
+++ b/mig/server/trac-py3.ini
@@ -52,7 +52,8 @@ tracext.hg.* = enabled
 # Optional plugins
 # Looks unsupported for Trac-1.6
 #customfieldadmin.* = enabled
-graphviz.* = enabled
+# We don't want to install nearly 300MB X11, Wayland, etc deps for this
+#graphviz.* = enabled
 # Unsupported for Trac-1.6
 #mastertickets.* = enabled
 wikiprint.* = enabled


### PR DESCRIPTION
Disable `graphviz` integration in `Trac` as it currently a.o. breaks `Trac` macros on Rocky 9 deployments in docker-migrid. Apparently because some dependencies are missing, but we don't want to install those ~280MB of dependences.