### PR TITLE
Prevent remove_rec from trying to follow symlinks in permission walk

### DIFF
--- a/mig/shared/fileio.py
+++ b/mig/shared/fileio.py
@@ -577,14 +577,20 @@ def remove_rec(dir_path, configuration):
         if not os.path.isdir(dir_path):
             raise Exception("Directory %r does not exist" % dir_path)
 
-        os.chmod(dir_path, 0o777)
-
-        # extend permissions top-down
+        # Allow write before remove to avoid access errors
+        _logger.debug("extend permissions top-down prior to removing %s" %
+                      dir_path)
+        os.chmod(dir_path, 0o770)
         for root, dirs, files in walk(dir_path, topdown=True):
-            for name in files:
-                os.chmod(os.path.join(root, name), 0o777)
-            for name in dirs:
-                os.chmod(os.path.join(root, name), 0o777)
+            for name in files + dirs:
+                target = os.path.join(root, name)
+                # NOTE: skip symlinks here to avoid errors for broken ones
+                # NOTE: follow_symlinks arg of chmod isn't generally supported
+                if os.path.islink(target):
+                    _logger.debug("skip symlink %s in walk %s" % (target,
+                                                                  dir_path))
+                    continue
+                os.chmod(os.path.join(root, name), 0o770)
         shutil.rmtree(dir_path)
 
     except Exception as err:

--- a/tests/test_mig_shared_fileio.py
+++ b/tests/test_mig_shared_fileio.py
@@ -1083,6 +1083,36 @@ class MigSharedFileio__remove_rec(MigTestCase):
         self.assertTrue(result)
         self.assertFalse(os.path.exists(self.tmp_path))
 
+    def test_removes_directory_recursively_with_symlink(self):
+        """Test remove_rec removes directory and contents with symlink"""
+        link_src = os.path.join(self.tmp_path, DUMMY_FILE_ONE)
+        link_dst = os.path.join(self.tmp_path, DUMMY_FILE_ONE + '.lnk')
+        os.symlink(link_src, link_dst)
+        self.assertTrue(os.path.exists(self.tmp_path))
+        result = fileio.remove_rec(self.tmp_path, self.configuration)
+        self.assertTrue(result)
+        self.assertFalse(os.path.exists(self.tmp_path))
+
+    def test_removes_directory_recursively_with_broken_symlink(self):
+        """Test remove_rec removes directory and contents with broken symlink"""
+        link_src = os.path.join(self.tmp_path, DUMMY_FILE_MISSING)
+        link_dst = os.path.join(self.tmp_path, DUMMY_FILE_MISSING + '.lnk')
+        os.symlink(link_src, link_dst)
+        self.assertTrue(os.path.exists(self.tmp_path))
+        result = fileio.remove_rec(self.tmp_path, self.configuration)
+        self.assertTrue(result)
+        self.assertFalse(os.path.exists(self.tmp_path))
+
+    def test_removes_directory_recursively_despite_readonly(self):
+        """Test remove_rec removes directory and contents despite set readonly"""
+        os.chmod(self.tmp_path, 0o500)
+        file_path = os.path.join(self.tmp_path, DUMMY_FILE_ONE)
+        os.chmod(file_path, 0o400)
+        self.assertTrue(os.path.exists(self.tmp_path))
+        result = fileio.remove_rec(self.tmp_path, self.configuration)
+        self.assertTrue(result)
+        self.assertFalse(os.path.exists(self.tmp_path))
+
     def test_rejects_regular_file(self):
         """Test remove_rec returns False when path is a regular file"""
         file_path = os.path.join(self.tmp_path, DUMMY_FILE_ONE)


### PR DESCRIPTION
Prevent `remove_rec` from trying to follow symlinks when fixing permissions prior to removal as `chmod` will fail if the symlink is broken. We hit that on sites with vgridtracker during vgrid removal because some targets are removed before the link to them.

Extended unit tests to cover both situations with valid and broken symlinks as well as a case with a readonly target where the permission walk is needed.