### PR TITLE
Update URLs to point to wiki on website

### DIFF
--- a/state/wwwpublic/index-erda.dk-ucph-science.html
+++ b/state/wwwpublic/index-erda.dk-ucph-science.html
@@ -350,14 +350,14 @@
                         </p>
                         <!-- NOTE: ul elements are NOT allowed inside p ones in html spec -->
                         <ul>
-                            <li><a class="introguidelink" href="/public/ucph-erda-guide_user-sign-up.pdf">Sign Up Intro</a> for UCPH and external users</li> 
-                            <li><a class="introguidelink" href="/public/ucph-erda-guide_workgroup-sharing.pdf">Workgroup Intro</a> about creating, managing and accessing Workgroups</li> 
-                            <li><a class="introguidelink" href="/public/ucph-erda-guide_network-drive_win.pdf">Network Drive Intro</a> about using ERDA as a network drive on your computer (only covers Windows for now)</li>
-                            <li><a class="introguidelink" href="/public/ucph-erda-guide_seafile-signup-sync.pdf">Seafile Intro</a> about Seafile sign up and file synchronization</li> 
-                            <li><a class="introguidelink" href="/public/ucph-erda-guide_seafile-share-exchange.pdf">Seafile Collaboration Intro</a> about Seafile data sharing and exchange</li> 
-                            <li><a class="infolink" href="/public/ucph-erda-guide_overview.pdf">ERDA Overview</a>
+                            <li><a class="introguidelink" href="https://erda.ku.dk/user-docs/html/sections/erda/signup/index.html">Sign Up Intro</a> for UCPH and external users</li> 
+                            <li><a class="introguidelink" href="https://erda.ku.dk/user-docs/html/sections/erda/workgroup/index.html">Workgroup Intro</a> about creating, managing and accessing Workgroups</li> 
+                            <li><a class="introguidelink" href="https://erda.ku.dk/user-docs/html/sections/erda/networkdrive/index.html">Network Drive Intro</a> about using ERDA as a network drive on your computer (only covers Windows for now)</li>
+                            <li><a class="introguidelink" href="https://erda.ku.dk/user-docs/html/sections/erda/seafile/index.html">Seafile Intro</a> about Seafile sign up and file synchronization</li> 
+                            <li><a class="introguidelink" href="https://erda.ku.dk/user-docs/html/sections/erda/seafile/index.html#exchange-or-share-data-with-others">Seafile Collaboration Intro</a> about Seafile data sharing and exchange</li> 
+                            <li><a class="infolink" href="https://erda.ku.dk/user-docs/html/sections/erda/overview/index.html">ERDA Overview</a>
                                 if you're not sure whether to use ERDA's main storage or Seafile</li> 
-                            <li><a class="userguidelink" href="/public/ucph-erda-user-guide.pdf">User Guide</a> with general usage instructions</li>
+                            <li><a class="userguidelink" href="/public/ucph-erda-user-guide.pdf">Old User Guide</a> with general usage instructions. Our wiki holds newer information, but a few use cases are still only documented here</li>
                         </ul>
                         <p>
                             We strongly recommend reading and following at least the first intro guide if

--- a/state/wwwpublic/index-erda.dk-ucph-science.html
+++ b/state/wwwpublic/index-erda.dk-ucph-science.html
@@ -350,12 +350,12 @@
                         </p>
                         <!-- NOTE: ul elements are NOT allowed inside p ones in html spec -->
                         <ul>
-                            <li><a class="introguidelink" href="https://erda.ku.dk/user-docs/html/sections/erda/signup/index.html">Sign Up Intro</a> for UCPH and external users</li> 
-                            <li><a class="introguidelink" href="https://erda.ku.dk/user-docs/html/sections/erda/workgroup/index.html">Workgroup Intro</a> about creating, managing and accessing Workgroups</li> 
-                            <li><a class="introguidelink" href="https://erda.ku.dk/user-docs/html/sections/erda/networkdrive/index.html">Network Drive Intro</a> about using ERDA as a network drive on your computer (only covers Windows for now)</li>
-                            <li><a class="introguidelink" href="https://erda.ku.dk/user-docs/html/sections/erda/seafile/index.html">Seafile Intro</a> about Seafile sign up and file synchronization</li> 
-                            <li><a class="introguidelink" href="https://erda.ku.dk/user-docs/html/sections/erda/seafile/index.html#exchange-or-share-data-with-others">Seafile Collaboration Intro</a> about Seafile data sharing and exchange</li> 
-                            <li><a class="infolink" href="https://erda.ku.dk/user-docs/html/sections/erda/overview/index.html">ERDA Overview</a>
+                            <li><a class="introguidelink" href="/user-docs/html/sections/erda/signup/index.html">Sign Up Intro</a> for UCPH and external users</li> 
+                            <li><a class="introguidelink" href="/user-docs/html/sections/erda/workgroup/index.html">Workgroup Intro</a> about creating, managing and accessing Workgroups</li> 
+                            <li><a class="introguidelink" href="/user-docs/html/sections/erda/networkdrive/index.html">Network Drive Intro</a> about using ERDA as a network drive on your computer (only covers Windows for now)</li>
+                            <li><a class="introguidelink" href="/user-docs/html/sections/erda/seafile/index.html">Seafile Intro</a> about Seafile sign up and file synchronization</li> 
+                            <li><a class="introguidelink" href="/user-docs/html/sections/erda/seafile/index.html#exchange-or-share-data-with-others">Seafile Collaboration Intro</a> about Seafile data sharing and exchange</li> 
+                            <li><a class="infolink" href="/user-docs/html/sections/erda/overview/index.html">ERDA Overview</a>
                                 if you're not sure whether to use ERDA's main storage or Seafile</li> 
                             <li><a class="userguidelink" href="/public/ucph-erda-user-guide.pdf">Old User Guide</a> with general usage instructions. Our wiki holds newer information, but a few use cases are still only documented here</li>
                         </ul>


### PR DESCRIPTION
I updated the URLs on the frontpage to point to our wiki sections containing the same information instead of to the PDFs.

Would there be a purpose to retain a small link to these former pages with a link at the end just titled "PDF (old)" in case we somehow missed a use-case listed in these documentations?

I also did not remove the user guide section, but rather documented that newer documentation could be found on our wiki, while a few use-cases mentioned in the user guide might not have made it over to the wiki yet, as I believe there is one or two sections we have not ported yet on FTPS or the like. I need to double-check that.