### PR TITLE
Adjust wsgi to handle Fieldstorage str vs bytes issue and log errors

### DIFF
--- a/mig/shared/scriptinput.py
+++ b/mig/shared/scriptinput.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # scriptinput - Handles html form style input from user
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,17 +20,20 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
 
-"""This module contains CGI/WSGI/... specific functions for
-handling user input.
+"""This module contains CGI/WSGI/... specific functions for handling user
+input.
 """
 
 from __future__ import print_function
 from __future__ import absolute_import
+
+import cgi
 
 # Expose some safeinput functions here, too
 
@@ -38,6 +41,7 @@ from mig.shared.safeinput import validated_boolean, validated_string, \
     validated_path, validated_fqdn, validated_commonname, \
     validated_integer, validated_job_id, html_escape
 from mig.shared.safeinput import InputException as CgiInputException
+from mig.shared.url import parse_qs
 
 
 def parse_input(user_arguments_dict, fields):
@@ -157,18 +161,34 @@ def parse_argument(
     return (raw, safe, error)
 
 
-def fieldstorage_to_dict(fieldstorage, fields=[]):
+def fieldstorage_to_dict(fieldstorage, fields=None):
     """Get a plain dictionary, rather than the '.value' system used by
     the cgi module. Please note that all values are on list form even
     if only a single value is provided.
     If the fields list is provided, only the provided fields are read.
     This may be necessary in PUT requests where fieldstorage key listing is
     not supported.
+
+    IMPORTANT: single value fieldstorage instances like:
+    FieldStorage(None, None, b'_csrf=dummy')
+    will fail if used as dict with fieldstorage.keys() or list(fieldstorage).
+    Please refer to FixedFieldStorage and it's use for further details.
     """
 
     params = {}
-    if not fields and fieldstorage:
-        fields = list(fieldstorage)
+    if fieldstorage is not None:
+        if fieldstorage.list is None:
+            params = parse_qs(fieldstorage.value)
+            if fields is None:
+                return params
+            else:
+                return dict([(i, params[i]) for i in params if i in fields])
+        else:
+            if fields is None:
+                fields = list(fieldstorage)
+
+    if fields is None:
+        fields = []
     for key in fields:
         try:
             params[key] = fieldstorage.getlist(key)
@@ -189,3 +209,22 @@ def fieldstorage_to_dict(fieldstorage, fields=[]):
             print('Warning: failed to extract values for %s: %s'
                   % (key, err))
     return params
+
+
+class FixedFieldStorage(cgi.FieldStorage):
+    """Wrapper to address a corner case issue in cgi.FieldStorage explained on
+
+    https://github.com/python/cpython/issues/71964
+
+    In short we need to make sure the make_file method does NOT treat single
+    value input on bytes form as str as that will ALWAYS fail in read_binary.
+    """
+
+    def make_file(self):
+        """Patch parent make_file to take input length into account, too"""
+        orig = self._binary_file
+        if self.length >= 0:
+            self._binary_file = True
+        tmp = cgi.FieldStorage.make_file(self)
+        self._binary_file = orig
+        return tmp

--- a/mig/shared/scriptinput.py
+++ b/mig/shared/scriptinput.py
@@ -161,13 +161,14 @@ def parse_argument(
     return (raw, safe, error)
 
 
-def fieldstorage_to_dict(fieldstorage, fields=None):
+def fieldstorage_to_dict(fieldstorage, fields=None, encoding='utf-8'):
     """Get a plain dictionary, rather than the '.value' system used by
     the cgi module. Please note that all values are on list form even
     if only a single value is provided.
     If the fields list is provided, only the provided fields are read.
     This may be necessary in PUT requests where fieldstorage key listing is
     not supported.
+    The optional encoding argument is used to decode any binary single values.
 
     IMPORTANT: single value fieldstorage instances like:
     FieldStorage(None, None, b'_csrf=dummy')
@@ -178,7 +179,10 @@ def fieldstorage_to_dict(fieldstorage, fields=None):
     params = {}
     if fieldstorage is not None:
         if fieldstorage.list is None:
-            params = parse_qs(fieldstorage.value)
+            val = fieldstorage.value
+            if isinstance(val, bytes) and encoding:
+                val = val.decode(encoding)
+            params = parse_qs(val)
             if fields is None:
                 return params
             else:

--- a/mig/wsgi-bin/migwsgi.py
+++ b/mig/wsgi-bin/migwsgi.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # migwsgi.py - Provides the entire WSGI interface
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -45,7 +46,7 @@ from mig.shared.conf import get_configuration_object
 from mig.shared.objecttypes import get_object_type_info
 from mig.shared.output import validate, format_output, dummy_main, reject_main
 from mig.shared.safeinput import valid_backend_name, html_escape, InputException
-from mig.shared.scriptinput import fieldstorage_to_dict
+from mig.shared.scriptinput import fieldstorage_to_dict, FixedFieldStorage
 
 
 def object_type_info(object_type):
@@ -312,13 +313,17 @@ def application(environ, start_response, configuration=None,
         # _logger.debug('DEBUG: wsgi found backend %s and script %s' %
         #              (backend, script_name))
         try:
-            fieldstorage = cgi.FieldStorage(fp=environ['wsgi.input'],
-                                            environ=environ)
+            fieldstorage = FixedFieldStorage(fp=environ['wsgi.input'],
+                                             environ=environ)
+            # _logger.debug("extracted fieldstorage from wsgi request: %s" %
+            #              fieldstorage)
+            user_arguments_dict = fieldstorage_to_dict(fieldstorage)
+            # _logger.debug("extracted user_arguments_dict from wsgi: %s" %
+            #              user_arguments_dict)
         except Exception as exc:
             _logger.error("wsgi %s failed to extract fieldstorage: %s" %
                           (backend, exc))
             raise exc
-        user_arguments_dict = fieldstorage_to_dict(fieldstorage)
         output_format = get_output_format(configuration, user_arguments_dict)
 
         module_path = 'mig.shared.functionality.%s' % backend
@@ -441,7 +446,7 @@ def application(environ, start_response, configuration=None,
     _logger.debug("done and cleaning up to prevent further log noise")
     if user_arguments_dict:
         del user_arguments_dict
-    if fieldstorage:
+    if fieldstorage is not None:
         del fieldstorage
     _logger.debug("done cleaning up - detach wsgi error loggers")
     # TMP! uncomment next to test unhandled exception and error log

--- a/mig/wsgi-bin/migwsgi.py
+++ b/mig/wsgi-bin/migwsgi.py
@@ -190,7 +190,7 @@ def wrap_wsgi_errors(environ, configuration, max_line_len=100):
 
 
 def application(environ, start_response, configuration=None,
-        _import_module=importlib.import_module, _set_os_environ=True):
+                _import_module=importlib.import_module, _set_os_environ=True):
     """MiG app called automatically by WSGI.
 
     *environ* is a dictionary populated by the server with CGI-like variables
@@ -311,8 +311,13 @@ def application(environ, start_response, configuration=None,
         backend = requested_backend(environ, fallback=default_page)
         # _logger.debug('DEBUG: wsgi found backend %s and script %s' %
         #              (backend, script_name))
-        fieldstorage = cgi.FieldStorage(fp=environ['wsgi.input'],
-                                        environ=environ)
+        try:
+            fieldstorage = cgi.FieldStorage(fp=environ['wsgi.input'],
+                                            environ=environ)
+        except Exception as exc:
+            _logger.error("wsgi %s failed to extract fieldstorage: %s" %
+                          (backend, exc))
+            raise exc
         user_arguments_dict = fieldstorage_to_dict(fieldstorage)
         output_format = get_output_format(configuration, user_arguments_dict)
 
@@ -354,7 +359,7 @@ def application(environ, start_response, configuration=None,
     for key in environ:
         if key.find('wsgi.') != -1:
             wsgi_env[key] = environ[key]
-    #_logger.debug('passing wsgi env to output handlers: %s' % wsgi_env)
+    # _logger.debug('passing wsgi env to output handlers: %s' % wsgi_env)
     wsgi_entry = {'object_type': 'wsgi', 'environ': wsgi_env}
     output_objs.append(wsgi_entry)
 
@@ -393,9 +398,9 @@ def application(environ, start_response, configuration=None,
     try:
         # IMPORTANT: headers must be on native string format here
         native_headers = force_native_str_rec(response_headers)
-        #_logger.debug("native headers: %s" % native_headers)
+        # _logger.debug("native headers: %s" % native_headers)
         start_response(status, native_headers)
-        #_logger.debug("started response to client")
+        # _logger.debug("started response to client")
 
         # NOTE: we consistently hit download error for archive files reaching ~2GB
         #       with showfreezefile.py on wsgi but the same on cgi does NOT suffer
@@ -414,8 +419,9 @@ def application(environ, start_response, configuration=None,
             # _logger.debug("WSGI %s yielding part %d / %d output parts" %
             #              (backend, i+1, chunk_parts))
             # end index may be after end of content - but no problem
-            part = output[i*download_block_size:(i+1)*download_block_size]
-            #_logger.debug("yield %r chunk to client" % backend)
+            part = output[i * download_block_size:(i + 1) *
+                          download_block_size]
+            # _logger.debug("yield %r chunk to client" % backend)
             # IMPORTANT: bytes are required here for all python versions
             yield force_utf8(part)
         if chunk_parts > 1:

--- a/tests/test_mig_wsgibin.py
+++ b/tests/test_mig_wsgibin.py
@@ -308,7 +308,7 @@ class MigWsgibin_output_objects(MigTestCase, WsgiAssertMixin, SnapshotAssertMixi
 
 class MigWsgibin_input_object(MigTestCase, WsgiAssertMixin, SnapshotAssertMixin):
 
-    DUMMY_BYTES = 'dummycsrfæøåßßß'
+    DUMMY_BYTES = 'dummyæøå-ßßß-value'.encode('utf-8')
 
     def _provide_configuration(self):
         return 'testconfig'
@@ -340,13 +340,13 @@ class MigWsgibin_input_object(MigTestCase, WsgiAssertMixin, SnapshotAssertMixin)
             _set_os_environ=False,
         )
 
-    @unittest.skip("fix the underlying wsgi use of Fieldstorage and enable")
+    # NOTE: enabled with underlying wsgi use of Fieldstorage fixed
     def test_put_text_plain_with_binary_input_succeeds(self):
         test_form = [('_csrf', self.DUMMY_BYTES)]
         test_env = {
             "REQUEST_METHOD": "PUT",
             "CONTENT_TYPE": "text/plain",
-            "CONTENT_LENGTH": len(self.DUMMY_BYTES)
+            "CONTENT_LENGTH": "100",
         }
         self._prepare_test(test_form, test_env)
 
@@ -371,13 +371,13 @@ class MigWsgibin_input_object(MigTestCase, WsgiAssertMixin, SnapshotAssertMixin)
         # Must succeed with HTTP 200 when it parses input
         output, _ = self.assertWsgiResponse(wsgi_result, self.fake_wsgi, 200)
 
-    # TODO: we should fix the underlying wsgi use of Fieldstorage and drop next
+    @unittest.skip("disabled with underlying wsgi use of Fieldstorage fixed")
     def test_put_text_plain_with_binary_input_fails(self):
         test_form = [('_csrf', self.DUMMY_BYTES)]
         test_env = {
             "REQUEST_METHOD": "PUT",
             "CONTENT_TYPE": "text/plain",
-            "CONTENT_LENGTH": len(self.DUMMY_BYTES)
+            "CONTENT_LENGTH": "100",
         }
         self._prepare_test(test_form, test_env)
 

--- a/tests/test_mig_wsgibin.py
+++ b/tests/test_mig_wsgibin.py
@@ -3,7 +3,7 @@
 # --- BEGIN_HEADER ---
 #
 # test_mig_wsgi-bin - unit tests of the WSGI glue
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -33,8 +33,10 @@ import importlib
 import os
 import stat
 import sys
+import unittest
 
-from tests.support import PY2, MIG_BASE, MigTestCase, testmain, is_path_within
+from tests.support import PY2, MIG_BASE, MigTestCase, ensure_dirs_exist, \
+    testmain, is_path_within
 from tests.support.snapshotsupp import SnapshotAssertMixin
 from tests.support.wsgisupp import prepare_wsgi, WsgiAssertMixin
 
@@ -302,6 +304,130 @@ class MigWsgibin_output_objects(MigTestCase, WsgiAssertMixin, SnapshotAssertMixi
 
         output, _ = self.assertWsgiResponse(wsgi_result, self.fake_wsgi, 200)
         self.assertSnapshotOfHtmlContent(output)
+
+
+class MigWsgibin_input_object(MigTestCase, WsgiAssertMixin, SnapshotAssertMixin):
+
+    DUMMY_BYTES = 'dummycsrfæøåßßß'
+
+    def _provide_configuration(self):
+        return 'testconfig'
+
+    def before_each(self):
+        self.fake_backend = FakeBackend()
+        self.fake_wsgi = None
+
+    # TODO: integrate all of this in the default prepare_wsgi?
+    def _prepare_test(self, form_overrides=None, custom_env=None):
+        """Override common setup with form and environ values as needed"""
+
+        # Set up a wsgi input with non-ascii bytes and open it in binary mode
+        # If form_overrides is passed a list of tuples like [('key' 'val')] it
+        # produces a fake_wsgi input on the form: b'key=val'
+        self.fake_wsgi = prepare_wsgi(self.configuration, 'http://localhost/',
+                                      form=form_overrides)
+        # override the default environ fields from wsgisupp
+        if custom_env:
+            self.fake_wsgi.environ.update(custom_env)
+
+        self.application_args = (
+            self.fake_wsgi.environ,
+            self.fake_wsgi.start_response,
+        )
+        self.application_kwargs = dict(
+            configuration=self.configuration,
+            _import_module=self.fake_backend.to_import_module(),
+            _set_os_environ=False,
+        )
+
+    @unittest.skip("fix the underlying wsgi use of Fieldstorage and enable")
+    def test_put_text_plain_with_binary_input_succeeds(self):
+        test_form = [('_csrf', self.DUMMY_BYTES)]
+        test_env = {
+            "REQUEST_METHOD": "PUT",
+            "CONTENT_TYPE": "text/plain",
+            "CONTENT_LENGTH": len(self.DUMMY_BYTES)
+        }
+        self._prepare_test(test_form, test_env)
+
+        output_objects = [
+            # workaround invalid HTML being generated with no title object
+            {
+                'object_type': 'title',
+                'text': 'TEST'
+            },
+            {
+                'object_type': 'text',
+                'text': 'some text',
+            }
+        ]
+        self.fake_backend.set_response(output_objects, returnvalues.OK)
+
+        wsgi_result = migwsgi.application(
+            *self.application_args,
+            **self.application_kwargs
+        )
+
+        # Must succeed with HTTP 200 when it parses input
+        output, _ = self.assertWsgiResponse(wsgi_result, self.fake_wsgi, 200)
+
+    # TODO: we should fix the underlying wsgi use of Fieldstorage and drop next
+    def test_put_text_plain_with_binary_input_fails(self):
+        test_form = [('_csrf', self.DUMMY_BYTES)]
+        test_env = {
+            "REQUEST_METHOD": "PUT",
+            "CONTENT_TYPE": "text/plain",
+            "CONTENT_LENGTH": len(self.DUMMY_BYTES)
+        }
+        self._prepare_test(test_form, test_env)
+
+        output_objects = [
+            # workaround invalid HTML being generated with no title object
+            {
+                'object_type': 'title',
+                'text': 'TEST'
+            },
+            {
+                'object_type': 'text',
+                'text': 'some text',
+            }
+        ]
+        self.fake_backend.set_response(output_objects, returnvalues.OK)
+
+        # TODO: can we add assertLogs to check error log explicitly?
+        wsgi_result = migwsgi.application(
+            *self.application_args,
+            **self.application_kwargs
+        )
+
+        # Must fail with HTTP 500 from failing to parse input
+        output, _ = self.assertWsgiResponse(wsgi_result, self.fake_wsgi, 500)
+
+    def test_post_url_encoded_with_binary_input_succeeds(self):
+        test_form = [('_csrf', self.DUMMY_BYTES)]
+        test_env = None
+        self._prepare_test(test_form, test_env)
+
+        output_objects = [
+            # workaround invalid HTML being generated with no title object
+            {
+                'object_type': 'title',
+                'text': 'TEST'
+            },
+            {
+                'object_type': 'text',
+                'text': 'some text',
+            }
+        ]
+        self.fake_backend.set_response(output_objects, returnvalues.OK)
+
+        wsgi_result = migwsgi.application(
+            *self.application_args,
+            **self.application_kwargs
+        )
+
+        # Must succeed with HTTP 200 when it parses input
+        output, _ = self.assertWsgiResponse(wsgi_result, self.fake_wsgi, 200)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adjust wsgi to handle the [single value corner-case issue](https://github.com/python/cpython/issues/71964) in `cgi.Fieldstorage` and log any remaining exceptions thrown.

In short the problem is that `cgi.FieldStorage` parses our `wsgi.input` under guidance from `environ` values and incorrectly tries to handle valid binary input as text e.g. in case wsgi receives data marked as `Content-Type` `text/plain`. It then hits the specific code path with `self.read_binary()` in `cgi` where it tries to write the received valid `bytes` to an `io.TextIOWrapper` instance, which crashes because it must be passed a `str` rather than `bytes`.
We patch the `FieldStorage` as proposed in the above issue and make sure to handle the resulting single value `FieldStorage` instance in our `user_argument_dict` helpers, too.
The included unit tests cover the common POST with url-encoded form data as well as the specific single value corner-case.

We will eventually have to migrate away from the `cgi` module now that it was retired with python 3.13, but if nothing better shows up, we can at least use the [legacy-cgi](https://pypi.org/project/legacy-cgi/) port.