### PR TITLE
Edit Support buttons to link to sphinxs user-docs URLs

### DIFF
--- a/state/wwwpublic/support-erda.dk.html
+++ b/state/wwwpublic/support-erda.dk.html
@@ -140,7 +140,6 @@
                             <h3>Workgroups</h3>
                             <p>Introduction to collaboration and data sharing on ERDA.</p>
                         </div>
-                        <!-- TODO: detect and switch netdrive button based on client platform -->
                         <div id="network-drive-intro-en-button" class="quick-support col-lg-6"
                              onClick="window.open('/user-docs/html/sections/erda/networkdrive/index.html');">
                             <h1 class="fa-button fas fa-cloud"></h1>

--- a/state/wwwpublic/support-erda.dk.html
+++ b/state/wwwpublic/support-erda.dk.html
@@ -144,7 +144,7 @@
                              onClick="window.open('/user-docs/html/sections/erda/networkdrive/index.html');">
                             <h1 class="fa-button fas fa-cloud"></h1>
                             <h3>Network Drive</h3>
-                            <p>Access your ERDA data as a network drive.</p>
+                            <p>Access your ERDA data as a network drive on your PC, Mac, or Linux/UNIX workstation.</p>
                         </div>
                         <div id="seafile-signup-sync-intro-en-button" class="quick-support col-lg-6"
                              onClick="window.open('/user-docs/html/sections/erda/seafile/index.html');">
@@ -159,10 +159,10 @@
                             <p>Overview: ERDA main storage vs. ERDA Seafile</p>
                         </div>
                         <div id="user-guide-en-button" class="quick-support col-lg-6"
-                             onClick="window.open('/public/ucph-erda-user-guide.pdf');">
+                             onClick="window.open('/user-docs/html/');">
                             <h1 class="fa-button fas fa-book"></h1>
                             <h3>User Guide</h3>
-                            <p>Read on in the user guide for full ERDA documentation (Our wiki holds newer information, but a few use cases are still only documented here).</p>
+                            <p>Read on in the complete ERDA documentation for further details.</p>
                         </div>
                     </div>
 

--- a/state/wwwpublic/support-erda.dk.html
+++ b/state/wwwpublic/support-erda.dk.html
@@ -129,44 +129,32 @@
                         <div class="vertical-spacer"></div>
                         <!-- NOTE: snippet recipient should override button onClick -->
                         <div id="sign-up-intro-en-button" class="quick-support col-lg-6"
-                             onClick="window.open('/public/ucph-erda-guide_user-sign-up.pdf');">
+                             onClick="window.open('/user-docs/html/sections/erda/signup/index.html');">
                             <h1 class="fa-button fas fa-laptop"></h1>
                             <h3>Getting started</h3>
                             <p>New to ERDA? Get started with your account.</p>
                         </div>
                         <div id="workgroups-intro-en-button" class="quick-support col-lg-6"
-                             onClick="window.open('/public/ucph-erda-guide_workgroup-sharing.pdf');">
+                             onClick="window.open('/user-docs/html/sections/erda/workgroup/index.html');">
                             <h1 class="fa-button fas fa-network-wired"></h1>
                             <h3>Workgroups</h3>
                             <p>Introduction to collaboration and data sharing on ERDA.</p>
                         </div>
                         <!-- TODO: detect and switch netdrive button based on client platform -->
-                        <div id="network-drive-win-intro-en-button" class="quick-support col-lg-6"
-                             onClick="window.open('/public/ucph-erda-guide_network-drive_win.pdf');">
+                        <div id="network-drive-intro-en-button" class="quick-support col-lg-6"
+                             onClick="window.open('/user-docs/html/sections/erda/networkdrive/index.html');">
                             <h1 class="fa-button fas fa-cloud"></h1>
                             <h3>Network Drive</h3>
-                            <p>Access your ERDA data as a network drive on your PC.</p>
-                        </div>
-                        <div id="network-drive-osx-intro-en-button" class="quick-support col-lg-6 hidden"
-                             onClick="window.open('/public/ucph-erda-guide_network-drive_osx.pdf');">
-                            <h1 class="fa-button fas fa-cloud"></h1>
-                            <h3>Network Drive</h3>
-                            <p>Access your ERDA data as a network drive on your Mac.</p>
-                        </div>
-                        <div id="network-drive-lnx-intro-en-button" class="quick-support col-lg-6 hidden"
-                             onClick="window.open('/public/ucph-erda-guide_network-drive_lnx.pdf');">
-                            <h1 class="fa-button fas fa-cloud"></h1>
-                            <h3>Network Drive</h3>
-                            <p>Access your ERDA data as a network drive on Linux/UNIX.</p>
+                            <p>Access your ERDA data as a network drive.</p>
                         </div>
                         <div id="seafile-signup-sync-intro-en-button" class="quick-support col-lg-6"
-                             onClick="window.open('/public/ucph-erda-guide_seafile-signup-sync.pdf');">
+                             onClick="window.open('/user-docs/html/sections/erda/seafile/index.html');">
                             <h1 class="fa-button fas fa-seafile"></h1>
                             <h3>Seafile</h3>
                             <p>Seafile sign up and file synchronization.</p>
                         </div>
                         <div id="erda-overview-en-button" class="quick-support col-lg-6"
-                             onClick="window.open('/public/ucph-erda-guide_overview.pdf');">
+                             onClick="window.open('/user-docs/html/sections/erda/overview/index.html');">
                             <h1 class="fa-button fas fa-newspaper"></h1>
                             <h3>ERDA Overview</h3>
                             <p>Overview: ERDA main storage vs. ERDA Seafile</p>
@@ -175,7 +163,7 @@
                              onClick="window.open('/public/ucph-erda-user-guide.pdf');">
                             <h1 class="fa-button fas fa-book"></h1>
                             <h3>User Guide</h3>
-                            <p>Read on in the user guide for full ERDA documentation.</p>
+                            <p>Read on in the user guide for full ERDA documentation (Our wiki holds newer information, but a few use cases are still only documented here).</p>
                         </div>
                     </div>
 


### PR DESCRIPTION
I have changed the links pointing to the old guides to instead point to our new documentation on our wiki.

I also removed the TODO in regards to different OS, as the new links would only point to one source and not three separate dependent on OS.