### PR TITLE
Replace the threading with multiprocessing in events and cron services run helpers

### DIFF
--- a/mig/server/grid_cron.py
+++ b/mig/server/grid_cron.py
@@ -46,7 +46,6 @@ import signal
 import sys
 import tempfile
 import time
-import threading
 
 try:
     from watchdog.observers import Observer
@@ -411,25 +410,27 @@ def __handle_cronjob(configuration, client_id, timestamp, crontab_entry):
 
 
 def run_handler(configuration, client_id, timestamp, crontab_entry):
-    """Run crontab entry for client_id in a separate thread"""
+    """Run crontab entry for client_id in a properly isolated process to avoid
+    concurrent worker interference.
+    """
 
     pid = multiprocessing.current_process().pid
 
-    # TODO: Replace try/catch with an event queue or thread pool setup
+    # TODO: Replace try/catch with an event queue or process pool setup
 
-    waiting_for_thread_resources = True
-    while waiting_for_thread_resources:
+    waiting_for_worker_resources = True
+    while waiting_for_worker_resources:
         try:
             worker = \
-                threading.Thread(target=__handle_cronjob,
-                                 args=(configuration, client_id,
-                                       timestamp, crontab_entry))
+                multiprocessing.Process(target=__handle_cronjob,
+                                        args=(configuration, client_id,
+                                              timestamp, crontab_entry))
             worker.daemon = True
             worker.start()
-            waiting_for_thread_resources = False
-        except threading.ThreadError as exc:
+            waiting_for_worker_resources = False
+        except multiprocessing.ProcessError as exc:
 
-            # logger.debug('(%s) Waiting for thread resources to handle crontab: %s'
+            # logger.debug('(%s) Waiting for worker resources to handle crontab: %s'
             #              % (pid, crontab_entry))
 
             time.sleep(1)

--- a/mig/server/grid_events.py
+++ b/mig/server/grid_events.py
@@ -1262,7 +1262,9 @@ class MiGFileEventHandler(PatternMatchingEventHandler):
         return src_path
 
     def run_handler(self, event):
-        """Trigger any rule actions bound to file state change"""
+        """Trigger any rule actions bound to file state change in a properly
+        isolated process to avoid concurrent worker interference.
+        """
 
         pid = multiprocessing.current_process().pid
         state = event.event_type
@@ -1355,21 +1357,21 @@ class MiGFileEventHandler(PatternMatchingEventHandler):
 
                     rule_hit = True
 
-                    # TODO: Replace try/catch with an event queue or thread
+                    # TODO: Replace try/catch with an event queue or process
                     #       pool setup
 
-                    waiting_for_thread_resources = True
-                    while waiting_for_thread_resources:
+                    waiting_for_worker_resources = True
+                    while waiting_for_worker_resources:
                         try:
                             worker = \
-                                threading.Thread(target=self.__handle_trigger,
-                                                 args=(event, target_path, rule))
+                                multiprocessing.Process(target=self.__handle_trigger,
+                                                        args=(event, target_path, rule))
                             worker.daemon = True
                             worker.start()
-                            waiting_for_thread_resources = False
-                        except threading.ThreadError as exc:
+                            waiting_for_worker_resources = False
+                        except multiprocessing.ProcessError as exc:
 
-                            # logger.debug('(%s) Waiting for thread resources to handle trigger: %s'
+                            # logger.debug('(%s) Waiting for worker resources to handle trigger: %s'
                             #              % (pid, event))
 
                             time.sleep(1)


### PR DESCRIPTION
Replace the `threading.Thread` in events and cron services run helpers with `multiprocessing.Process` to properly isolate individual worker runs from any concurrently running workers. Especially to avoid the inline changes to `os.environ` from spilling over between threads under high load.