### PR TITLE
Address a few issues in grid_events.py as pointed out by pylint

### DIFF
--- a/mig/server/grid_events.py
+++ b/mig/server/grid_events.py
@@ -518,10 +518,10 @@ class MiGRuleEventHandler(PatternMatchingEventHandler):
     ):
         """Constructor"""
 
-        PatternMatchingEventHandler.__init__(self, patterns,
-                                             ignore_patterns,
-                                             ignore_directories,
-                                             case_sensitive)
+        PatternMatchingEventHandler.__init__(
+            self, patterns=patterns, ignore_patterns=ignore_patterns,
+            ignore_directories=ignore_directories,
+            case_sensitive=case_sensitive)
 
     def __update_rule_monitor(
         self,
@@ -681,10 +681,10 @@ class MiGFileEventHandler(PatternMatchingEventHandler):
     ):
         """Constructor"""
 
-        PatternMatchingEventHandler.__init__(self, patterns,
-                                             ignore_patterns,
-                                             ignore_directories,
-                                             case_sensitive)
+        PatternMatchingEventHandler.__init__(
+            self, patterns=patterns, ignore_patterns=ignore_patterns,
+            ignore_directories=ignore_directories,
+            case_sensitive=case_sensitive)
         self.sub_vgrids = sub_vgrids
 
     def __workflow_log(

--- a/mig/server/grid_events.py
+++ b/mig/server/grid_events.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # grid_events - event handler to monitor files and trigger actions
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -285,8 +285,12 @@ def get_rule_hits(rule, limit_field):
     if limit_field == _rate_limit_field:
         (hit_count, hit_period) = extract_hit_limit(rule, limit_field)
     elif limit_field == _settle_time_field:
-        (hit_count, hit_period) = (1, extract_time_in_secs(rule,
-                                                           limit_field))
+        (hit_count, hit_period) = (1, extract_time_in_secs(rule, limit_field))
+    else:
+        logger.error('(%s) get_rule_hits invalid limit_field %s' %
+                     (pid, limit_field))
+        raise ValueError("got unexpected limit_field %r" % limit_field)
+
     _hits_lock.acquire()
     rule_history = rule_hits.get(rule['rule_id'], [])
     res = (rule_history, hit_count, hit_period)
@@ -614,7 +618,8 @@ class MiGRuleEventHandler(PatternMatchingEventHandler):
             # Remove all old rules for this vgrid and
             # leave rules for parent and sub-vgrids
 
-            for target_path in all_rules:
+            # NOTE: we need to iterate over a copy of keys for in-place edits
+            for target_path in list(all_rules):
                 all_rules[target_path] = [i for i in
                                           all_rules[target_path] if i['vgrid_name']
                                           != vgrid_name]
@@ -1220,7 +1225,10 @@ class MiGFileEventHandler(PatternMatchingEventHandler):
 
         logger.info('(%s) expire all old entries in miss cache' % pid)
         now = time.time()
-        for (event_id, time_stamp) in miss_cache.items():
+
+        # NOTE: we need to iterate over a copy of keys for in-place edits
+        for event_id in list(miss_cache):
+            time_stamp = miss_cache[event_id]
             if time_stamp + _miss_cache_ttl < now:
                 del miss_cache[event_id]
         logger.info('(%s) miss cache entries left after expire: %d' %
@@ -1532,6 +1540,7 @@ def add_vgrid_file_monitors(configuration, vgrid_name):
 
     vgrid_dir_cache = dir_cache[vgrid_name]
 
+    # NOTE: we need to iterate over a copy of keys for in-place edits
     vgrid_dir_cache_keys = list(vgrid_dir_cache)
     for path in vgrid_dir_cache_keys:
         # Make sure we only have utf8 everywhere to avoid encoding issues
@@ -1630,6 +1639,7 @@ def load_dir_cache(configuration, vgrid_name):
             generate_cache = False
             # TODO: once all caches are migrated we can remove this loop again
             # Make sure we only have utf8 everywhere to avoid encoding issues
+            # NOTE: we need to iterate over a copy of keys for in-place edits
             for old_path in [i for i in loaded_dir_cache if i != force_utf8(i)]:
                 print("NOTE: forcing old cache entry %s to utf8" % [old_path])
                 new_path = force_utf8(old_path)


### PR DESCRIPTION
Address a couple of issues in grid_events.py as pointed out by pylint in GH Actions:
```
************* Module mig.server.grid_events
mig/server/grid_events.py:275:25: E0606: Possibly using variable 'hit_count' before assignment (possibly-used-before-assignment)
mig/server/grid_events.py:275:36: E0606: Possibly using variable 'hit_period' before assignment (possibly-used-before-assignment)
```
also covered in #338, and similarly pylint on Rocky9 deployments:
```
************* Module mig.server.grid_events
mig/server/grid_events.py:618:16: E4702: Iterated dict 'all_rules' is being modified inside for loop body, iterate through a copy of it instead. (modified-iterating-dict)
mig/server/grid_events.py:624:20: E4702: Iterated dict 'all_rules' is being modified inside for loop body, iterate through a copy of it instead. (modified-iterating-dict)
```
Added a similar fix for the in-place `miss_cache` clean up as well.

The last one about the `PatternMatchingEventHandler` only applies with watchdog 5.x and later:
```
************* Module mig.server.grid_events
mig/server/grid_events.py:521:8: E1121: Too many positional arguments for unbound method call (too-many-function-args)
mig/server/grid_events.py:684:8: E1121: Too many positional arguments for unbound method call (too-many-function-args)
```
due to an API change in the constructor, and it is fixed with a minor update to our constructor calls.