### PR TITLE
Remove the old console logging of mouse up/start

### DIFF
--- a/mig/assets/js/V3/ui-extra.js
+++ b/mig/assets/js/V3/ui-extra.js
@@ -53,7 +53,6 @@ function hamburgerMenuToggle() {
 
 $(document).mouseup(function (e)
 {
-    console.log("mouse up start");
   var container = $("#hamMenu"); // YOUR CONTAINER SELECTOR
   var container2 = $("#sideBar");
   var x = document.getElementById("hamMenu");
@@ -73,7 +72,6 @@ $(document).mouseup(function (e)
       z.innerHTML = "Menu"
     }
   }
-    console.log("mouse up done");
 }
 );
 


### PR DESCRIPTION
Remove old console logs that don't appear to have any function currently other than filling the browser console log with mouse clicks.