### PR TITLE
Add missing `enable_antislowloris` bool option to `generateconfs.py`

### DIFF
--- a/mig/install/generateconfs.py
+++ b/mig/install/generateconfs.py
@@ -283,6 +283,7 @@ def main(argv, _generate_confs=generate_confs, _print=print):
         'enable_cloud',
         'enable_gdp',
         'enable_hsts',
+        'enable_antislowloris',
         'enable_vhost_certs',
         'enable_verify_certs',
         'enable_seafile',


### PR DESCRIPTION
Add missing `enable_antislowloris` bool option to `generateconfs.py` as needed by recently merged PR #388.

I must have forgotten to commit it in the original PR :-/