### PR TITLE
Unit tests for the userio module helpers.

### DIFF
--- a/mig/shared/userio.py
+++ b/mig/shared/userio.py
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -574,7 +575,7 @@ def __clean_test_files(configuration, test_path):
                                                            exc))
 
 
-def main(_exit=sys.exit, _print=print):
+def legacy_main(_exit=sys.exit, _print=print):
     """Run module self-tests"""
     from mig.shared.base import client_id_dir
     from mig.shared.conf import get_configuration_object
@@ -681,4 +682,4 @@ def main(_exit=sys.exit, _print=print):
 
 
 if __name__ == "__main__":
-    main()
+    legacy_main()

--- a/tests/test_mig_shared_userio.py
+++ b/tests/test_mig_shared_userio.py
@@ -3,7 +3,7 @@
 # --- BEGIN_HEADER ---
 #
 # test_mig_shared_userio - test module of same name
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -28,9 +28,7 @@
 """Unit tests for the migrid module pointed to in the filename"""
 
 import os
-import sys
 import unittest
-from past.builtins import basestring, unicode
 
 from tests.support import MigTestCase, testmain, ensure_dirs_exist
 
@@ -38,16 +36,14 @@ from mig.shared.userio import ACTIONS, CREATE, MODIFY, MOVE, DELETE, \
     DEFAULT_COMPRESS, get_home_location, get_trash_location, _check_access, \
     _get_compression_helpers, _build_changes_path, _fill_changes, \
     prepare_changes, commit_changes, abort_changes, delete_path, remove_path, \
-    touch_path, __make_test_files, __clean_test_files, main as userio_main
+    touch_path, main as userio_main
 from mig.shared.vgrid import vgrid_set_entities
 
-
-# Constants from tests/test_mig_lib_janitor.py
+# TODO: gather shared constants in a tests.support library module
 DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com'
 DUMMY_CLIENT_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.com'
 TEST_VGRID_NAME = 'testvgrid'
 TEST_OWNER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test Owner/emailAddress=owner@example.org'
-MODIFY_ACTION = 'modify'
 
 
 class TestMigSharedUserIO_main(MigTestCase):
@@ -102,6 +98,7 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def before_each(self):
         """Setup test environment before each test method"""
+        self.configuration.mig_server_id = 'test-id'
         ensure_dirs_exist(self.configuration.user_db_home)
         ensure_dirs_exist(self.configuration.user_home)
         ensure_dirs_exist(self.configuration.freeze_home)
@@ -109,6 +106,7 @@ class TestMigSharedUserIO_main(MigTestCase):
         ensure_dirs_exist(self.configuration.vgrid_files_home)
         ensure_dirs_exist(self.configuration.vgrid_files_writable)
         ensure_dirs_exist(self.configuration.vgrid_files_readonly)
+        ensure_dirs_exist(self.configuration.events_home)
 
     def test_constants(self):
         """Test constants are defined correctly"""
@@ -234,12 +232,12 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test__get_compression_helpers_gzip(self):
         """Test _get_compression_helpers with gzip"""
-        open_func, ext = _get_compression_helpers(self.configuration, 'gzip')
+        _, ext = _get_compression_helpers(self.configuration, 'gzip')
         self.assertEqual(ext, '.gz')
 
     def test__get_compression_helpers_bz2(self):
         """Test _get_compression_helpers with bz2"""
-        open_func, ext = _get_compression_helpers(self.configuration, 'bz2')
+        _, ext = _get_compression_helpers(self.configuration, 'bz2')
         self.assertEqual(ext, '.bz2')
 
     def test__get_compression_helpers_invalid(self):
@@ -282,7 +280,7 @@ class TestMigSharedUserIO_main(MigTestCase):
         valid_path = os.path.join(
             self.configuration.user_home, DUMMY_CLIENT_DIR, 'valid.txt')
         try:
-            _check_access(self.configuration, MODIFY_ACTION, [valid_path])
+            _check_access(self.configuration, MODIFY, [valid_path])
         except ValueError:
             self.fail("Unexpected ValueError for valid path")
 
@@ -292,7 +290,7 @@ class TestMigSharedUserIO_main(MigTestCase):
         invisible_path = os.path.join(
             self.configuration.user_home, DUMMY_CLIENT_DIR, '.htaccess')
         with self.assertRaises(ValueError):
-            _check_access(self.configuration, MODIFY_ACTION, [invisible_path])
+            _check_access(self.configuration, MODIFY, [invisible_path])
 
     def test__check_access_symlink_path_modify_rejected(self):
         """Test _check_access with symlink path"""
@@ -303,8 +301,133 @@ class TestMigSharedUserIO_main(MigTestCase):
             self.configuration.user_home, DUMMY_CLIENT_DIR, 'link')
         os.symlink(symlink_src, symlink_dst)
         with self.assertRaises(ValueError):
-            _check_access(self.configuration, MODIFY_ACTION, [symlink_dst])
+            _check_access(self.configuration, MODIFY, [symlink_dst])
         os.remove(symlink_dst)
+
+    @unittest.skip("TODO: fix issue 460 and enable")
+    def test__fill_changes_default_compression(self):
+        """Test _fill_changes helper"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        changeset = 'test-changeset'
+        action = DELETE
+        target_list = [os.path.join(self.configuration.user_home,
+                                    DUMMY_CLIENT_DIR, 'file.txt')]
+        pending_path = _fill_changes(
+            self.configuration, changeset, action, target_list)
+        self.assertIsNotNone(pending_path)
+        self.assertTrue(os.path.exists(pending_path))
+        open_func, _ = _get_compression_helpers(self.configuration,
+                                                DEFAULT_COMPRESS)
+        with open_func(pending_path, 'rt') as f:
+            content = f.read()
+            self.assertIn("%s:%s" % (action, target_list[0]), content)
+        os.remove(pending_path)
+
+    def test__fill_changes_uncompressed(self):
+        """Test _fill_changes helper"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        changeset = 'test-changeset'
+        action = DELETE
+        target_list = [os.path.join(self.configuration.user_home,
+                                    DUMMY_CLIENT_DIR, 'file.txt')]
+        pending_path = _fill_changes(
+            self.configuration, changeset, action, target_list, compress=None)
+        self.assertIsNotNone(pending_path)
+        self.assertTrue(os.path.exists(pending_path))
+        open_func, _ = _get_compression_helpers(self.configuration, None)
+        with open_func(pending_path, 'r') as f:
+            content = f.read()
+            self.assertIn("%s:%s" % (action, target_list[0]), content)
+        os.remove(pending_path)
+
+    @unittest.skip("TODO: fix issue 460 and enable")
+    def test_prepare_changes_default_compression(self):
+        """Test prepare_changes function"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        changeset = 'test-changeset'
+        action = DELETE
+        path = os.path.join(self.configuration.user_home, DUMMY_CLIENT_DIR,
+                            'file.txt')
+        pending_path = prepare_changes(
+            self.configuration, action, changeset, action, path, False,
+            DEFAULT_COMPRESS)
+        self.assertIsNotNone(pending_path)
+        self.assertTrue(os.path.exists(pending_path))
+        os.remove(pending_path)
+
+    def test_prepare_changes_uncompressed(self):
+        """Test prepare_changes function"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        changeset = 'test-changeset'
+        action = DELETE
+        path = os.path.join(self.configuration.user_home, DUMMY_CLIENT_DIR,
+                            'file.txt')
+        pending_path = prepare_changes(
+            self.configuration, action, changeset, action, path, False, None)
+        self.assertIsNotNone(pending_path)
+        self.assertTrue(os.path.exists(pending_path))
+        os.remove(pending_path)
+
+    def test_commit_changes(self):
+        """Test commit_changes function"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        changeset = 'test-changeset'
+        pending_path = _build_changes_path(
+            self.configuration, changeset, pending=True)
+        with open(pending_path, 'w') as f:
+            f.write("test content\n")
+        committed_path = commit_changes(
+            self.configuration, changeset, DEFAULT_COMPRESS)
+        self.assertIsNotNone(committed_path)
+        self.assertTrue(os.path.exists(committed_path))
+        self.assertFalse(os.path.exists(pending_path))
+
+    def test_abort_changes(self):
+        """Test abort_changes function"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        changeset = 'test-changeset'
+        pending_path = _build_changes_path(
+            self.configuration, changeset, pending=True)
+        with open(pending_path, 'w') as f:
+            f.write("test content\n")
+        result = abort_changes(self.configuration, changeset, DEFAULT_COMPRESS)
+        self.assertTrue(result)
+        self.assertFalse(os.path.exists(pending_path))
+
+    def test_delete_path(self):
+        """Test delete_path function"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        test_file = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, 'test.txt')
+        with open(test_file, 'w') as f:
+            f.write("test content\n")
+        result, errors = delete_path(self.configuration, test_file)
+        self.assertTrue(result)
+        self.assertEqual(errors, [])
+        self.assertFalse(os.path.exists(test_file))
+
+    def test_remove_path(self):
+        """Test remove_path function"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        test_file = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, 'test.txt')
+        with open(test_file, 'w') as f:
+            f.write("test content\n")
+        result, errors = remove_path(self.configuration, test_file)
+        self.assertTrue(result)
+        self.assertEqual(errors, [])
+        trash_path = get_trash_location(self.configuration, test_file)
+        self.assertTrue(os.path.exists(trash_path))
+
+    def test_touch_path(self):
+        """Test touch_path function"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        test_file = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, 'test.txt')
+        result, errors = touch_path(self.configuration, test_file)
+        self.assertTrue(result)
+        self.assertEqual(errors, [])
+        self.assertTrue(os.path.exists(test_file))
 
 
 class TestMigSharedUserIO__legacy(MigTestCase):
@@ -312,6 +435,7 @@ class TestMigSharedUserIO__legacy(MigTestCase):
 
     # TODO: migrate all legacy self-check functionality into the above?
     def test_existing_main(self):
+        """Wrap old inline self-test as an additional unit test"""
         def raise_on_error_exit(exit_code):
             if exit_code != 0:
                 if raise_on_error_exit.last_print is not None:
@@ -323,6 +447,7 @@ class TestMigSharedUserIO__legacy(MigTestCase):
         raise_on_error_exit.last_print = None
 
         def record_last_print(value):
+            """Helper to show last print on error"""
             raise_on_error_exit.last_print = value
 
         userio_main(_exit=raise_on_error_exit, _print=record_last_print)

--- a/tests/test_mig_shared_userio.py
+++ b/tests/test_mig_shared_userio.py
@@ -29,16 +29,288 @@
 
 import os
 import sys
+import unittest
 from past.builtins import basestring, unicode
 
-from tests.support import MigTestCase, testmain
+from tests.support import MigTestCase, testmain, ensure_dirs_exist
 
-from mig.shared.userio import main as userio_main
+from mig.shared.userio import ACTIONS, CREATE, MODIFY, MOVE, DELETE, \
+    DEFAULT_COMPRESS, get_home_location, get_trash_location, _check_access, \
+    _get_compression_helpers, _build_changes_path, _fill_changes, \
+    prepare_changes, commit_changes, abort_changes, delete_path, remove_path, \
+    touch_path, __make_test_files, __clean_test_files, main as userio_main
+from mig.shared.vgrid import vgrid_set_entities
 
 
-class MigSharedUserIO(MigTestCase):
+# Constants from tests/test_mig_lib_janitor.py
+DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com'
+DUMMY_CLIENT_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.com'
+TEST_VGRID_NAME = 'testvgrid'
+TEST_OWNER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test Owner/emailAddress=owner@example.org'
+MODIFY_ACTION = 'modify'
+
+
+class TestMigSharedUserIO_main(MigTestCase):
     """Unit tests for userio related helper functions"""
 
+    def _provide_configuration(self):
+        """Prepare isolated test config"""
+        return 'testconfig'
+
+    # TODO: migrate to support as _provision_vgrid or similar
+    def _create_vgrid(self, vgrid_name, owners=None, members=None,
+                      resources=None, settings=None, triggers=None):
+        """Helper to create valid skeleton vgrid for testing"""
+        for vgrid_base in (self.configuration.vgrid_home,
+                           self.configuration.vgrid_files_home,
+                           self.configuration.vgrid_files_writable,
+                           self.configuration.vgrid_files_readonly,
+                           self.configuration.vgrid_private_base,
+                           self.configuration.vgrid_public_base, ):
+            vgrid_path = os.path.join(vgrid_base, vgrid_name)
+            ensure_dirs_exist(vgrid_path)
+        # Save vgrid owners, members, resources, settings and triggers
+        if owners is None:
+            owners = []
+        success_and_msg = vgrid_set_entities(self.configuration, vgrid_name,
+                                             'owners', owners, allow_empty=True)
+        self.assertEqual(success_and_msg, (True, ""))
+        if members is None:
+            members = []
+        success_and_msg = vgrid_set_entities(self.configuration, vgrid_name,
+                                             'members', members,
+                                             allow_empty=True)
+        self.assertEqual(success_and_msg, (True, ""))
+        if resources is None:
+            resources = []
+        success_and_msg = vgrid_set_entities(self.configuration, vgrid_name,
+                                             'resources', resources,
+                                             allow_empty=True)
+        self.assertEqual(success_and_msg, (True, ""))
+        if settings is None:
+            settings = [('vgrid_name', vgrid_name)]
+        success_and_msg = vgrid_set_entities(self.configuration, vgrid_name,
+                                             'settings', settings,
+                                             allow_empty=True)
+        self.assertEqual(success_and_msg, (True, ""))
+        if triggers is None:
+            triggers = []
+        success_and_msg = vgrid_set_entities(self.configuration, vgrid_name,
+                                             'triggers', triggers,
+                                             allow_empty=True)
+        self.assertEqual(success_and_msg, (True, ""))
+
+    def before_each(self):
+        """Setup test environment before each test method"""
+        ensure_dirs_exist(self.configuration.user_db_home)
+        ensure_dirs_exist(self.configuration.user_home)
+        ensure_dirs_exist(self.configuration.freeze_home)
+        ensure_dirs_exist(self.configuration.vgrid_home)
+        ensure_dirs_exist(self.configuration.vgrid_files_home)
+        ensure_dirs_exist(self.configuration.vgrid_files_writable)
+        ensure_dirs_exist(self.configuration.vgrid_files_readonly)
+
+    def test_constants(self):
+        """Test constants are defined correctly"""
+        self.assertEqual(ACTIONS, ("create", "modify", "move", "delete"))
+        self.assertEqual(CREATE, "create")
+        self.assertEqual(MODIFY, "modify")
+        self.assertEqual(MOVE, "move")
+        self.assertEqual(DELETE, "delete")
+        self.assertEqual(DEFAULT_COMPRESS, 'bz2')
+
+    def test_get_home_location_user_home(self):
+        """Test get_home_location with user_home path"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        user_path = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, 'file.txt')
+        with open(user_path, "w") as fd:
+            fd.close()
+        result = get_home_location(self.configuration, user_path)
+        expected = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR)
+        self.assertEqual(result, expected)
+
+    def test_get_home_location_vgrid_files_home(self):
+        """Test get_home_location with vgrid_files_home path"""
+        self._create_vgrid(TEST_VGRID_NAME, [TEST_OWNER_DN])
+        vgrid_path = os.path.join(
+            self.configuration.vgrid_files_home, TEST_VGRID_NAME, 'file.txt')
+        with open(vgrid_path, "w") as fd:
+            fd.close()
+        result = get_home_location(self.configuration, vgrid_path)
+        expected = os.path.join(
+            self.configuration.vgrid_files_home, TEST_VGRID_NAME)
+        self.assertEqual(result, expected)
+
+    @unittest.skip("TODO: fix read-only mount/copy of vgrid_files_writable and enable")
+    def test_get_home_location_vgrid_files_writable(self):
+        """Test get_home_location with vgrid_files_writable path"""
+        self._create_vgrid(TEST_VGRID_NAME, [TEST_OWNER_DN])
+        writable_path = os.path.join(
+            self.configuration.vgrid_files_writable, TEST_VGRID_NAME, 'file.txt')
+        with open(writable_path, "w") as fd:
+            fd.close()
+        # NOTE: mimic proper read-only support with a copy and permissions
+        readonly_path = os.path.join(
+            self.configuration.vgrid_files_readonly, TEST_VGRID_NAME, 'file.txt')
+        with open(readonly_path, "w") as fd:
+            fd.close()
+        os.chmod(readonly_path, 0o400)
+        os.chmod(os.path.dirname(readonly_path), 0o500)
+
+        result = get_home_location(self.configuration, writable_path)
+        expected = os.path.join(
+            self.configuration.vgrid_files_writable, TEST_VGRID_NAME)
+        # Allow clean up
+        os.chmod(os.path.dirname(readonly_path), 0o700)
+        self.assertEqual(result, expected)
+
+    def test_get_home_location_vgrid_private_base(self):
+        """Test get_home_location with vgrid_private_base path"""
+        self._create_vgrid(TEST_VGRID_NAME, [TEST_OWNER_DN])
+        priv_path = os.path.join(
+            self.configuration.vgrid_private_base, TEST_VGRID_NAME, 'file.txt')
+        with open(priv_path, "w") as fd:
+            fd.close()
+        result = get_home_location(self.configuration, priv_path)
+        expected = os.path.join(
+            self.configuration.vgrid_private_base, TEST_VGRID_NAME)
+        self.assertEqual(result, expected)
+
+    def test_get_home_location_vgrid_public_base(self):
+        """Test get_home_location with vgrid_public_base path"""
+        self._create_vgrid(TEST_VGRID_NAME, [TEST_OWNER_DN])
+        pub_path = os.path.join(
+            self.configuration.vgrid_public_base, TEST_VGRID_NAME, 'file.txt')
+        with open(pub_path, "w") as fd:
+            fd.close()
+        result = get_home_location(self.configuration, pub_path)
+        expected = os.path.join(
+            self.configuration.vgrid_public_base, TEST_VGRID_NAME)
+        self.assertEqual(result, expected)
+
+    def test_get_home_location_invalid_path(self):
+        """Test get_home_location with invalid path"""
+        invalid_path = '/invalid/path/file.txt'
+        result = get_home_location(self.configuration, invalid_path)
+        self.assertIsNone(result)
+
+    def test_get_trash_location_visible_link_false(self):
+        """Test get_trash_location with visible_link=False"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        test_path = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, 'file.txt')
+        result = get_trash_location(self.configuration, test_path)
+        expected = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, '.trash')
+        self.assertEqual(result, expected)
+
+    def test_get_trash_location_visible_link_true(self):
+        """Test get_trash_location with visible_link=True"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        test_path = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, 'file.txt')
+        result = get_trash_location(self.configuration, test_path, True)
+        expected = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, 'Trash')
+        self.assertEqual(result, expected)
+
+    def test_get_trash_location_vgrid_path(self):
+        """Test get_trash_location with vgrid path"""
+        self._create_vgrid(TEST_VGRID_NAME, [TEST_OWNER_DN])
+        vgrid_path = os.path.join(
+            self.configuration.vgrid_files_home, TEST_VGRID_NAME, 'file.txt')
+        result = get_trash_location(self.configuration, vgrid_path)
+        expected = os.path.join(
+            self.configuration.vgrid_files_home, TEST_VGRID_NAME, '.trash')
+        self.assertEqual(result, expected)
+
+    def test__get_compression_helpers_none(self):
+        """Test _get_compression_helpers with None"""
+        open_func, ext = _get_compression_helpers(self.configuration, None)
+        self.assertEqual(open_func, open)
+        self.assertEqual(ext, '')
+
+    def test__get_compression_helpers_gzip(self):
+        """Test _get_compression_helpers with gzip"""
+        open_func, ext = _get_compression_helpers(self.configuration, 'gzip')
+        self.assertEqual(ext, '.gz')
+
+    def test__get_compression_helpers_bz2(self):
+        """Test _get_compression_helpers with bz2"""
+        open_func, ext = _get_compression_helpers(self.configuration, 'bz2')
+        self.assertEqual(ext, '.bz2')
+
+    def test__get_compression_helpers_invalid(self):
+        """Test _get_compression_helpers with invalid"""
+        with self.assertRaises(ValueError):
+            _get_compression_helpers(self.configuration, 'invalid')
+
+    def test__build_changes_path_pending_false(self):
+        """Test _build_changes_path with pending=False"""
+        changeset = 'test-changeset'
+        path = _build_changes_path(self.configuration, changeset)
+        expected = os.path.join(
+            self.configuration.events_home,
+            "%s-%s.bz2" % (self.configuration.mig_server_id, changeset))
+        self.assertEqual(path, expected)
+
+    def test__build_changes_path_pending_true(self):
+        """Test _build_changes_path with pending=True"""
+        changeset = 'test-changeset'
+        path = _build_changes_path(
+            self.configuration, changeset, pending=True)
+        expected = os.path.join(
+            self.configuration.events_home,
+            ".%s-%s-pending.bz2" % (self.configuration.mig_server_id, changeset))
+        self.assertEqual(path, expected)
+
+    def test__build_changes_path_compress_none(self):
+        """Test _build_changes_path with compress=None"""
+        changeset = 'test-changeset'
+        path = _build_changes_path(
+            self.configuration, changeset, compress=None)
+        expected = os.path.join(
+            self.configuration.events_home,
+            "%s-%s" % (self.configuration.mig_server_id, changeset))
+        self.assertEqual(path, expected)
+
+    def test__check_access_valid_path(self):
+        """Test _check_access with valid path"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        valid_path = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, 'valid.txt')
+        try:
+            _check_access(self.configuration, MODIFY_ACTION, [valid_path])
+        except ValueError:
+            self.fail("Unexpected ValueError for valid path")
+
+    def test__check_access_invisible_path(self):
+        """Test _check_access with invisible path"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        invisible_path = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, '.htaccess')
+        with self.assertRaises(ValueError):
+            _check_access(self.configuration, MODIFY_ACTION, [invisible_path])
+
+    def test__check_access_symlink_path_modify_rejected(self):
+        """Test _check_access with symlink path"""
+        self._provision_test_user(self, DUMMY_USER_DN)
+        symlink_src = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR)
+        symlink_dst = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, 'link')
+        os.symlink(symlink_src, symlink_dst)
+        with self.assertRaises(ValueError):
+            _check_access(self.configuration, MODIFY_ACTION, [symlink_dst])
+        os.remove(symlink_dst)
+
+
+class TestMigSharedUserIO__legacy(MigTestCase):
+    """Legacy tests for safeinput module self-checks"""
+
+    # TODO: migrate all legacy self-check functionality into the above?
     def test_existing_main(self):
         def raise_on_error_exit(exit_code):
             if exit_code != 0:

--- a/tests/test_mig_shared_userio.py
+++ b/tests/test_mig_shared_userio.py
@@ -31,11 +31,27 @@ import os
 import unittest
 
 # Imports of the code under test
-from mig.shared.userio import ACTIONS, CREATE, MODIFY, MOVE, DELETE, \
-    DEFAULT_COMPRESS, get_home_location, get_trash_location, _check_access, \
-    _get_compression_helpers, _build_changes_path, _fill_changes, \
-    prepare_changes, commit_changes, abort_changes, delete_path, remove_path, \
-    touch_path, legacy_main
+from mig.shared.userio import (
+    ACTIONS,
+    CREATE,
+    DEFAULT_COMPRESS,
+    DELETE,
+    MODIFY,
+    MOVE,
+    _build_changes_path,
+    _check_access,
+    _fill_changes,
+    _get_compression_helpers,
+    abort_changes,
+    commit_changes,
+    delete_path,
+    get_home_location,
+    get_trash_location,
+    legacy_main,
+    prepare_changes,
+    remove_path,
+    touch_path,
+)
 
 # Imports required for the unit test wrapping
 from mig.shared.vgrid import vgrid_set_entities
@@ -45,9 +61,9 @@ from tests.support import MigTestCase, ensure_dirs_exist, testmain
 from tests.support.usersupp import TEST_USER_DN, UserAssertMixin
 
 # TODO: gather shared constants in a tests.support library module
-TEST_USER_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.com'
-TEST_VGRID_NAME = 'testvgrid'
-TEST_OWNER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test Owner/emailAddress=owner@example.org'
+TEST_USER_DIR = "+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.com"
+TEST_VGRID_NAME = "testvgrid"
+TEST_OWNER_DN = "/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test Owner/emailAddress=owner@example.org"
 
 
 class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
@@ -55,55 +71,78 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
 
     def _provide_configuration(self):
         """Prepare isolated test config"""
-        return 'testconfig'
+        return "testconfig"
 
     # TODO: migrate this helper to support.vgridsup module or similar
-    def _provision_test_vgrid(self, vgrid_name, *, owners=None, members=None,
-                              resources=None, settings=None, triggers=None):
+    def _provision_test_vgrid(
+        self,
+        vgrid_name,
+        *,
+        owners=None,
+        members=None,
+        resources=None,
+        settings=None,
+        triggers=None
+    ):
         """Helper to create valid skeleton vgrid for testing"""
         ensure_dirs_exist(self.configuration.mig_system_files)
-        for vgrid_base in (self.configuration.vgrid_home,
-                           self.configuration.vgrid_files_home,
-                           self.configuration.vgrid_files_writable,
-                           self.configuration.vgrid_files_readonly,
-                           self.configuration.vgrid_private_base,
-                           self.configuration.vgrid_public_base, ):
+        for vgrid_base in (
+            self.configuration.vgrid_home,
+            self.configuration.vgrid_files_home,
+            self.configuration.vgrid_files_writable,
+            self.configuration.vgrid_files_readonly,
+            self.configuration.vgrid_private_base,
+            self.configuration.vgrid_public_base,
+        ):
             vgrid_path = os.path.join(vgrid_base, vgrid_name)
             ensure_dirs_exist(vgrid_path)
         # Save vgrid owners, members, resources, settings and triggers
         if owners is None:
             owners = []
-        success_and_msg = vgrid_set_entities(self.configuration, vgrid_name,
-                                             'owners', owners, allow_empty=True)
+        success_and_msg = vgrid_set_entities(
+            self.configuration, vgrid_name, "owners", owners, allow_empty=True
+        )
         self.assertEqual(success_and_msg, (True, ""))
         if members is None:
             members = []
-        success_and_msg = vgrid_set_entities(self.configuration, vgrid_name,
-                                             'members', members,
-                                             allow_empty=True)
+        success_and_msg = vgrid_set_entities(
+            self.configuration, vgrid_name, "members", members, allow_empty=True
+        )
         self.assertEqual(success_and_msg, (True, ""))
         if resources is None:
             resources = []
-        success_and_msg = vgrid_set_entities(self.configuration, vgrid_name,
-                                             'resources', resources,
-                                             allow_empty=True)
+        success_and_msg = vgrid_set_entities(
+            self.configuration,
+            vgrid_name,
+            "resources",
+            resources,
+            allow_empty=True,
+        )
         self.assertEqual(success_and_msg, (True, ""))
         if settings is None:
-            settings = [('vgrid_name', vgrid_name)]
-        success_and_msg = vgrid_set_entities(self.configuration, vgrid_name,
-                                             'settings', settings,
-                                             allow_empty=True)
+            settings = [("vgrid_name", vgrid_name)]
+        success_and_msg = vgrid_set_entities(
+            self.configuration,
+            vgrid_name,
+            "settings",
+            settings,
+            allow_empty=True,
+        )
         self.assertEqual(success_and_msg, (True, ""))
         if triggers is None:
             triggers = []
-        success_and_msg = vgrid_set_entities(self.configuration, vgrid_name,
-                                             'triggers', triggers,
-                                             allow_empty=True)
+        success_and_msg = vgrid_set_entities(
+            self.configuration,
+            vgrid_name,
+            "triggers",
+            triggers,
+            allow_empty=True,
+        )
         self.assertEqual(success_and_msg, (True, ""))
 
     def before_each(self):
         """Setup test environment before each test method"""
-        self.configuration.mig_server_id = 'test-id'
+        self.configuration.mig_server_id = "test-id"
         ensure_dirs_exist(self.configuration.user_db_home)
         ensure_dirs_exist(self.configuration.user_home)
         ensure_dirs_exist(self.configuration.freeze_home)
@@ -120,43 +159,49 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
         self.assertEqual(MODIFY, "modify")
         self.assertEqual(MOVE, "move")
         self.assertEqual(DELETE, "delete")
-        self.assertEqual(DEFAULT_COMPRESS, 'bz2')
+        self.assertEqual(DEFAULT_COMPRESS, "bz2")
 
     def test_get_home_location_user_home(self):
         """Test get_home_location with user_home path"""
         self._provision_test_user(self, TEST_USER_DN)
         user_path = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR, 'file.txt')
+            self.configuration.user_home, TEST_USER_DIR, "file.txt"
+        )
         with open(user_path, "w") as fd:
             fd.close()
         result = get_home_location(self.configuration, user_path)
-        expected = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR)
+        expected = os.path.join(self.configuration.user_home, TEST_USER_DIR)
         self.assertEqual(result, expected)
 
     def test_get_home_location_vgrid_files_home(self):
         """Test get_home_location with vgrid_files_home path"""
         self._provision_test_vgrid(TEST_VGRID_NAME, owners=[TEST_OWNER_DN])
         vgrid_path = os.path.join(
-            self.configuration.vgrid_files_home, TEST_VGRID_NAME, 'file.txt')
+            self.configuration.vgrid_files_home, TEST_VGRID_NAME, "file.txt"
+        )
         with open(vgrid_path, "w") as fd:
             fd.close()
         result = get_home_location(self.configuration, vgrid_path)
         expected = os.path.join(
-            self.configuration.vgrid_files_home, TEST_VGRID_NAME)
+            self.configuration.vgrid_files_home, TEST_VGRID_NAME
+        )
         self.assertEqual(result, expected)
 
-    @unittest.skip("TODO: fix read-only mount/copy of vgrid_files_writable and enable")
+    @unittest.skip(
+        "TODO: fix read-only mount/copy of vgrid_files_writable and enable"
+    )
     def test_get_home_location_vgrid_files_writable(self):
         """Test get_home_location with vgrid_files_writable path"""
         self._provision_test_vgrid(TEST_VGRID_NAME, owners=[TEST_OWNER_DN])
         writable_path = os.path.join(
-            self.configuration.vgrid_files_writable, TEST_VGRID_NAME, 'file.txt')
+            self.configuration.vgrid_files_writable, TEST_VGRID_NAME, "file.txt"
+        )
         with open(writable_path, "w") as fd:
             fd.close()
         # NOTE: mimic proper read-only support with a copy and permissions
         readonly_path = os.path.join(
-            self.configuration.vgrid_files_readonly, TEST_VGRID_NAME, 'file.txt')
+            self.configuration.vgrid_files_readonly, TEST_VGRID_NAME, "file.txt"
+        )
         with open(readonly_path, "w") as fd:
             fd.close()
         os.chmod(readonly_path, 0o400)
@@ -164,7 +209,8 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
 
         result = get_home_location(self.configuration, writable_path)
         expected = os.path.join(
-            self.configuration.vgrid_files_writable, TEST_VGRID_NAME)
+            self.configuration.vgrid_files_writable, TEST_VGRID_NAME
+        )
         # Allow clean up
         os.chmod(os.path.dirname(readonly_path), 0o700)
         self.assertEqual(result, expected)
@@ -173,29 +219,33 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
         """Test get_home_location with vgrid_private_base path"""
         self._provision_test_vgrid(TEST_VGRID_NAME, owners=[TEST_OWNER_DN])
         priv_path = os.path.join(
-            self.configuration.vgrid_private_base, TEST_VGRID_NAME, 'file.txt')
+            self.configuration.vgrid_private_base, TEST_VGRID_NAME, "file.txt"
+        )
         with open(priv_path, "w") as fd:
             fd.close()
         result = get_home_location(self.configuration, priv_path)
         expected = os.path.join(
-            self.configuration.vgrid_private_base, TEST_VGRID_NAME)
+            self.configuration.vgrid_private_base, TEST_VGRID_NAME
+        )
         self.assertEqual(result, expected)
 
     def test_get_home_location_vgrid_public_base(self):
         """Test get_home_location with vgrid_public_base path"""
         self._provision_test_vgrid(TEST_VGRID_NAME, owners=[TEST_OWNER_DN])
         pub_path = os.path.join(
-            self.configuration.vgrid_public_base, TEST_VGRID_NAME, 'file.txt')
+            self.configuration.vgrid_public_base, TEST_VGRID_NAME, "file.txt"
+        )
         with open(pub_path, "w") as fd:
             fd.close()
         result = get_home_location(self.configuration, pub_path)
         expected = os.path.join(
-            self.configuration.vgrid_public_base, TEST_VGRID_NAME)
+            self.configuration.vgrid_public_base, TEST_VGRID_NAME
+        )
         self.assertEqual(result, expected)
 
     def test_get_home_location_invalid_path(self):
         """Test get_home_location with invalid path"""
-        invalid_path = '/invalid/path/file.txt'
+        invalid_path = "/invalid/path/file.txt"
         result = get_home_location(self.configuration, invalid_path)
         self.assertIsNone(result)
 
@@ -203,87 +253,96 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
         """Test get_trash_location with visible_link=False"""
         self._provision_test_user(self, TEST_USER_DN)
         test_path = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR, 'file.txt')
+            self.configuration.user_home, TEST_USER_DIR, "file.txt"
+        )
         result = get_trash_location(self.configuration, test_path)
         expected = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR, '.trash')
+            self.configuration.user_home, TEST_USER_DIR, ".trash"
+        )
         self.assertEqual(result, expected)
 
     def test_get_trash_location_visible_link_true(self):
         """Test get_trash_location with visible_link=True"""
         self._provision_test_user(self, TEST_USER_DN)
         test_path = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR, 'file.txt')
+            self.configuration.user_home, TEST_USER_DIR, "file.txt"
+        )
         result = get_trash_location(self.configuration, test_path, True)
         expected = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR, 'Trash')
+            self.configuration.user_home, TEST_USER_DIR, "Trash"
+        )
         self.assertEqual(result, expected)
 
     def test_get_trash_location_vgrid_path(self):
         """Test get_trash_location with vgrid path"""
         self._provision_test_vgrid(TEST_VGRID_NAME, owners=[TEST_OWNER_DN])
         vgrid_path = os.path.join(
-            self.configuration.vgrid_files_home, TEST_VGRID_NAME, 'file.txt')
+            self.configuration.vgrid_files_home, TEST_VGRID_NAME, "file.txt"
+        )
         result = get_trash_location(self.configuration, vgrid_path)
         expected = os.path.join(
-            self.configuration.vgrid_files_home, TEST_VGRID_NAME, '.trash')
+            self.configuration.vgrid_files_home, TEST_VGRID_NAME, ".trash"
+        )
         self.assertEqual(result, expected)
 
     def test__get_compression_helpers_none(self):
         """Test _get_compression_helpers with None"""
         open_func, ext = _get_compression_helpers(self.configuration, None)
         self.assertEqual(open_func, open)
-        self.assertEqual(ext, '')
+        self.assertEqual(ext, "")
 
     def test__get_compression_helpers_gzip(self):
         """Test _get_compression_helpers with gzip"""
-        _, ext = _get_compression_helpers(self.configuration, 'gzip')
-        self.assertEqual(ext, '.gz')
+        _, ext = _get_compression_helpers(self.configuration, "gzip")
+        self.assertEqual(ext, ".gz")
 
     def test__get_compression_helpers_bz2(self):
         """Test _get_compression_helpers with bz2"""
-        _, ext = _get_compression_helpers(self.configuration, 'bz2')
-        self.assertEqual(ext, '.bz2')
+        _, ext = _get_compression_helpers(self.configuration, "bz2")
+        self.assertEqual(ext, ".bz2")
 
     def test__get_compression_helpers_invalid(self):
         """Test _get_compression_helpers with invalid"""
         with self.assertRaises(ValueError):
-            _get_compression_helpers(self.configuration, 'invalid')
+            _get_compression_helpers(self.configuration, "invalid")
 
     def test__build_changes_path_pending_false(self):
         """Test _build_changes_path with pending=False"""
-        changeset = 'test-changeset'
+        changeset = "test-changeset"
         path = _build_changes_path(self.configuration, changeset)
         expected = os.path.join(
             self.configuration.events_home,
-            "%s-%s.bz2" % (self.configuration.mig_server_id, changeset))
+            "%s-%s.bz2" % (self.configuration.mig_server_id, changeset),
+        )
         self.assertEqual(path, expected)
 
     def test__build_changes_path_pending_true(self):
         """Test _build_changes_path with pending=True"""
-        changeset = 'test-changeset'
-        path = _build_changes_path(
-            self.configuration, changeset, pending=True)
+        changeset = "test-changeset"
+        path = _build_changes_path(self.configuration, changeset, pending=True)
         expected = os.path.join(
             self.configuration.events_home,
-            ".%s-%s-pending.bz2" % (self.configuration.mig_server_id, changeset))
+            ".%s-%s-pending.bz2"
+            % (self.configuration.mig_server_id, changeset),
+        )
         self.assertEqual(path, expected)
 
     def test__build_changes_path_compress_none(self):
         """Test _build_changes_path with compress=None"""
-        changeset = 'test-changeset'
-        path = _build_changes_path(
-            self.configuration, changeset, compress=None)
+        changeset = "test-changeset"
+        path = _build_changes_path(self.configuration, changeset, compress=None)
         expected = os.path.join(
             self.configuration.events_home,
-            "%s-%s" % (self.configuration.mig_server_id, changeset))
+            "%s-%s" % (self.configuration.mig_server_id, changeset),
+        )
         self.assertEqual(path, expected)
 
     def test__check_access_valid_path(self):
         """Test _check_access with valid path"""
         self._provision_test_user(self, TEST_USER_DN)
         valid_path = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR, 'valid.txt')
+            self.configuration.user_home, TEST_USER_DIR, "valid.txt"
+        )
         try:
             _check_access(self.configuration, MODIFY, [valid_path])
         except ValueError:
@@ -293,17 +352,18 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
         """Test _check_access with invisible path"""
         self._provision_test_user(self, TEST_USER_DN)
         invisible_path = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR, '.htaccess')
+            self.configuration.user_home, TEST_USER_DIR, ".htaccess"
+        )
         with self.assertRaises(ValueError):
             _check_access(self.configuration, MODIFY, [invisible_path])
 
     def test__check_access_symlink_path_modify_rejected(self):
         """Test _check_access with symlink path"""
         self._provision_test_user(self, TEST_USER_DN)
-        symlink_src = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR)
+        symlink_src = os.path.join(self.configuration.user_home, TEST_USER_DIR)
         symlink_dst = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR, 'link')
+            self.configuration.user_home, TEST_USER_DIR, "link"
+        )
         os.symlink(symlink_src, symlink_dst)
         with self.assertRaises(ValueError):
             _check_access(self.configuration, MODIFY, [symlink_dst])
@@ -313,17 +373,22 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
     def test__fill_changes_default_compression(self):
         """Test _fill_changes helper"""
         self._provision_test_user(self, TEST_USER_DN)
-        changeset = 'test-changeset'
+        changeset = "test-changeset"
         action = DELETE
-        target_list = [os.path.join(self.configuration.user_home,
-                                    TEST_USER_DIR, 'file.txt')]
+        target_list = [
+            os.path.join(
+                self.configuration.user_home, TEST_USER_DIR, "file.txt"
+            )
+        ]
         pending_path = _fill_changes(
-            self.configuration, changeset, action, target_list)
+            self.configuration, changeset, action, target_list
+        )
         self.assertIsNotNone(pending_path)
         self.assertTrue(os.path.exists(pending_path))
-        open_func, _ = _get_compression_helpers(self.configuration,
-                                                DEFAULT_COMPRESS)
-        with open_func(pending_path, 'rt') as f:
+        open_func, _ = _get_compression_helpers(
+            self.configuration, DEFAULT_COMPRESS
+        )
+        with open_func(pending_path, "rt") as f:
             content = f.read()
             self.assertIn("%s:%s" % (action, target_list[0]), content)
         os.remove(pending_path)
@@ -331,16 +396,20 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
     def test__fill_changes_uncompressed(self):
         """Test _fill_changes helper"""
         self._provision_test_user(self, TEST_USER_DN)
-        changeset = 'test-changeset'
+        changeset = "test-changeset"
         action = DELETE
-        target_list = [os.path.join(self.configuration.user_home,
-                                    TEST_USER_DIR, 'file.txt')]
+        target_list = [
+            os.path.join(
+                self.configuration.user_home, TEST_USER_DIR, "file.txt"
+            )
+        ]
         pending_path = _fill_changes(
-            self.configuration, changeset, action, target_list, compress=None)
+            self.configuration, changeset, action, target_list, compress=None
+        )
         self.assertIsNotNone(pending_path)
         self.assertTrue(os.path.exists(pending_path))
         open_func, _ = _get_compression_helpers(self.configuration, None)
-        with open_func(pending_path, 'r') as f:
+        with open_func(pending_path, "r") as f:
             content = f.read()
             self.assertIn("%s:%s" % (action, target_list[0]), content)
         os.remove(pending_path)
@@ -349,13 +418,20 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
     def test_prepare_changes_default_compression(self):
         """Test prepare_changes function"""
         self._provision_test_user(self, TEST_USER_DN)
-        changeset = 'test-changeset'
+        changeset = "test-changeset"
         action = DELETE
-        path = os.path.join(self.configuration.user_home, TEST_USER_DIR,
-                            'file.txt')
+        path = os.path.join(
+            self.configuration.user_home, TEST_USER_DIR, "file.txt"
+        )
         pending_path = prepare_changes(
-            self.configuration, action, changeset, action, path, False,
-            DEFAULT_COMPRESS)
+            self.configuration,
+            action,
+            changeset,
+            action,
+            path,
+            False,
+            DEFAULT_COMPRESS,
+        )
         self.assertIsNotNone(pending_path)
         self.assertTrue(os.path.exists(pending_path))
         os.remove(pending_path)
@@ -363,12 +439,14 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
     def test_prepare_changes_uncompressed(self):
         """Test prepare_changes function"""
         self._provision_test_user(self, TEST_USER_DN)
-        changeset = 'test-changeset'
+        changeset = "test-changeset"
         action = DELETE
-        path = os.path.join(self.configuration.user_home, TEST_USER_DIR,
-                            'file.txt')
+        path = os.path.join(
+            self.configuration.user_home, TEST_USER_DIR, "file.txt"
+        )
         pending_path = prepare_changes(
-            self.configuration, action, changeset, action, path, False, None)
+            self.configuration, action, changeset, action, path, False, None
+        )
         self.assertIsNotNone(pending_path)
         self.assertTrue(os.path.exists(pending_path))
         os.remove(pending_path)
@@ -376,13 +454,15 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
     def test_commit_changes(self):
         """Test commit_changes function"""
         self._provision_test_user(self, TEST_USER_DN)
-        changeset = 'test-changeset'
+        changeset = "test-changeset"
         pending_path = _build_changes_path(
-            self.configuration, changeset, pending=True)
-        with open(pending_path, 'w') as f:
+            self.configuration, changeset, pending=True
+        )
+        with open(pending_path, "w") as f:
             f.write("test content\n")
         committed_path = commit_changes(
-            self.configuration, changeset, DEFAULT_COMPRESS)
+            self.configuration, changeset, DEFAULT_COMPRESS
+        )
         self.assertIsNotNone(committed_path)
         self.assertTrue(os.path.exists(committed_path))
         self.assertFalse(os.path.exists(pending_path))
@@ -390,10 +470,11 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
     def test_abort_changes(self):
         """Test abort_changes function"""
         self._provision_test_user(self, TEST_USER_DN)
-        changeset = 'test-changeset'
+        changeset = "test-changeset"
         pending_path = _build_changes_path(
-            self.configuration, changeset, pending=True)
-        with open(pending_path, 'w') as f:
+            self.configuration, changeset, pending=True
+        )
+        with open(pending_path, "w") as f:
             f.write("test content\n")
         result = abort_changes(self.configuration, changeset, DEFAULT_COMPRESS)
         self.assertTrue(result)
@@ -403,8 +484,9 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
         """Test delete_path function"""
         self._provision_test_user(self, TEST_USER_DN)
         test_file = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR, 'test.txt')
-        with open(test_file, 'w') as f:
+            self.configuration.user_home, TEST_USER_DIR, "test.txt"
+        )
+        with open(test_file, "w") as f:
             f.write("test content\n")
         result, errors = delete_path(self.configuration, test_file)
         self.assertTrue(result)
@@ -415,8 +497,9 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
         """Test remove_path function"""
         self._provision_test_user(self, TEST_USER_DN)
         test_file = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR, 'test.txt')
-        with open(test_file, 'w') as f:
+            self.configuration.user_home, TEST_USER_DIR, "test.txt"
+        )
+        with open(test_file, "w") as f:
             f.write("test content\n")
         result, errors = remove_path(self.configuration, test_file)
         self.assertTrue(result)
@@ -428,7 +511,8 @@ class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
         """Test touch_path function"""
         self._provision_test_user(self, TEST_USER_DN)
         test_file = os.path.join(
-            self.configuration.user_home, TEST_USER_DIR, 'test.txt')
+            self.configuration.user_home, TEST_USER_DIR, "test.txt"
+        )
         result, errors = touch_path(self.configuration, test_file)
         self.assertTrue(result)
         self.assertEqual(errors, [])
@@ -441,14 +525,17 @@ class TestMigSharedUserIO__legacy_main(MigTestCase):
     # TODO: migrate all legacy self-check functionality into the above?
     def test_existing_main(self):
         """Wrap old inline self-test as an additional unit test"""
+
         def raise_on_error_exit(exit_code):
             if exit_code != 0:
                 if raise_on_error_exit.last_print is not None:
                     identifying_message = raise_on_error_exit.last_print
                 else:
-                    identifying_message = 'unknown'
+                    identifying_message = "unknown"
                 raise AssertionError(
-                    'failure in unittest/testcore: %s' % (identifying_message,))
+                    "failure in unittest/testcore: %s" % (identifying_message,)
+                )
+
         raise_on_error_exit.last_print = None
 
         def record_last_print(value):
@@ -458,5 +545,5 @@ class TestMigSharedUserIO__legacy_main(MigTestCase):
         legacy_main(_exit=raise_on_error_exit, _print=record_last_print)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     testmain()

--- a/tests/test_mig_shared_userio.py
+++ b/tests/test_mig_shared_userio.py
@@ -30,33 +30,38 @@
 import os
 import unittest
 
-from tests.support import MigTestCase, testmain, ensure_dirs_exist
-
+# Imports of the code under test
 from mig.shared.userio import ACTIONS, CREATE, MODIFY, MOVE, DELETE, \
     DEFAULT_COMPRESS, get_home_location, get_trash_location, _check_access, \
     _get_compression_helpers, _build_changes_path, _fill_changes, \
     prepare_changes, commit_changes, abort_changes, delete_path, remove_path, \
-    touch_path, main as userio_main
+    touch_path, legacy_main
+
+# Imports required for the unit test wrapping
 from mig.shared.vgrid import vgrid_set_entities
 
+# Imports required for the unit tests themselves
+from tests.support import MigTestCase, ensure_dirs_exist, testmain
+from tests.support.usersupp import TEST_USER_DN, UserAssertMixin
+
 # TODO: gather shared constants in a tests.support library module
-DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com'
-DUMMY_CLIENT_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.com'
+TEST_USER_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.com'
 TEST_VGRID_NAME = 'testvgrid'
 TEST_OWNER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test Owner/emailAddress=owner@example.org'
 
 
-class TestMigSharedUserIO_main(MigTestCase):
+class TestMigSharedUserIO_legacy_main(MigTestCase, UserAssertMixin):
     """Unit tests for userio related helper functions"""
 
     def _provide_configuration(self):
         """Prepare isolated test config"""
         return 'testconfig'
 
-    # TODO: migrate to support as _provision_vgrid or similar
-    def _create_vgrid(self, vgrid_name, owners=None, members=None,
-                      resources=None, settings=None, triggers=None):
+    # TODO: migrate this helper to support.vgridsup module or similar
+    def _provision_test_vgrid(self, vgrid_name, *, owners=None, members=None,
+                              resources=None, settings=None, triggers=None):
         """Helper to create valid skeleton vgrid for testing"""
+        ensure_dirs_exist(self.configuration.mig_system_files)
         for vgrid_base in (self.configuration.vgrid_home,
                            self.configuration.vgrid_files_home,
                            self.configuration.vgrid_files_writable,
@@ -119,19 +124,19 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test_get_home_location_user_home(self):
         """Test get_home_location with user_home path"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         user_path = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, 'file.txt')
+            self.configuration.user_home, TEST_USER_DIR, 'file.txt')
         with open(user_path, "w") as fd:
             fd.close()
         result = get_home_location(self.configuration, user_path)
         expected = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR)
+            self.configuration.user_home, TEST_USER_DIR)
         self.assertEqual(result, expected)
 
     def test_get_home_location_vgrid_files_home(self):
         """Test get_home_location with vgrid_files_home path"""
-        self._create_vgrid(TEST_VGRID_NAME, [TEST_OWNER_DN])
+        self._provision_test_vgrid(TEST_VGRID_NAME, owners=[TEST_OWNER_DN])
         vgrid_path = os.path.join(
             self.configuration.vgrid_files_home, TEST_VGRID_NAME, 'file.txt')
         with open(vgrid_path, "w") as fd:
@@ -144,7 +149,7 @@ class TestMigSharedUserIO_main(MigTestCase):
     @unittest.skip("TODO: fix read-only mount/copy of vgrid_files_writable and enable")
     def test_get_home_location_vgrid_files_writable(self):
         """Test get_home_location with vgrid_files_writable path"""
-        self._create_vgrid(TEST_VGRID_NAME, [TEST_OWNER_DN])
+        self._provision_test_vgrid(TEST_VGRID_NAME, owners=[TEST_OWNER_DN])
         writable_path = os.path.join(
             self.configuration.vgrid_files_writable, TEST_VGRID_NAME, 'file.txt')
         with open(writable_path, "w") as fd:
@@ -166,7 +171,7 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test_get_home_location_vgrid_private_base(self):
         """Test get_home_location with vgrid_private_base path"""
-        self._create_vgrid(TEST_VGRID_NAME, [TEST_OWNER_DN])
+        self._provision_test_vgrid(TEST_VGRID_NAME, owners=[TEST_OWNER_DN])
         priv_path = os.path.join(
             self.configuration.vgrid_private_base, TEST_VGRID_NAME, 'file.txt')
         with open(priv_path, "w") as fd:
@@ -178,7 +183,7 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test_get_home_location_vgrid_public_base(self):
         """Test get_home_location with vgrid_public_base path"""
-        self._create_vgrid(TEST_VGRID_NAME, [TEST_OWNER_DN])
+        self._provision_test_vgrid(TEST_VGRID_NAME, owners=[TEST_OWNER_DN])
         pub_path = os.path.join(
             self.configuration.vgrid_public_base, TEST_VGRID_NAME, 'file.txt')
         with open(pub_path, "w") as fd:
@@ -196,27 +201,27 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test_get_trash_location_visible_link_false(self):
         """Test get_trash_location with visible_link=False"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         test_path = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, 'file.txt')
+            self.configuration.user_home, TEST_USER_DIR, 'file.txt')
         result = get_trash_location(self.configuration, test_path)
         expected = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, '.trash')
+            self.configuration.user_home, TEST_USER_DIR, '.trash')
         self.assertEqual(result, expected)
 
     def test_get_trash_location_visible_link_true(self):
         """Test get_trash_location with visible_link=True"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         test_path = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, 'file.txt')
+            self.configuration.user_home, TEST_USER_DIR, 'file.txt')
         result = get_trash_location(self.configuration, test_path, True)
         expected = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, 'Trash')
+            self.configuration.user_home, TEST_USER_DIR, 'Trash')
         self.assertEqual(result, expected)
 
     def test_get_trash_location_vgrid_path(self):
         """Test get_trash_location with vgrid path"""
-        self._create_vgrid(TEST_VGRID_NAME, [TEST_OWNER_DN])
+        self._provision_test_vgrid(TEST_VGRID_NAME, owners=[TEST_OWNER_DN])
         vgrid_path = os.path.join(
             self.configuration.vgrid_files_home, TEST_VGRID_NAME, 'file.txt')
         result = get_trash_location(self.configuration, vgrid_path)
@@ -276,9 +281,9 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test__check_access_valid_path(self):
         """Test _check_access with valid path"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         valid_path = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, 'valid.txt')
+            self.configuration.user_home, TEST_USER_DIR, 'valid.txt')
         try:
             _check_access(self.configuration, MODIFY, [valid_path])
         except ValueError:
@@ -286,19 +291,19 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test__check_access_invisible_path(self):
         """Test _check_access with invisible path"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         invisible_path = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, '.htaccess')
+            self.configuration.user_home, TEST_USER_DIR, '.htaccess')
         with self.assertRaises(ValueError):
             _check_access(self.configuration, MODIFY, [invisible_path])
 
     def test__check_access_symlink_path_modify_rejected(self):
         """Test _check_access with symlink path"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         symlink_src = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR)
+            self.configuration.user_home, TEST_USER_DIR)
         symlink_dst = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, 'link')
+            self.configuration.user_home, TEST_USER_DIR, 'link')
         os.symlink(symlink_src, symlink_dst)
         with self.assertRaises(ValueError):
             _check_access(self.configuration, MODIFY, [symlink_dst])
@@ -307,11 +312,11 @@ class TestMigSharedUserIO_main(MigTestCase):
     @unittest.skip("TODO: fix issue 460 and enable")
     def test__fill_changes_default_compression(self):
         """Test _fill_changes helper"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         changeset = 'test-changeset'
         action = DELETE
         target_list = [os.path.join(self.configuration.user_home,
-                                    DUMMY_CLIENT_DIR, 'file.txt')]
+                                    TEST_USER_DIR, 'file.txt')]
         pending_path = _fill_changes(
             self.configuration, changeset, action, target_list)
         self.assertIsNotNone(pending_path)
@@ -325,11 +330,11 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test__fill_changes_uncompressed(self):
         """Test _fill_changes helper"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         changeset = 'test-changeset'
         action = DELETE
         target_list = [os.path.join(self.configuration.user_home,
-                                    DUMMY_CLIENT_DIR, 'file.txt')]
+                                    TEST_USER_DIR, 'file.txt')]
         pending_path = _fill_changes(
             self.configuration, changeset, action, target_list, compress=None)
         self.assertIsNotNone(pending_path)
@@ -343,10 +348,10 @@ class TestMigSharedUserIO_main(MigTestCase):
     @unittest.skip("TODO: fix issue 460 and enable")
     def test_prepare_changes_default_compression(self):
         """Test prepare_changes function"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         changeset = 'test-changeset'
         action = DELETE
-        path = os.path.join(self.configuration.user_home, DUMMY_CLIENT_DIR,
+        path = os.path.join(self.configuration.user_home, TEST_USER_DIR,
                             'file.txt')
         pending_path = prepare_changes(
             self.configuration, action, changeset, action, path, False,
@@ -357,10 +362,10 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test_prepare_changes_uncompressed(self):
         """Test prepare_changes function"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         changeset = 'test-changeset'
         action = DELETE
-        path = os.path.join(self.configuration.user_home, DUMMY_CLIENT_DIR,
+        path = os.path.join(self.configuration.user_home, TEST_USER_DIR,
                             'file.txt')
         pending_path = prepare_changes(
             self.configuration, action, changeset, action, path, False, None)
@@ -370,7 +375,7 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test_commit_changes(self):
         """Test commit_changes function"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         changeset = 'test-changeset'
         pending_path = _build_changes_path(
             self.configuration, changeset, pending=True)
@@ -384,7 +389,7 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test_abort_changes(self):
         """Test abort_changes function"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         changeset = 'test-changeset'
         pending_path = _build_changes_path(
             self.configuration, changeset, pending=True)
@@ -396,9 +401,9 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test_delete_path(self):
         """Test delete_path function"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         test_file = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, 'test.txt')
+            self.configuration.user_home, TEST_USER_DIR, 'test.txt')
         with open(test_file, 'w') as f:
             f.write("test content\n")
         result, errors = delete_path(self.configuration, test_file)
@@ -408,9 +413,9 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test_remove_path(self):
         """Test remove_path function"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         test_file = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, 'test.txt')
+            self.configuration.user_home, TEST_USER_DIR, 'test.txt')
         with open(test_file, 'w') as f:
             f.write("test content\n")
         result, errors = remove_path(self.configuration, test_file)
@@ -421,16 +426,16 @@ class TestMigSharedUserIO_main(MigTestCase):
 
     def test_touch_path(self):
         """Test touch_path function"""
-        self._provision_test_user(self, DUMMY_USER_DN)
+        self._provision_test_user(self, TEST_USER_DN)
         test_file = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, 'test.txt')
+            self.configuration.user_home, TEST_USER_DIR, 'test.txt')
         result, errors = touch_path(self.configuration, test_file)
         self.assertTrue(result)
         self.assertEqual(errors, [])
         self.assertTrue(os.path.exists(test_file))
 
 
-class TestMigSharedUserIO__legacy(MigTestCase):
+class TestMigSharedUserIO__legacy_main(MigTestCase):
     """Legacy tests for safeinput module self-checks"""
 
     # TODO: migrate all legacy self-check functionality into the above?
@@ -450,7 +455,7 @@ class TestMigSharedUserIO__legacy(MigTestCase):
             """Helper to show last print on error"""
             raise_on_error_exit.last_print = value
 
-        userio_main(_exit=raise_on_error_exit, _print=record_last_print)
+        legacy_main(_exit=raise_on_error_exit, _print=record_last_print)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fundamental unit tests for the `userio` helpers including regression tests for issue #460 to be enabled along with the fix. Increasing tests coverage is easy now that the basic structure is in place for generating them.