### PR TITLE
Ensure that every host node in the reqjupyterservice.py can be selected

### DIFF
--- a/mig/shared/functionality/reqjupyterservice.py
+++ b/mig/shared/functionality/reqjupyterservice.py
@@ -247,7 +247,7 @@ def get_host_from_service(configuration, service, base_url=None):
         if len(hosts) == 1:
             rng = 0
         else:
-            rng = random.randrange(0, len(hosts) - 1)
+            rng = random.randrange(0, len(hosts))
         try:
             with requests.session() as session:
                 _logger.info("requsting url: %s%s" % (hosts[rng], base_url))


### PR DESCRIPTION
This fixes the issue described in #437 where the last host/index can't be selected by a user because the random.randrange is non-inclusive of the stop parameter when defining a range from which a random number should be selected.
