### PR TITLE
Filter a few harmless request types to chkXroot in migerrors monitor

### DIFF
--- a/mig/install/migerrors-template.sh.cronjob
+++ b/mig/install/migerrors-template.sh.cronjob
@@ -45,7 +45,7 @@ ENABLE_DAVS="__ENABLE_DAVS__"
 
 grep -H " ERROR " $LOGDIR/chkchroot.log | grep -E -v " from ${SECSCANIP} "| \
         grep -E -v "__CRACK_WEB_REGEX__" | \
-        grep -E -v "/index\.html$|/state/webserver_home/share_redirect$" | \
+        grep -E -v "/index\.html.$|/state/webserver_home/share_redirect.$" | \
         tail -n $MAXLINES
 
 # NOTE: we ignore script crashed errors here and treat specifically next

--- a/tests/fixture/confs-stdlocal/migerrors
+++ b/tests/fixture/confs-stdlocal/migerrors
@@ -45,7 +45,7 @@ ENABLE_DAVS="False"
 
 grep -H " ERROR " $LOGDIR/chkchroot.log | grep -E -v " from ${SECSCANIP} "| \
         grep -E -v "((HNAP1|GponForm|provisioning|provision|prov|polycom|yealink|CertProv|phpmyadmin|admin|cfg|wp|wordpress|cms|blog|old|new|test|dev|tmp|temp|remote|mgmt|properties|authenticate|tmui|ddem|a2billing|vtigercrm|secure|rpc|recordings|dana-na)(/.*|)|.*(Login|login|logon|configuration|header|admin|index)\.(php|jsp|asp)|(api/v1/pods|Telerik.Web.UI.WebResource.axd))" | \
-        grep -E -v "/index\.html$|/state/webserver_home/share_redirect$" | \
+        grep -E -v "/index\.html.$|/state/webserver_home/share_redirect.$" | \
         tail -n $MAXLINES
 
 # NOTE: we ignore script crashed errors here and treat specifically next


### PR DESCRIPTION
Ignore flagging two common harmless requests types in chkXroot helper again after rev `53628d8829` changed `chkXroot.py` log format from `%s` to `%r`. It broke the existing regex match e.g. in `index.html$`, as that pattern does not take the final `'` before end of line marker `$` added but `%r` into account.

In effect this change will restore the previous behaviour to again ignore harmless log lines like the following from hitting the log error monitoring:
```
/path/to/state/log/chkchroot.log:2026-01-28 09:06:45,928 ERROR got path from a.b.c.d outside user home: '/path/to/state/user_home/index.html'
```
