### PR TITLE
Fix the janitor accountreq function calls to actually act on the return values status

### DIFF
--- a/mig/lib/janitor.py
+++ b/mig/lib/janitor.py
@@ -273,16 +273,18 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
         _logger.info("%r made an invalid account request" % client_id)
         # NOTE: 'invalid' is a list of validation error strings if set
         reason = "invalid request: %s." % ". ".join(req_invalid)
-        if not reject_account_req(
+        (rej_status, rej_err) = reject_account_req(
             req_id,
             configuration,
             reason,
             user_copy=user_copy,
             admin_copy=admin_copy,
             auth_type=auth_type,
-        ):
+        )
+        if not rej_status:
             _logger.warning(
-                "failed to reject invalid %r account request" % client_id
+                "failed to reject invalid %r account request: %s" % (client_id,
+                                                                     rej_err)
             )
         else:
             _logger.info("rejected invalid %r account request" % client_id)
@@ -297,7 +299,7 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
                 "%r requested and authorized password reset" % client_id
             )
             peer_id = user_dict.get("peers", [None])[0]
-            if not accept_account_req(
+            (acc_status, acc_err) = accept_account_req(
                 req_id,
                 configuration,
                 peer_id,
@@ -305,27 +307,32 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
                 admin_copy=admin_copy,
                 auth_type=auth_type,
                 default_renew=default_renew,
-            ):
+            )
+            if not acc_status:
                 _logger.warning(
-                    "failed to accept %r password reset" % client_id
+                    "failed to accept %r password reset: %s" % (client_id,
+                                                                acc_err)
                 )
             else:
                 _logger.info("accepted %r password reset" % client_id)
         else:
             _logger.warning(
-                "%r requested password reset with bad token" % client_id
+                "%r requested password reset with bad token: %s" % (
+                    client_id, reset_token)
             )
             reason = "invalid password reset token"
-            if not reject_account_req(
+            (rej_status, rej_err) = reject_account_req(
                 req_id,
                 configuration,
                 reason,
                 user_copy=user_copy,
                 admin_copy=admin_copy,
                 auth_type=auth_type,
-            ):
+            )
+            if not rej_status:
                 _logger.warning(
-                    "failed to reject %r password reset" % client_id
+                    "failed to reject %r password reset: %s" % (client_id,
+                                                                rej_err)
                 )
             else:
                 _logger.info("rejected %r password reset" % client_id)
@@ -333,30 +340,35 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
         #  NOTE: probably should no longer happen after initial auto clean
         _logger.warning("%r request is now past expire" % client_id)
         reason = "expired request - please re-request if still relevant"
-        if not reject_account_req(
+        (rej_status, rej_err) = reject_account_req(
             req_id,
             configuration,
             reason,
             user_copy=user_copy,
             admin_copy=admin_copy,
             auth_type=auth_type,
-        ):
-            _logger.warning("failed to reject expired %r request" % client_id)
+        )
+        if not rej_status:
+            _logger.warning("failed to reject expired %r request: %s" %
+                            (client_id, rej_err)
+                            )
         else:
             _logger.info("rejected %r request now past expire" % client_id)
     elif existing_user_collision(configuration, req_dict, client_id):
         _logger.warning("ID collision in request from %r" % client_id)
         reason = "ID collision - please re-request with *existing* ID fields"
-        if not reject_account_req(
+        (rej_status, rej_err) = reject_account_req(
             req_id,
             configuration,
             reason,
             user_copy=user_copy,
             admin_copy=admin_copy,
             auth_type=auth_type,
-        ):
+        )
+        if not rej_status:
             _logger.warning(
-                "failed to reject %r request with ID collision" % client_id
+                "failed to reject %r request with ID collision: %s" %
+                (client_id, rej_err)
             )
         else:
             _logger.info("rejected %r request with ID collision" % client_id)
@@ -448,16 +460,17 @@ def remind_and_expire_user_pending(configuration, now=None):
             )
             user_copy = True
             admin_copy = True
-            if not reject_account_req(
+            (rej_status, rej_err) = reject_account_req(
                 req_id,
                 configuration,
                 reason,
                 user_copy=user_copy,
                 admin_copy=admin_copy,
                 auth_type=auth_type,
-            ):
-                _logger.warning("failed to expire %s request from %r" %
-                                (req_id, client_id))
+            )
+            if not rej_status:
+                _logger.warning("failed to expire %s request from %r: %s" %
+                                (req_id, client_id, rej_err))
             else:
                 _logger.info("expired %s request from %r" % (req_id,
                                                              client_id))

--- a/mig/shared/pwcrypto.py
+++ b/mig/shared/pwcrypto.py
@@ -720,15 +720,15 @@ def verify_reset_token(configuration, user_dict, token, auth_type,
     try:
         assure_reset_supported(configuration, user_dict, auth_type)
     except ValueError as vae:
-        _logger.warning("verify %s reset token %s failed: %s" % (auth_type,
-                                                                 token, vae))
+        _logger.warning("unsupported verify %s reset token %s: %s" %
+                        (auth_type, token, vae))
         return False
 
     token_stamp, token_hash = parse_reset_token(configuration, token,
                                                 auth_type)
     if token_stamp > timestamp or timestamp - token_stamp > RESET_TOKEN_TTL:
-        _logger.debug("reject reset token %r with timestamp %d (%d)" %
-                      (token, token_stamp, timestamp))
+        _logger.warning("reject expired reset token %r with timestamp %d (%d)"
+                        % (token, token_stamp, timestamp))
         return False
 
     pw_hash = None
@@ -740,9 +740,9 @@ def verify_reset_token(configuration, user_dict, token, auth_type,
 
     if token_hash != pw_hash:
         # IMPORTANT: do NOT log actual hash but just a snippet hint
-        _logger.debug("reject reset token %r with wrong hash: %s vs %s" %
-                      (token, string_snippet(token_hash),
-                       string_snippet(pw_hash)))
+        _logger.warning("reject reset token %r with wrong hash: %s vs %s" %
+                        (token, string_snippet(token_hash),
+                         string_snippet(pw_hash)))
         return False
 
         # IMPORTANT: do NOT log actual hash but just a snippet hint

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -3,7 +3,7 @@
 # --- BEGIN_HEADER ---
 #
 # test_mig_lib_janitor - unit test of the corresponding mig lib module
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -44,6 +44,7 @@ from mig.lib.janitor import EXPIRE_DUMMY_JOBS_DAYS, EXPIRE_REQ_DAYS, \
     remind_and_expire_user_pending, task_triggers
 from mig.shared.accountreq import save_account_request
 from mig.shared.base import distinguished_name_to_user
+from mig.shared.pwcrypto import generate_reset_token
 from tests.support import MigTestCase, ensure_dirs_exist
 
 DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com'
@@ -52,13 +53,22 @@ DUMMY_ORGANIZATION = "Test Org"
 DUMMY_EMAIL = "test@example.com"
 DUMMY_SKIP_EMAIL = ''
 DUMMY_CLIENT_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.com'
-DUMMY_AUTH = 'migcert'
+# TODO: adjust password reset token helpers to handle configured services
+#       it currently silently fails if not in migoid(c) or migcert
+# DUMMY_SERVICE = 'dummy-svc'
+DUMMY_AUTH = DUMMY_SERVICE = 'migoid'
 DUMMY_USERDB = 'MiG-users.db'
 DUMMY_PEER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=peer@example.com'
 # NOTE: these passwords are not and should not ever be used outside unit tests
 DUMMY_MODERN_PW = 'QZFnCp7hmI1G'
 DUMMY_MODERN_PW_PBKDF2 = \
     "PBKDF2$sha256$10000$MDAwMDAwMDAwMDAw$B22uw6C7C4VFiYAe4Vf10n58FHrn1pjX"
+DUMMY_NEW_MODERN_PW_PBKDF2 = \
+    "PBKDF2$sha256$10000$MDAwMDAwMDAwMDAw$B22uw6C7C4VFiYAe4Vf10n581pjXFHrn"
+DUMMY_INVALID_PW_PBKDF2 = \
+    "PBKDF2$sha256$10000$MDAwMDAwMDAwMDAw$B22uw6C7C4VFiYAe4Vf1rn1pjX0n58FH"
+# NOTE: tokens always should contain a multiple of 4 chars
+INVALID_DUMMY_TOKEN = 'THIS_RESET_TOKEN_WAS_NEVER_VALID'
 
 
 class MigLibJanitor(MigTestCase):
@@ -88,6 +98,9 @@ class MigLibJanitor(MigTestCase):
     def before_each(self):
         """Set up test configuration and reset state before each test"""
         self.configuration.site_enable_jobs = True
+        # Certain pw reset tests require auth method to match signup
+        self.configuration.site_signup_methods.append(DUMMY_AUTH)
+        self.configuration.site_login_methods.append(DUMMY_AUTH)
         # Prevent admin email during reject, etc.
         self.configuration.admin_email = DUMMY_SKIP_EMAIL
         self.user_db_path = os.path.join(self.configuration.user_db_home,
@@ -489,15 +502,23 @@ class MigLibJanitor(MigTestCase):
             'organization': DUMMY_ORGANIZATION,
             # NOTE: disable email to prevent send failing on reject
             'email': DUMMY_SKIP_EMAIL,
-            'reset_token': 'INVALID_TOKEN',
-            'expire': time.time() - SECS_PER_DAY,
+            'password_hash': DUMMY_MODERN_PW_PBKDF2,
+            'expire': time.time() + SECS_PER_DAY,
         }
+        user_dict = {}
+        user_dict.update(req_dict)
+        # We need to save user in DB with password_hash for reset_token check
+        self._write_user_db({DUMMY_USER_DN: user_dict})
+        # Mimic proper but old expired token
+        timestamp = 42
+        # IMPORTANT: we can't use a fixed token here due to dynamic crypto seed
+        req_dict['reset_token'] = generate_reset_token(self.configuration,
+                                                       req_dict, DUMMY_SERVICE,
+                                                       timestamp)
+        # Change password_hash here to mimic pw change
+        req_dict['password_hash'] = DUMMY_NEW_MODERN_PW_PBKDF2
         saved, req_path = save_account_request(self.configuration, req_dict)
         req_id = os.path.basename(req_path)
-
-        user_dict = {'distinguished_name': DUMMY_USER_DN,
-                     'password_hash': DUMMY_MODERN_PW_PBKDF2}
-        self._write_user_db({DUMMY_USER_DN: user_dict})
 
         with self.assertLogs(level='WARNING') as log_capture:
             manage_single_req(
@@ -508,7 +529,47 @@ class MigLibJanitor(MigTestCase):
                 time.time()
             )
 
-        self.assertTrue(any('bad token' in msg for msg in log_capture.output))
+        self.assertTrue(
+            any('reject expired reset token' in msg for msg in log_capture.output))
+        self.assertFalse(os.path.exists(req_path),
+                         "Failed to clean token req for %s" % req_path)
+
+    @unittest.skip("TODO: enable once fernet decrypt err handling is improved")
+    def test_manage_single_req_invalid_token(self):
+        """Test request handling with invalid reset token"""
+        req_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'organization': DUMMY_ORGANIZATION,
+            # NOTE: disable email to prevent send failing on reject
+            'email': DUMMY_SKIP_EMAIL,
+            'password_hash': DUMMY_MODERN_PW_PBKDF2,
+            'expire': time.time() - SECS_PER_DAY,
+        }
+        user_dict = {}
+        user_dict.update(req_dict)
+        # We need to save user in DB with password_hash for reset_token check
+        self._write_user_db({DUMMY_USER_DN: user_dict})
+        # Inject known invalid reset token
+        req_dict['reset_token'] = INVALID_DUMMY_TOKEN
+        # Change password_hash here to mimic pw change
+        req_dict['password_hash'] = DUMMY_NEW_MODERN_PW_PBKDF2
+        saved, req_path = save_account_request(self.configuration, req_dict)
+        req_id = os.path.basename(req_path)
+
+        with self.assertLogs(level='WARNING') as log_capture:
+            manage_single_req(
+                self.configuration,
+                req_id,
+                req_path,
+                self.user_db_path,
+                time.time()
+            )
+
+        self.assertTrue(
+            any('reset with bad token' in msg for msg in log_capture.output))
         self.assertFalse(os.path.exists(req_path),
                          "Failed to clean token req for %s" % req_path)
 
@@ -549,6 +610,44 @@ class MigLibJanitor(MigTestCase):
                             for msg in log_capture.output))
         self.assertFalse(os.path.exists(req_path),
                          "Failed cleanup collision for %s" % req_path)
+
+    @unittest.skip("TODO: enable once janitor handles auth change reqs")
+    def test_manage_single_req_auth_change(self):
+        """Test request handling with auth password change"""
+        req_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'organization': DUMMY_ORGANIZATION,
+            # NOTE: disable email to prevent send failing on reject
+            'email': DUMMY_SKIP_EMAIL,
+            'password_hash': DUMMY_MODERN_PW_PBKDF2,
+            'expire': time.time() + SECS_PER_DAY,
+        }
+        user_dict = {}
+        user_dict.update(req_dict)
+        # We need to save user in DB with password_hash for reset_token check
+        self._write_user_db({DUMMY_USER_DN: user_dict})
+        # Change password_hash here to mimic pw change
+        req_dict['password_hash'] = DUMMY_NEW_MODERN_PW_PBKDF2
+        req_dict['authorized'] = True
+        saved, req_path = save_account_request(self.configuration, req_dict)
+        req_id = os.path.basename(req_path)
+
+        with self.assertLogs(level='INFO') as log_capture:
+            manage_single_req(
+                self.configuration,
+                req_id,
+                req_path,
+                self.user_db_path,
+                time.time()
+            )
+
+        self.assertTrue(
+            any('accepted' in msg for msg in log_capture.output))
+        self.assertFalse(os.path.exists(req_path),
+                         "Failed to clean token req for %s" % req_path)
 
     def test_handle_cache_updates_stub(self):
         """Test handle_cache_updates placeholder returns zero"""
@@ -606,7 +705,7 @@ class MigLibJanitor(MigTestCase):
         )
         self.assertEqual(handled, 1)
 
-    @ unittest.skip("TODO: enable once unpickling error handling is improved")
+    @unittest.skip("TODO: enable once unpickling error handling is improved")
     def test_manage_single_req_corrupted_file(self):
         """Test manage_single_req with corrupted request file"""
         req_id = 'corrupted_req'
@@ -668,9 +767,21 @@ class MigLibJanitor(MigTestCase):
             'organization': DUMMY_ORGANIZATION,
             # NOTE: disable email to prevent send failing on reject
             'email': DUMMY_SKIP_EMAIL,
-            'reset_token': 'INVALID_TOKEN_HERE',
+            'password_hash': DUMMY_MODERN_PW_PBKDF2,
             'expire': time.time() + SECS_PER_DAY,  # Future expiration
         }
+        user_dict = {}
+        user_dict.update(req_dict)
+        # We need to save user in DB with password_hash for reset_token check
+        self._write_user_db({DUMMY_USER_DN: user_dict})
+        timestamp = time.time()
+
+        # Now change to another pw hash and generate invalid token from it
+        req_dict['password_hash'] = DUMMY_INVALID_PW_PBKDF2
+        req_dict['reset_token'] = generate_reset_token(self.configuration,
+                                                       req_dict, DUMMY_SERVICE,
+                                                       timestamp)
+
         saved, req_path = save_account_request(self.configuration, req_dict)
         req_id = os.path.basename(req_path)
 
@@ -683,8 +794,48 @@ class MigLibJanitor(MigTestCase):
                 time.time()
             )
 
-        self.assertTrue(any('bad token' in msg.lower()
-                            or 'password reset' in msg.lower()
+        self.assertTrue(any('wrong hash' in msg.lower()
+                            for msg in log_capture.output))
+        self.assertFalse(os.path.exists(req_path),
+                         "Failed cleanup invalid token for %s" % req_path)
+
+    def test_verify_reset_token_success(self):
+        """Test token verification success with valid token"""
+        req_dict = {
+            'client_id': DUMMY_USER_DN,
+            'distinguished_name': DUMMY_USER_DN,
+            'auth': [DUMMY_AUTH],
+            'full_name': DUMMY_FULL_NAME,
+            'organization': DUMMY_ORGANIZATION,
+            # NOTE: disable email to prevent send failing on reject
+            'email': DUMMY_SKIP_EMAIL,
+            'password': '',
+            'password_hash': DUMMY_MODERN_PW_PBKDF2,
+            'expire': time.time() + SECS_PER_DAY,  # Future expiration
+        }
+        user_dict = {}
+        user_dict.update(req_dict)
+        # We need to save user in DB with password_hash for reset_token check
+        self._write_user_db({DUMMY_USER_DN: user_dict})
+        timestamp = time.time()
+        reset_token = generate_reset_token(self.configuration, req_dict,
+                                           DUMMY_SERVICE, timestamp)
+        req_dict['reset_token'] = reset_token
+        # Change password_hash here to mimic pw change
+        req_dict['password_hash'] = DUMMY_NEW_MODERN_PW_PBKDF2
+        saved, req_path = save_account_request(self.configuration, req_dict)
+        req_id = os.path.basename(req_path)
+
+        with self.assertLogs(level='INFO') as log_capture:
+            manage_single_req(
+                self.configuration,
+                req_id,
+                req_path,
+                self.user_db_path,
+                time.time()
+            )
+
+        self.assertTrue(any('accepted' in msg.lower()
                             for msg in log_capture.output))
 
     def test_remind_and_expire_edge_cases(self):
@@ -759,7 +910,7 @@ class MigLibJanitor(MigTestCase):
         self.assertEqual(_lookup_last_run(
             self.configuration, "cache-updates"), last_cache_update)
 
-    @ unittest.skip("TODO: enable once cleaner has improved error handling")
+    @unittest.skip("TODO: enable once cleaner has improved error handling")
     def test_clean_stale_files_nonexistent_dir(self):
         """Test state cleaner with invalid directory path"""
         target_dir = os.path.join(self.configuration.mig_system_files,
@@ -773,7 +924,7 @@ class MigLibJanitor(MigTestCase):
         )
         self.assertEqual(handled, 0)
 
-    @ unittest.skip("TODO: enable once cleaner has improved error handling")
+    @unittest.skip("TODO: enable once cleaner has improved error handling")
     def test_clean_stale_files_permission_error(self):
         """Test state cleaner handles permission errors gracefully"""
         test_dir = self.temppath("readonly_dir", ensure_dir=True)

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -622,6 +622,7 @@ class MigLibJanitor(MigTestCase):
             'organization': DUMMY_ORGANIZATION,
             # NOTE: disable email to prevent send failing on reject
             'email': DUMMY_SKIP_EMAIL,
+            'password': '',
             'password_hash': DUMMY_MODERN_PW_PBKDF2,
             'expire': time.time() + SECS_PER_DAY,
         }


### PR DESCRIPTION
Fix the janitor `accountreq` function calls to _actually_ act on the return value `status` part rather than the full `(status, errmsg)`-tuple as the latter will always be trivially True for our tuples. Include any error messages in logs upon failure.

Extend `pwcrypto` function logs to explain errors in log warnings rather than only in debug logs. Use those details better in unit tests and make sure not to treat various other unrelated errors as sufficient proof that known invalid tests correctly fail. 
Some of the password and token handling functions are random seed dependent and therefore unfortunately **cannot** rely solely on fixed test strings so we use the generate helpers for that. Additionally the reset token tests require an existing user with matching password hash in the user database. Adjusted mainly the reset token tests to take those two details properly into account.

Prepare a test case for the authenticated password change from PR #364 but leave it disabled here.