### PR TITLE
Refactor mig shared events into mig lib events with more cron and event service helpers

### DIFF
--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -38,6 +38,7 @@ import multiprocessing
 import os
 import re
 import shlex
+import sys
 
 from mig.shared.base import client_id_dir
 from mig.shared.cmdapi import parse_command_args
@@ -323,8 +324,12 @@ def run_cron_command(
     # logger.debug('(%s) run %s on behalf of %s' % (pid, command_str,
     #             client_id))
 
-    (function, user_arguments_dict) = parse_command_args(configuration,
-                                                         command_list)
+    try:
+        (function, user_arguments_dict) = parse_command_args(configuration,
+                                                             command_list)
+    except Exception as exc:
+        logger.error('(%s) failed to lookup function matching command %s' %
+                     (pid, command_str))
 
     form_method = 'post'
     target_op = "%s" % function
@@ -399,8 +404,12 @@ def run_events_command(
     # logger.debug('(%s) run %s on behalf of %s' % (pid, command_str,
     #             client_id))
 
-    (function, user_arguments_dict) = parse_command_args(configuration,
-                                                         command_list)
+    try:
+        (function, user_arguments_dict) = parse_command_args(configuration,
+                                                             command_list)
+    except Exception as exc:
+        logger.error('(%s) failed to lookup function matching command %s' %
+                     (pid, command_str))
 
     form_method = 'post'
     target_op = "%s" % function
@@ -414,8 +423,8 @@ def run_events_command(
     main = id
     txt_format = id
     try:
-        exec('from mig.shared.functionality.%s import main' % function)
-        exec('from mig.shared.output import txt_format')
+        main = importlib.import_module('mig.shared.functionality.%s' %
+                                       function).main
 
         # logger.debug('(%s) run %s on %s for %s' % \
         #              (pid, function, user_arguments_dict, client_id))
@@ -456,7 +465,8 @@ def run_events_command(
     #                                               ret_msg, txt_out))
 
 
-if __name__ == '__main__':
+def main(_exit=sys.exit, _print=print):
+    """Run module self-tests"""
     from mig.shared.conf import get_configuration_object
     conf = get_configuration_object()
     client_id = '/C=DK/ST=NA/L=NA/O=NBI/OU=NA/CN=Jonas Bardino/emailAddress=bardino@nbi.ku.dk'
@@ -502,3 +512,7 @@ if __name__ == '__main__':
             remain = at_remain(conf, timestamp, rule)
             print("At %s job is %dm in the future for rule" % (
                 timestamp, remain))
+
+
+if __name__ == '__main__':
+    main()

--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -48,8 +48,8 @@ from mig.shared.output import txt_format
 
 # Init global crontab regexp once and for all
 # Format: minute hour dayofmonth month dayofweek command
-crontab_pattern = "^(\*|[0-9]{1,2}) (\*|[0-9]{1,2}) (\*|[0-9]{1,2}) "
-crontab_pattern += "(\*|[0-9]{1,2}) (\*|[0-6]) (.*)$"
+crontab_pattern = r"^(\*|[0-9]{1,2}) (\*|[0-9]{1,2}) (\*|[0-9]{1,2}) "
+crontab_pattern += r"(\*|[0-9]{1,2}) (\*|[0-6]) (.*)$"
 crontab_expr = re.compile(crontab_pattern)
 # Init global atjobs regexp once and for all
 # ISO format with space between date and time and without msecs:

--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -350,6 +350,7 @@ def run_cron_command(
     except Exception as exc:
         logger.error('(%s) failed to lookup function matching command %s' %
                      (pid, command_str))
+        raise exc
 
     form_method = 'post'
     target_op = "%s" % function
@@ -433,6 +434,7 @@ def run_events_command(
     except Exception as exc:
         logger.error('(%s) failed to lookup function matching command %s' %
                      (pid, command_str))
+        raise exc
 
     form_method = 'post'
     target_op = "%s" % function

--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -283,7 +283,7 @@ def parse_and_save_atjobs(atjobs, client_id, configuration):
     return (status, msg)
 
 
-def cron_match(configuration, cron_time, entry):
+def cron_match(configuration, cron_time, entry, _warn_mismatch=False):
     """Check if cron_time matches the time specs in entry"""
     _logger = configuration.logger
     time_vals = {'minute': cron_time.minute, 'hour': cron_time.hour,
@@ -293,8 +293,11 @@ def cron_match(configuration, cron_time, entry):
     for (name, val) in time_vals.items():
         # Strip any leading zeros before integer match
         if not fnmatch.fnmatch("%s" % val, entry[name].lstrip('0')):
-            _logger.debug("no cron_match on %s: %s vs %s" %
-                          (name, val, entry[name]))
+            msg = "no cron_match on %s: %s vs %s" % (name, val, entry[name])
+            if _warn_mismatch:
+                _logger.warning(msg)
+            else:
+                _logger.debug(msg)
             return False
     return True
 

--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -28,8 +28,7 @@
 
 """Event trigger and cron/at helper functions"""
 
-from __future__ import print_function
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import datetime
 import fnmatch
@@ -42,7 +41,7 @@ import sys
 
 from mig.shared.base import client_id_dir
 from mig.shared.cmdapi import parse_command_args
-from mig.shared.defaults import crontab_name, csrf_field, atjobs_name
+from mig.shared.defaults import atjobs_name, crontab_name, csrf_field
 from mig.shared.fileio import read_file, read_file_lines, write_file
 from mig.shared.handlers import get_csrf_limit, make_csrf_token
 from mig.shared.output import txt_format
@@ -59,7 +58,7 @@ atjobs_pattern = "^([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2}):"
 atjobs_pattern += "([0-9]{2}) (.*)$"
 atjobs_expr = re.compile(atjobs_pattern)
 
-TRIGGER_EVENT = '_trigger_event'
+TRIGGER_EVENT = "_trigger_event"
 
 # Only cache rule misses for one minute at a time to catch rule updates.
 # Run complete expire cycle if miss cache exceeds expire size.
@@ -69,15 +68,15 @@ CACHE_EXPIRE_SIZE = 10000
 
 # Rate limit helpers
 
-(RATE_LIMIT_FIELD, SETTLE_TIME_FIELD) = ('rate_limit', 'settle_time')
-DEFAULT_PERIOD = 'm'
-DEFAULT_TIME = '0'
+RATE_LIMIT_FIELD, SETTLE_TIME_FIELD = ("rate_limit", "settle_time")
+DEFAULT_PERIOD = "m"
+DEFAULT_TIME = "0"
 UNIT_PERIODS = {
-    's': 1,
-    'm': 60,
-    'h': 60 * 60,
-    'd': 24 * 60 * 60,
-    'w': 7 * 24 * 60 * 60,
+    "s": 1,
+    "m": 60,
+    "h": 60 * 60,
+    "d": 24 * 60 * 60,
+    "w": 7 * 24 * 60 * 60,
 }
 
 
@@ -88,20 +87,20 @@ def get_path_expand_map(trigger_path, rule, state_change):
 
     trigger_filename = os.path.basename(trigger_path)
     trigger_dirname = os.path.dirname(trigger_path)
-    trigger_relpath = os.path.relpath(trigger_path, rule['vgrid_name'])
+    trigger_relpath = os.path.relpath(trigger_path, rule["vgrid_name"])
     trigger_reldirname = os.path.dirname(trigger_relpath)
-    (prefix, extension) = os.path.splitext(trigger_filename)
+    prefix, extension = os.path.splitext(trigger_filename)
     expand_map = {
-        '+TRIGGERPATH+': trigger_path,
-        '+TRIGGERRELPATH+': trigger_relpath,
-        '+TRIGGERDIRNAME+': trigger_dirname,
-        '+TRIGGERRELDIRNAME+': trigger_reldirname,
-        '+TRIGGERFILENAME+': trigger_filename,
-        '+TRIGGERPREFIX+': prefix,
-        '+TRIGGEREXTENSION+': extension,
-        '+TRIGGERCHANGE+': state_change,
-        '+TRIGGERVGRIDNAME+': rule['vgrid_name'],
-        '+TRIGGERRUNAS+': rule['run_as'],
+        "+TRIGGERPATH+": trigger_path,
+        "+TRIGGERRELPATH+": trigger_relpath,
+        "+TRIGGERDIRNAME+": trigger_dirname,
+        "+TRIGGERRELDIRNAME+": trigger_reldirname,
+        "+TRIGGERFILENAME+": trigger_filename,
+        "+TRIGGERPREFIX+": prefix,
+        "+TRIGGEREXTENSION+": extension,
+        "+TRIGGERCHANGE+": state_change,
+        "+TRIGGERVGRIDNAME+": rule["vgrid_name"],
+        "+TRIGGERRUNAS+": rule["run_as"],
     }
 
     # TODO: provide exact expanded wildcards?
@@ -117,14 +116,14 @@ def get_time_expand_map(timestamp, rule):
 
     # NOTE: we force two digits in the values where it can be one or two
     expand_map = {
-        '+SCHEDSECOND+': "%.2d" % timestamp.second,
-        '+SCHEDMINUTE+': "%.2d" % timestamp.minute,
-        '+SCHEDHOUR+': "%.2d" % timestamp.hour,
-        '+SCHEDDAY+': "%.2d" % timestamp.day,
-        '+SCHEDMONTH+': "%.2d" % timestamp.month,
-        '+SCHEDYEAR+': "%d" % timestamp.year,
-        '+SCHEDDAYOFWEEK+': "%d" % timestamp.weekday(),
-        '+SCHEDRUNAS+': rule['run_as'],
+        "+SCHEDSECOND+": "%.2d" % timestamp.second,
+        "+SCHEDMINUTE+": "%.2d" % timestamp.minute,
+        "+SCHEDHOUR+": "%.2d" % timestamp.hour,
+        "+SCHEDDAY+": "%.2d" % timestamp.day,
+        "+SCHEDMONTH+": "%.2d" % timestamp.month,
+        "+SCHEDYEAR+": "%d" % timestamp.year,
+        "+SCHEDDAYOFWEEK+": "%d" % timestamp.weekday(),
+        "+SCHEDRUNAS+": rule["run_as"],
     }
     return expand_map
 
@@ -133,14 +132,16 @@ def load_crontab(client_id, configuration, allow_missing=True):
     """Load entries from plain user crontab file"""
     _logger = configuration.logger
     client_dir = client_id_dir(client_id)
-    crontab_path = os.path.join(configuration.user_settings, client_dir,
-                                crontab_name)
-    crontab_contents = read_file(crontab_path, _logger,
-                                 allow_missing=allow_missing)
+    crontab_path = os.path.join(
+        configuration.user_settings, client_dir, crontab_name
+    )
+    crontab_contents = read_file(
+        crontab_path, _logger, allow_missing=allow_missing
+    )
     if crontab_contents is None:
         if not allow_missing:
-            _logger.error('failed reading %s crontab file' % client_id)
-        crontab_contents = ''
+            _logger.error("failed reading %s crontab file" % client_id)
+        crontab_contents = ""
     return crontab_contents
 
 
@@ -148,14 +149,16 @@ def load_atjobs(client_id, configuration, allow_missing=True):
     """Load entries from plain user atjobs file"""
     _logger = configuration.logger
     client_dir = client_id_dir(client_id)
-    atjobs_path = os.path.join(configuration.user_settings, client_dir,
-                               atjobs_name)
-    atjobs_contents = read_file(atjobs_path, _logger,
-                                allow_missing=allow_missing)
+    atjobs_path = os.path.join(
+        configuration.user_settings, client_dir, atjobs_name
+    )
+    atjobs_contents = read_file(
+        atjobs_path, _logger, allow_missing=allow_missing
+    )
     if atjobs_contents is None:
         if not allow_missing:
-            _logger.error('failed reading %s atjobs file' % client_id)
-        atjobs_contents = ''
+            _logger.error("failed reading %s atjobs file" % client_id)
+        atjobs_contents = ""
     return atjobs_contents
 
 
@@ -172,14 +175,20 @@ def parse_crontab_contents(configuration, client_id, crontab_lines):
             continue
         hit = crontab_expr.match(line.strip())
         if not hit:
-            _logger.warning("Skip invalid crontab line for %s: %s" %
-                            (client_id, line))
+            _logger.warning(
+                "Skip invalid crontab line for %s: %s" % (client_id, line)
+            )
             continue
         # Format: minute hour dayofmonth month dayofweek command
-        entry = {'minute': hit.group(1), 'hour': hit.group(2),
-                 'dayofmonth': hit.group(3), 'month': hit.group(4),
-                 'dayofweek': hit.group(5),
-                 'command': shlex.split(hit.group(6)), 'run_as': client_id}
+        entry = {
+            "minute": hit.group(1),
+            "hour": hit.group(2),
+            "dayofmonth": hit.group(3),
+            "month": hit.group(4),
+            "dayofweek": hit.group(5),
+            "command": shlex.split(hit.group(6)),
+            "run_as": client_id,
+        }
         crontab_entries.append(entry)
     return crontab_entries
 
@@ -199,23 +208,31 @@ def parse_atjobs_contents(configuration, client_id, atjobs_lines):
             continue
         hit = atjobs_expr.match(line.strip())
         if not hit:
-            _logger.warning("Skip invalid atjobs line for %s: %s" %
-                            (client_id, line))
+            _logger.warning(
+                "Skip invalid atjobs line for %s: %s" % (client_id, line)
+            )
             continue
         # ISO format (see top)
         try:
-            when = datetime.datetime(int(hit.group(1)), int(hit.group(2)),
-                                     int(hit.group(3)), int(hit.group(4)),
-                                     int(hit.group(5)), int(hit.group(6)))
+            when = datetime.datetime(
+                int(hit.group(1)),
+                int(hit.group(2)),
+                int(hit.group(3)),
+                int(hit.group(4)),
+                int(hit.group(5)),
+                int(hit.group(6)),
+            )
         except Exception as exc:
-            _logger.warning("Skip invalid atjobs line for %s: %s (%s)" %
-                            (client_id, line, exc))
+            _logger.warning(
+                "Skip invalid atjobs line for %s: %s (%s)"
+                % (client_id, line, exc)
+            )
             continue
 
         # Ignore seconds
         when = when.replace(second=0)
         cmd_list = shlex.split(hit.group(7))
-        entry = {'time_stamp': when, 'run_as': client_id, 'command': cmd_list}
+        entry = {"time_stamp": when, "run_as": client_id, "command": cmd_list}
         if (when - now).total_seconds() >= 0:
             atjobs_entries.append(entry)
         else:
@@ -251,17 +268,19 @@ def parse_and_save_crontab(crontab, client_id, configuration):
     """Validate and write the crontab for client_id"""
     _logger = configuration.logger
     client_dir = client_id_dir(client_id)
-    crontab_path = os.path.join(configuration.user_settings, client_dir,
-                                crontab_name)
-    status, msg = True, ''
-    crontab_entries = parse_crontab_contents(configuration, client_id,
-                                             crontab.splitlines())
+    crontab_path = os.path.join(
+        configuration.user_settings, client_dir, crontab_name
+    )
+    status, msg = True, ""
+    crontab_entries = parse_crontab_contents(
+        configuration, client_id, crontab.splitlines()
+    )
     # TODO: filter out broken lines before write?
     if write_file(crontab, crontab_path, _logger):
         msg = "Found and saved %d valid crontab entries" % len(crontab_entries)
     else:
         status = False
-        msg = 'ERROR: writing crontab file'
+        msg = "ERROR: writing crontab file"
     return (status, msg)
 
 
@@ -269,30 +288,36 @@ def parse_and_save_atjobs(atjobs, client_id, configuration):
     """Validate and write the atjobs for client_id"""
     _logger = configuration.logger
     client_dir = client_id_dir(client_id)
-    atjobs_path = os.path.join(configuration.user_settings, client_dir,
-                               atjobs_name)
-    status, msg = True, ''
-    atjobs_entries = parse_atjobs_contents(configuration, client_id,
-                                           atjobs.splitlines())
+    atjobs_path = os.path.join(
+        configuration.user_settings, client_dir, atjobs_name
+    )
+    status, msg = True, ""
+    atjobs_entries = parse_atjobs_contents(
+        configuration, client_id, atjobs.splitlines()
+    )
     # TODO: filter out broken lines before write?
     if write_file(atjobs, atjobs_path, _logger):
         msg = "Found and saved %d valid atjobs entries" % len(atjobs_entries)
     else:
         status = False
-        msg = 'ERROR: writing atjobs file'
+        msg = "ERROR: writing atjobs file"
     return (status, msg)
 
 
 def cron_match(configuration, cron_time, entry, _warn_mismatch=False):
     """Check if cron_time matches the time specs in entry"""
     _logger = configuration.logger
-    time_vals = {'minute': cron_time.minute, 'hour': cron_time.hour,
-                 'month': cron_time.month, 'dayofmonth': cron_time.day,
-                 'dayofweek': cron_time.weekday()}
+    time_vals = {
+        "minute": cron_time.minute,
+        "hour": cron_time.hour,
+        "month": cron_time.month,
+        "dayofmonth": cron_time.day,
+        "dayofweek": cron_time.weekday(),
+    }
     # TODO: extend to support e.g. */5, 8-16 and the likes?
-    for (name, val) in time_vals.items():
+    for name, val in time_vals.items():
         # Strip any leading zeros before integer match
-        if not fnmatch.fnmatch("%s" % val, entry[name].lstrip('0')):
+        if not fnmatch.fnmatch("%s" % val, entry[name].lstrip("0")):
             msg = "no cron_match on %s: %s vs %s" % (name, val, entry[name])
             if _warn_mismatch:
                 _logger.warning(msg)
@@ -305,7 +330,7 @@ def cron_match(configuration, cron_time, entry, _warn_mismatch=False):
 def at_remain(configuration, at_time, entry):
     """Return the number of minutes remaining before entry should run"""
     _logger = configuration.logger
-    return int((entry['time_stamp'] - at_time).total_seconds() // 60)
+    return int((entry["time_stamp"] - at_time).total_seconds() // 60)
 
 
 def _save_env(environ=None):
@@ -339,27 +364,32 @@ def run_cron_command(
     """
     logger = configuration.logger
     pid = multiprocessing.current_process().pid
-    client_id = crontab_entry['run_as']
-    command_str = ' '.join(command_list)
-    logger.info('(%s) run command for %s: %s' % (pid, target_path,
-                                                 command_list))
+    client_id = crontab_entry["run_as"]
+    command_str = " ".join(command_list)
+    logger.info(
+        "(%s) run command for %s: %s" % (pid, target_path, command_list)
+    )
 
     # logger.debug('(%s) run %s on behalf of %s' % (pid, command_str,
     #             client_id))
 
     try:
-        (function, user_arguments_dict) = parse_command_args(configuration,
-                                                             command_list)
+        function, user_arguments_dict = parse_command_args(
+            configuration, command_list
+        )
     except Exception as exc:
-        logger.error('(%s) failed to lookup function matching command %s' %
-                     (pid, command_str))
+        logger.error(
+            "(%s) failed to lookup function matching command %s"
+            % (pid, command_str)
+        )
         raise exc
 
-    form_method = 'post'
+    form_method = "post"
     target_op = "%s" % function
     csrf_limit = get_csrf_limit(configuration)
-    csrf_token = make_csrf_token(configuration, form_method, target_op,
-                                 client_id, csrf_limit)
+    csrf_token = make_csrf_token(
+        configuration, form_method, target_op, client_id, csrf_limit
+    )
     user_arguments_dict[csrf_field] = [csrf_token]
 
     # logger.debug('(%s) import main from %s' % (pid, function))
@@ -367,46 +397,55 @@ def run_cron_command(
     main = None
     saved_environ = _save_env(os.environ)
     try:
-        main = importlib.import_module('mig.shared.functionality.%s' %
-                                       function).main
+        main = importlib.import_module(
+            "mig.shared.functionality.%s" % function
+        ).main
 
         # logger.debug('(%s) run %s on %s for %s' % \
         #              (pid, function, user_arguments_dict, client_id))
 
         # Fake HTTP POST manually setting fields required for CSRF check
 
-        os.environ['HTTP_USER_AGENT'] = 'grid cron daemon'
-        os.environ['BACKEND_NAME'] = '%s' % function
-        os.environ['PATH_INFO'] = '%s.py' % function
-        os.environ['REQUEST_METHOD'] = form_method.upper()
+        os.environ["HTTP_USER_AGENT"] = "grid cron daemon"
+        os.environ["BACKEND_NAME"] = "%s" % function
+        os.environ["PATH_INFO"] = "%s.py" % function
+        os.environ["REQUEST_METHOD"] = form_method.upper()
         # We may need a REMOTE_ADDR for gdplog call even if not really enabled
-        os.environ['REMOTE_ADDR'] = '127.0.0.1'
-        (output_objects, (ret_code, ret_msg)) = main(client_id,
-                                                     user_arguments_dict)
+        os.environ["REMOTE_ADDR"] = "127.0.0.1"
+        output_objects, (ret_code, ret_msg) = main(
+            client_id, user_arguments_dict
+        )
         _restore_env(saved_environ, os.environ)
     except Exception as exc:
-        logger.error('(%s) failed to run %s main on %s: %s' %
-                     (pid, function, user_arguments_dict, exc))
+        logger.error(
+            "(%s) failed to run %s main on %s: %s"
+            % (pid, function, user_arguments_dict, exc)
+        )
         import traceback
-        logger.info('traceback:\n%s' % traceback.format_exc())
+
+        logger.info("traceback:\n%s" % traceback.format_exc())
         _restore_env(saved_environ, os.environ)
         raise exc
-    logger.info('(%s) done running command for %s: %s' %
-                (pid, target_path, command_str))
+    logger.info(
+        "(%s) done running command for %s: %s" % (pid, target_path, command_str)
+    )
 
     # logger.debug('(%s) raw output is: %s' % (pid, output_objects))
 
     try:
-        txt_out = txt_format(configuration, ret_code, ret_msg,
-                             output_objects)
+        txt_out = txt_format(configuration, ret_code, ret_msg, output_objects)
     except Exception as exc:
-        txt_out = 'internal command output text formatting failed'
-        logger.error('(%s) text formating failed: %s\nraw output is: %s %s %s'
-                     % (pid, exc, ret_code, ret_msg, output_objects))
+        txt_out = "internal command output text formatting failed"
+        logger.error(
+            "(%s) text formating failed: %s\nraw output is: %s %s %s"
+            % (pid, exc, ret_code, ret_msg, output_objects)
+        )
     if ret_code != 0:
-        logger.warning('(%s) command finished but with error code %d :\n%s'
-                       % (pid, ret_code, output_objects))
-        raise Exception('command error: %s' % txt_out)
+        logger.warning(
+            "(%s) command finished but with error code %d :\n%s"
+            % (pid, ret_code, output_objects)
+        )
+        raise Exception("command error: %s" % txt_out)
 
     # logger.debug('(%s) result was %s : %s:\n%s' % (pid, ret_code,
     #                                               ret_msg, txt_out))
@@ -423,27 +462,32 @@ def run_events_command(
     """
     logger = configuration.logger
     pid = multiprocessing.current_process().pid
-    client_id = rule['run_as']
-    command_str = ' '.join(command_list)
-    logger.info('(%s) run command for %s: %s' % (pid, target_path,
-                                                 command_list))
+    client_id = rule["run_as"]
+    command_str = " ".join(command_list)
+    logger.info(
+        "(%s) run command for %s: %s" % (pid, target_path, command_list)
+    )
 
     # logger.debug('(%s) run %s on behalf of %s' % (pid, command_str,
     #             client_id))
 
     try:
-        (function, user_arguments_dict) = parse_command_args(configuration,
-                                                             command_list)
+        function, user_arguments_dict = parse_command_args(
+            configuration, command_list
+        )
     except Exception as exc:
-        logger.error('(%s) failed to lookup function matching command %s' %
-                     (pid, command_str))
+        logger.error(
+            "(%s) failed to lookup function matching command %s"
+            % (pid, command_str)
+        )
         raise exc
 
-    form_method = 'post'
+    form_method = "post"
     target_op = "%s" % function
     csrf_limit = get_csrf_limit(configuration)
-    csrf_token = make_csrf_token(configuration, form_method, target_op,
-                                 client_id, csrf_limit)
+    csrf_token = make_csrf_token(
+        configuration, form_method, target_op, client_id, csrf_limit
+    )
     user_arguments_dict[csrf_field] = [csrf_token]
 
     # logger.debug('(%s) import main from %s' % (pid, function))
@@ -452,46 +496,55 @@ def run_events_command(
     txt_format = id
     saved_environ = _save_env(os.environ)
     try:
-        main = importlib.import_module('mig.shared.functionality.%s' %
-                                       function).main
+        main = importlib.import_module(
+            "mig.shared.functionality.%s" % function
+        ).main
 
         # logger.debug('(%s) run %s on %s for %s' % \
         #              (pid, function, user_arguments_dict, client_id))
 
         # Fake HTTP POST manually setting fields required for CSRF check
 
-        os.environ['HTTP_USER_AGENT'] = 'grid events daemon'
-        os.environ['BACKEND_NAME'] = '%s' % function
-        os.environ['PATH_INFO'] = '%s.py' % function
-        os.environ['REQUEST_METHOD'] = form_method.upper()
+        os.environ["HTTP_USER_AGENT"] = "grid events daemon"
+        os.environ["BACKEND_NAME"] = "%s" % function
+        os.environ["PATH_INFO"] = "%s.py" % function
+        os.environ["REQUEST_METHOD"] = form_method.upper()
         # We may need a REMOTE_ADDR for gdplog call even if not really enabled
-        os.environ['REMOTE_ADDR'] = '127.0.0.1'
-        (output_objects, (ret_code, ret_msg)) = main(client_id,
-                                                     user_arguments_dict)
+        os.environ["REMOTE_ADDR"] = "127.0.0.1"
+        output_objects, (ret_code, ret_msg) = main(
+            client_id, user_arguments_dict
+        )
         _restore_env(saved_environ, os.environ)
     except Exception as exc:
-        logger.error('(%s) failed to run %s main on %s: %s' %
-                     (pid, function, user_arguments_dict, exc))
+        logger.error(
+            "(%s) failed to run %s main on %s: %s"
+            % (pid, function, user_arguments_dict, exc)
+        )
         import traceback
-        logger.info('traceback:\n%s' % traceback.format_exc())
+
+        logger.info("traceback:\n%s" % traceback.format_exc())
         _restore_env(saved_environ, os.environ)
         raise exc
-    logger.info('(%s) done running command for %s: %s' %
-                (pid, target_path, command_str))
+    logger.info(
+        "(%s) done running command for %s: %s" % (pid, target_path, command_str)
+    )
 
     # logger.debug('(%s) raw output is: %s' % (pid, output_objects))
 
     try:
-        txt_out = txt_format(configuration, ret_code, ret_msg,
-                             output_objects)
+        txt_out = txt_format(configuration, ret_code, ret_msg, output_objects)
     except Exception as exc:
-        txt_out = 'internal command output text formatting failed'
-        logger.error('(%s) text formating failed: %s\nraw output is: %s %s %s'
-                     % (pid, exc, ret_code, ret_msg, output_objects))
+        txt_out = "internal command output text formatting failed"
+        logger.error(
+            "(%s) text formating failed: %s\nraw output is: %s %s %s"
+            % (pid, exc, ret_code, ret_msg, output_objects)
+        )
     if ret_code != 0:
-        logger.warning('(%s) command finished but with error code %d :\n%s'
-                       % (pid, ret_code, output_objects))
-        raise Exception('command error: %s' % txt_out)
+        logger.warning(
+            "(%s) command finished but with error code %d :\n%s"
+            % (pid, ret_code, output_objects)
+        )
+        raise Exception("command error: %s" % txt_out)
 
     # logger.debug('(%s) result was %s : %s:\n%s' % (pid, ret_code,
     #                                               ret_msg, txt_out))
@@ -500,29 +553,43 @@ def run_events_command(
 def main(_exit=sys.exit, _print=print):
     """Run module self-tests"""
     from mig.shared.conf import get_configuration_object
+
     conf = get_configuration_object()
-    client_id = '/C=DK/ST=NA/L=NA/O=NBI/OU=NA/CN=Jonas Bardino/emailAddress=bardino@nbi.ku.dk'
+    client_id = "/C=DK/ST=NA/L=NA/O=NBI/OU=NA/CN=Jonas Bardino/emailAddress=bardino@nbi.ku.dk"
     now = datetime.datetime.now()
     now = now.replace(second=0, microsecond=0)
     trigger_rule = {
-        'templates': [], 'run_as': client_id, 'rate_limit': '',
-        'vgrid_name': 'eScience', 'rule_id': 'test-dummy', 'match_dirs': False,
-        'match_files': True, 'arguments': ['+TRIGGERPATH+'], 'settle_time': '',
-        'path': '*.txt*', 'changes': ['modified'], 'action': 'trigger-created',
-        'match_recursive': True}
-    trigger_samples = [('abc.txt', 'modified'), ('subdir/def.txt', 'modified')]
+        "templates": [],
+        "run_as": client_id,
+        "rate_limit": "",
+        "vgrid_name": "eScience",
+        "rule_id": "test-dummy",
+        "match_dirs": False,
+        "match_files": True,
+        "arguments": ["+TRIGGERPATH+"],
+        "settle_time": "",
+        "path": "*.txt*",
+        "changes": ["modified"],
+        "action": "trigger-created",
+        "match_recursive": True,
+    }
+    trigger_samples = [("abc.txt", "modified"), ("subdir/def.txt", "modified")]
     print("Test trigger event map:")
-    for (path, change) in trigger_samples:
+    for path, change in trigger_samples:
         print("Expanded path vars for %s %s:" % (path, change))
         expanded = get_path_expand_map(path, trigger_rule, change)
-        for (key, val) in expanded.items():
+        for key, val in expanded.items():
             print("    %s: %s" % (key, val))
 
     crontab_lines = [
-        '* * * * * pack cront-test.txt cron-test-+SCHEDYEAR+-+SCHEDMONTH+-+SCHEDDAY+.zip']
+        "* * * * * pack cront-test.txt cron-test-+SCHEDYEAR+-+SCHEDMONTH+-+SCHEDDAY+.zip"
+    ]
     crontab_rules = parse_crontab_contents(conf, client_id, crontab_lines)
-    cron_times = [now, datetime.datetime(now.year + 1, 12, 24, 12, 42),
-                  datetime.datetime(now.year + 2, 1, 2, 9, 2)]
+    cron_times = [
+        now,
+        datetime.datetime(now.year + 1, 12, 24, 12, 42),
+        datetime.datetime(now.year + 2, 1, 2, 9, 2),
+    ]
     print("Test cron event map:")
     for rule in crontab_rules:
         for timestamp in cron_times:
@@ -530,11 +597,12 @@ def main(_exit=sys.exit, _print=print):
             print("Cron match against %s in rule: %s" % (timestamp, match))
             print("Expanded time %s vars:" % timestamp)
             expanded = get_time_expand_map(timestamp, rule)
-            for (key, val) in expanded.items():
+            for key, val in expanded.items():
                 print("    %s: %s" % (key, val))
     now_stamp = now.isoformat(" ")
-    atjobs_lines = ['%s touch at-test-+SCHEDYEAR+-+SCHEDMONTH+-+SCHEDDAY+.zip'
-                    % now_stamp]
+    atjobs_lines = [
+        "%s touch at-test-+SCHEDYEAR+-+SCHEDMONTH+-+SCHEDDAY+.zip" % now_stamp
+    ]
     print("parse at job lines: %s" % atjobs_lines)
     atjobs_rules = parse_atjobs_contents(conf, client_id, atjobs_lines)
     print("found at job rules: %s" % atjobs_rules)
@@ -542,9 +610,10 @@ def main(_exit=sys.exit, _print=print):
     for rule in atjobs_rules:
         for timestamp in cron_times:
             remain = at_remain(conf, timestamp, rule)
-            print("At %s job is %dm in the future for rule" % (
-                timestamp, remain))
+            print(
+                "At %s job is %dm in the future for rule" % (timestamp, remain)
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -33,13 +33,18 @@ from __future__ import absolute_import
 
 import datetime
 import fnmatch
+import importlib
+import multiprocessing
 import os
 import re
 import shlex
 
 from mig.shared.base import client_id_dir
-from mig.shared.defaults import crontab_name, atjobs_name
+from mig.shared.cmdapi import parse_command_args
+from mig.shared.defaults import crontab_name, csrf_field, atjobs_name
 from mig.shared.fileio import read_file, read_file_lines, write_file
+from mig.shared.handlers import get_csrf_limit, make_csrf_token
+from mig.shared.output import txt_format
 
 # Init global crontab regexp once and for all
 # Format: minute hour dayofmonth month dayofweek command
@@ -297,6 +302,158 @@ def at_remain(configuration, at_time, entry):
     """Return the number of minutes remaining before entry should run"""
     _logger = configuration.logger
     return int((entry['time_stamp'] - at_time).total_seconds() // 60)
+
+
+def run_cron_command(
+    command_list,
+    target_path,
+    crontab_entry,
+    configuration,
+):
+    """Run backend command built from command_list on behalf of user from
+    crontab_entry and with args mapped to the backend variables.
+    """
+    logger = configuration.logger
+    pid = multiprocessing.current_process().pid
+    client_id = crontab_entry['run_as']
+    command_str = ' '.join(command_list)
+    logger.info('(%s) run command for %s: %s' % (pid, target_path,
+                                                 command_list))
+
+    # logger.debug('(%s) run %s on behalf of %s' % (pid, command_str,
+    #             client_id))
+
+    (function, user_arguments_dict) = parse_command_args(configuration,
+                                                         command_list)
+
+    form_method = 'post'
+    target_op = "%s" % function
+    csrf_limit = get_csrf_limit(configuration)
+    csrf_token = make_csrf_token(configuration, form_method, target_op,
+                                 client_id, csrf_limit)
+    user_arguments_dict[csrf_field] = [csrf_token]
+
+    # logger.debug('(%s) import main from %s' % (pid, function))
+
+    main = None
+    try:
+        main = importlib.import_module('mig.shared.functionality.%s' %
+                                       function).main
+
+        # logger.debug('(%s) run %s on %s for %s' % \
+        #              (pid, function, user_arguments_dict, client_id))
+
+        # Fake HTTP POST manually setting fields required for CSRF check
+
+        os.environ['HTTP_USER_AGENT'] = 'grid cron daemon'
+        os.environ['BACKEND_NAME'] = '%s' % function
+        os.environ['PATH_INFO'] = '%s.py' % function
+        os.environ['REQUEST_METHOD'] = form_method.upper()
+        # We may need a REMOTE_ADDR for gdplog call even if not really enabled
+        os.environ['REMOTE_ADDR'] = '127.0.0.1'
+        (output_objects, (ret_code, ret_msg)) = main(client_id,
+                                                     user_arguments_dict)
+    except Exception as exc:
+        logger.error('(%s) failed to run %s main on %s: %s' %
+                     (pid, function, user_arguments_dict, exc))
+        import traceback
+        logger.info('traceback:\n%s' % traceback.format_exc())
+        raise exc
+    logger.info('(%s) done running command for %s: %s' %
+                (pid, target_path, command_str))
+
+    # logger.debug('(%s) raw output is: %s' % (pid, output_objects))
+
+    try:
+        txt_out = txt_format(configuration, ret_code, ret_msg,
+                             output_objects)
+    except Exception as exc:
+        txt_out = 'internal command output text formatting failed'
+        logger.error('(%s) text formating failed: %s\nraw output is: %s %s %s'
+                     % (pid, exc, ret_code, ret_msg, output_objects))
+    if ret_code != 0:
+        logger.warning('(%s) command finished but with error code %d :\n%s'
+                       % (pid, ret_code, output_objects))
+        raise Exception('command error: %s' % txt_out)
+
+    # logger.debug('(%s) result was %s : %s:\n%s' % (pid, ret_code,
+    #                                               ret_msg, txt_out))
+
+
+def run_events_command(
+    command_list,
+    target_path,
+    rule,
+    configuration,
+):
+    """Run backend command built from command_list on behalf of user from
+    rule and with args mapped to the backend variables.
+    """
+    logger = configuration.logger
+    pid = multiprocessing.current_process().pid
+    client_id = rule['run_as']
+    command_str = ' '.join(command_list)
+    logger.info('(%s) run command for %s: %s' % (pid, target_path,
+                                                 command_list))
+
+    # logger.debug('(%s) run %s on behalf of %s' % (pid, command_str,
+    #             client_id))
+
+    (function, user_arguments_dict) = parse_command_args(configuration,
+                                                         command_list)
+
+    form_method = 'post'
+    target_op = "%s" % function
+    csrf_limit = get_csrf_limit(configuration)
+    csrf_token = make_csrf_token(configuration, form_method, target_op,
+                                 client_id, csrf_limit)
+    user_arguments_dict[csrf_field] = [csrf_token]
+
+    # logger.debug('(%s) import main from %s' % (pid, function))
+
+    main = id
+    txt_format = id
+    try:
+        exec('from mig.shared.functionality.%s import main' % function)
+        exec('from mig.shared.output import txt_format')
+
+        # logger.debug('(%s) run %s on %s for %s' % \
+        #              (pid, function, user_arguments_dict, client_id))
+
+        # Fake HTTP POST manually setting fields required for CSRF check
+
+        os.environ['HTTP_USER_AGENT'] = 'grid events daemon'
+        os.environ['PATH_INFO'] = '%s.py' % function
+        os.environ['REQUEST_METHOD'] = form_method.upper()
+        # We may need a REMOTE_ADDR for gdplog call even if not really enabled
+        os.environ['REMOTE_ADDR'] = '127.0.0.1'
+        (output_objects, (ret_code, ret_msg)) = main(client_id,
+                                                     user_arguments_dict)
+    except Exception as exc:
+        logger.error('(%s) failed to run %s main on %s: %s' %
+                     (pid, function, user_arguments_dict, exc))
+        import traceback
+        logger.info('traceback:\n%s' % traceback.format_exc())
+        raise exc
+    logger.info('(%s) done running command for %s: %s' %
+                (pid, target_path, command_str))
+
+    # logger.debug('(%s) raw output is: %s' % (pid, output_objects))
+
+    try:
+        txt_out = txt_format(configuration, ret_code, ret_msg,
+                             output_objects)
+    except Exception as exc:
+        txt_out = 'internal command output text formatting failed'
+        logger.error('(%s) text formating failed: %s\nraw output is: %s %s %s'
+                     % (pid, exc, ret_code, ret_msg, output_objects))
+    if ret_code != 0:
+        logger.warning('(%s) command finished but with error code %d :\n%s'
+                       % (pid, ret_code, output_objects))
+        raise Exception('command error: %s' % txt_out)
+
+    # logger.debug('(%s) result was %s : %s:\n%s' % (pid, ret_code,
+    #                                               ret_msg, txt_out))
 
 
 if __name__ == '__main__':

--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # events - shared event trigger and cron/at helper functions
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #

--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -53,6 +53,27 @@ atjobs_pattern = "^([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2}):"
 atjobs_pattern += "([0-9]{2}) (.*)$"
 atjobs_expr = re.compile(atjobs_pattern)
 
+TRIGGER_EVENT = '_trigger_event'
+
+# Only cache rule misses for one minute at a time to catch rule updates.
+# Run complete expire cycle if miss cache exceeds expire size.
+
+MISS_CACHE_TTL = 60
+CACHE_EXPIRE_SIZE = 10000
+
+# Rate limit helpers
+
+(RATE_LIMIT_FIELD, SETTLE_TIME_FIELD) = ('rate_limit', 'settle_time')
+DEFAULT_PERIOD = 'm'
+DEFAULT_TIME = '0'
+UNIT_PERIODS = {
+    's': 1,
+    'm': 60,
+    'h': 60 * 60,
+    'd': 24 * 60 * 60,
+    'w': 7 * 24 * 60 * 60,
+}
+
 
 def get_path_expand_map(trigger_path, rule, state_change):
     """Generate a dictionary with the supported variables to be expanded and

--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -289,11 +289,11 @@ def cron_match(configuration, cron_time, entry):
     time_vals = {'minute': cron_time.minute, 'hour': cron_time.hour,
                  'month': cron_time.month, 'dayofmonth': cron_time.day,
                  'dayofweek': cron_time.weekday()}
-    # TODO: extend to support e.g. */5 and the likes?
+    # TODO: extend to support e.g. */5, 8-16 and the likes?
     for (name, val) in time_vals.items():
         # Strip any leading zeros before integer match
         if not fnmatch.fnmatch("%s" % val, entry[name].lstrip('0')):
-            _logger.debug("cron_match failed on %s: %s vs %s" %
+            _logger.debug("no cron_match on %s: %s vs %s" %
                           (name, val, entry[name]))
             return False
     return True

--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -54,8 +54,8 @@ crontab_expr = re.compile(crontab_pattern)
 # Init global atjobs regexp once and for all
 # ISO format with space between date and time and without msecs:
 # YYYY-MM-DD HH:MM:SS COMMAND
-atjobs_pattern = "^([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2}):"
-atjobs_pattern += "([0-9]{2}) (.*)$"
+atjobs_pattern = r"^([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2}):"
+atjobs_pattern += r"([0-9]{2}) (.*)$"
 atjobs_expr = re.compile(atjobs_pattern)
 
 TRIGGER_EVENT = "_trigger_event"
@@ -427,7 +427,8 @@ def run_cron_command(
         _restore_env(saved_environ, os.environ)
         raise exc
     logger.info(
-        "(%s) done running command for %s: %s" % (pid, target_path, command_str)
+        "(%s) done running command for %s: %s" % (
+            pid, target_path, command_str)
     )
 
     # logger.debug('(%s) raw output is: %s' % (pid, output_objects))
@@ -526,7 +527,8 @@ def run_events_command(
         _restore_env(saved_environ, os.environ)
         raise exc
     logger.info(
-        "(%s) done running command for %s: %s" % (pid, target_path, command_str)
+        "(%s) done running command for %s: %s" % (
+            pid, target_path, command_str)
     )
 
     # logger.debug('(%s) raw output is: %s' % (pid, output_objects))

--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -305,6 +305,26 @@ def at_remain(configuration, at_time, entry):
     return int((entry['time_stamp'] - at_time).total_seconds() // 60)
 
 
+def _save_env(environ=None):
+    """Save a copy of environ for later restore. If environ is left unset
+    os.environ will be used.
+    """
+    if environ is None:
+        environ = os.environ
+    return dict(environ)
+
+
+def _restore_env(saved, environ=None):
+    """Restore a previously saved enviroment dict into environ. If environ is
+    left unset os.environ will be used.
+    """
+    if environ is None:
+        environ = os.environ
+    environ.clear()
+    environ.update(saved)
+    return environ
+
+
 def run_cron_command(
     command_list,
     target_path,
@@ -341,6 +361,7 @@ def run_cron_command(
     # logger.debug('(%s) import main from %s' % (pid, function))
 
     main = None
+    saved_environ = _save_env(os.environ)
     try:
         main = importlib.import_module('mig.shared.functionality.%s' %
                                        function).main
@@ -358,11 +379,13 @@ def run_cron_command(
         os.environ['REMOTE_ADDR'] = '127.0.0.1'
         (output_objects, (ret_code, ret_msg)) = main(client_id,
                                                      user_arguments_dict)
+        _restore_env(saved_environ, os.environ)
     except Exception as exc:
         logger.error('(%s) failed to run %s main on %s: %s' %
                      (pid, function, user_arguments_dict, exc))
         import traceback
         logger.info('traceback:\n%s' % traceback.format_exc())
+        _restore_env(saved_environ, os.environ)
         raise exc
     logger.info('(%s) done running command for %s: %s' %
                 (pid, target_path, command_str))
@@ -422,6 +445,7 @@ def run_events_command(
 
     main = id
     txt_format = id
+    saved_environ = _save_env(os.environ)
     try:
         main = importlib.import_module('mig.shared.functionality.%s' %
                                        function).main
@@ -432,17 +456,20 @@ def run_events_command(
         # Fake HTTP POST manually setting fields required for CSRF check
 
         os.environ['HTTP_USER_AGENT'] = 'grid events daemon'
+        os.environ['BACKEND_NAME'] = '%s' % function
         os.environ['PATH_INFO'] = '%s.py' % function
         os.environ['REQUEST_METHOD'] = form_method.upper()
         # We may need a REMOTE_ADDR for gdplog call even if not really enabled
         os.environ['REMOTE_ADDR'] = '127.0.0.1'
         (output_objects, (ret_code, ret_msg)) = main(client_id,
                                                      user_arguments_dict)
+        _restore_env(saved_environ, os.environ)
     except Exception as exc:
         logger.error('(%s) failed to run %s main on %s: %s' %
                      (pid, function, user_arguments_dict, exc))
         import traceback
         logger.info('traceback:\n%s' % traceback.format_exc())
+        _restore_env(saved_environ, os.environ)
         raise exc
     logger.info('(%s) done running command for %s: %s' %
                 (pid, target_path, command_str))

--- a/mig/server/grid_cron.py
+++ b/mig/server/grid_cron.py
@@ -57,6 +57,7 @@ except ImportError:
     print('ERROR: the python watchdog module is required for this daemon')
     sys.exit(1)
 
+from mig.lib.daemon import check_stop, register_stop_handler, stop_running
 from mig.lib.events import get_time_expand_map, parse_crontab, cron_match, \
     parse_atjobs, at_remain
 from mig.shared.base import force_utf8, client_dir_id, client_id_dir
@@ -84,16 +85,7 @@ shared_state['base_dir_len'] = 0
 shared_state['crontab_inotify'] = None
 shared_state['crontab_handler'] = None
 
-_cron_event = '_cron_event'
-stop_running = multiprocessing.Event()
 (configuration, logger) = (None, None)
-
-
-def stop_handler(sig, frame):
-    """A simple signal handler to quit on Ctrl+C (SIGINT) in main"""
-    # Print blank line to avoid mix with Ctrl-C line
-    print('')
-    stop_running.set()
 
 
 def run_command(
@@ -510,7 +502,7 @@ def monitor(configuration):
     # logger.debug('(%s) loaded initial crontabs:\n%s' % (pid,
     # all_crontab_files))
 
-    while not stop_running.is_set():
+    while not check_stop():
         try:
             loop_start = datetime.datetime.now()
             loop_minute = loop_start.replace(second=0, microsecond=0)
@@ -550,7 +542,7 @@ def monitor(configuration):
                     del all_atjobs[atjobs_path]
         except KeyboardInterrupt:
             print('(%s) caught interrupt' % pid)
-            stop_running.set()
+            stop_running()
         except Exception as exc:
             logger.error('unexpected exception in monitor: %s' % exc)
             import traceback
@@ -595,7 +587,7 @@ if __name__ == '__main__':
     register_hangup_handler(configuration)
 
     # Allow clean shutdown on SIGINT only to main process
-    signal.signal(signal.SIGINT, stop_handler)
+    register_stop_handler(configuration)
 
     if not configuration.site_enable_crontab:
         err_msg = "Cron support is disabled in configuration!"
@@ -622,11 +614,11 @@ unless it is available in mig/server/MiGserver.conf
 
     logger.debug('(%s) Starting main loop' % main_pid)
     print("%s: Start main loop" % os.getpid())
-    while not stop_running.is_set():
+    while not check_stop():
         try:
             time.sleep(1)
         except KeyboardInterrupt:
-            stop_running.set()
+            stop_running()
             # NOTE: we can't be sure if SIGINT was sent to only main process
             #       so we make sure to propagate to monitor child
             print("Interrupt requested - close monitor and shutdown")

--- a/mig/server/grid_cron.py
+++ b/mig/server/grid_cron.py
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -56,13 +57,13 @@ except ImportError:
     print('ERROR: the python watchdog module is required for this daemon')
     sys.exit(1)
 
+from mig.lib.events import get_time_expand_map, parse_crontab, cron_match, \
+    parse_atjobs, at_remain
 from mig.shared.base import force_utf8, client_dir_id, client_id_dir
 from mig.shared.cmdapi import parse_command_args
 from mig.shared.conf import get_configuration_object
 from mig.shared.defaults import crontab_name, atjobs_name, cron_output_dir, \
     cron_log_name, cron_log_size, cron_log_cnt, csrf_field
-from mig.shared.events import get_time_expand_map, parse_crontab, cron_match, \
-    parse_atjobs, at_remain
 from mig.shared.fileio import makedirs_rec, scandir, walk
 from mig.shared.handlers import get_csrf_limit, make_csrf_token
 from mig.shared.job import fill_mrsl_template, new_job

--- a/mig/server/grid_cron.py
+++ b/mig/server/grid_cron.py
@@ -36,22 +36,18 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import datetime
-import fnmatch
-import glob
 import logging
 import logging.handlers
 import multiprocessing
 import os
 import signal
 import sys
-import tempfile
 import time
 
 try:
     from watchdog.observers import Observer
     from watchdog.events import PatternMatchingEventHandler, \
-        FileModifiedEvent, FileCreatedEvent, FileDeletedEvent, \
-        DirModifiedEvent, DirCreatedEvent, DirDeletedEvent
+        FileModifiedEvent, FileCreatedEvent, DirCreatedEvent
 except ImportError:
     print('ERROR: the python watchdog module is required for this daemon')
     sys.exit(1)
@@ -63,8 +59,7 @@ from mig.shared.base import force_utf8, client_dir_id, client_id_dir
 from mig.shared.conf import get_configuration_object
 from mig.shared.defaults import crontab_name, atjobs_name, cron_output_dir, \
     cron_log_name, cron_log_size, cron_log_cnt
-from mig.shared.fileio import makedirs_rec, scandir, walk
-from mig.shared.job import fill_mrsl_template, new_job
+from mig.shared.fileio import scandir, walk
 from mig.shared.logger import daemon_logger, register_hangup_handler
 
 # Global cron entry dictionaries with crontabs for all users

--- a/mig/server/grid_cron.py
+++ b/mig/server/grid_cron.py
@@ -38,7 +38,6 @@ from __future__ import absolute_import
 import datetime
 import fnmatch
 import glob
-import importlib
 import logging
 import logging.handlers
 import multiprocessing
@@ -59,17 +58,14 @@ except ImportError:
 
 from mig.lib.daemon import check_stop, register_stop_handler, stop_running
 from mig.lib.events import get_time_expand_map, parse_crontab, cron_match, \
-    parse_atjobs, at_remain
+    parse_atjobs, at_remain, run_cron_command
 from mig.shared.base import force_utf8, client_dir_id, client_id_dir
-from mig.shared.cmdapi import parse_command_args
 from mig.shared.conf import get_configuration_object
 from mig.shared.defaults import crontab_name, atjobs_name, cron_output_dir, \
-    cron_log_name, cron_log_size, cron_log_cnt, csrf_field
+    cron_log_name, cron_log_size, cron_log_cnt
 from mig.shared.fileio import makedirs_rec, scandir, walk
-from mig.shared.handlers import get_csrf_limit, make_csrf_token
 from mig.shared.job import fill_mrsl_template, new_job
 from mig.shared.logger import daemon_logger, register_hangup_handler
-from mig.shared.output import txt_format
 
 # Global cron entry dictionaries with crontabs for all users
 
@@ -86,82 +82,6 @@ shared_state['crontab_inotify'] = None
 shared_state['crontab_handler'] = None
 
 (configuration, logger) = (None, None)
-
-
-def run_command(
-    command_list,
-    target_path,
-    crontab_entry,
-    configuration,
-):
-    """Run backend command built from command_list on behalf of user from
-    crontab_entry and with args mapped to the backend variables.
-    """
-
-    pid = multiprocessing.current_process().pid
-    client_id = crontab_entry['run_as']
-    command_str = ' '.join(command_list)
-    logger.info('(%s) run command for %s: %s' % (pid, target_path,
-                                                 command_list))
-
-    # logger.debug('(%s) run %s on behalf of %s' % (pid, command_str,
-    #             client_id))
-
-    (function, user_arguments_dict) = parse_command_args(configuration,
-                                                         command_list)
-
-    form_method = 'post'
-    target_op = "%s" % function
-    csrf_limit = get_csrf_limit(configuration)
-    csrf_token = make_csrf_token(configuration, form_method, target_op,
-                                 client_id, csrf_limit)
-    user_arguments_dict[csrf_field] = [csrf_token]
-
-    # logger.debug('(%s) import main from %s' % (pid, function))
-
-    main = None
-    try:
-        main = importlib.import_module('mig.shared.functionality.%s' %
-                                       function).main
-
-        # logger.debug('(%s) run %s on %s for %s' % \
-        #              (pid, function, user_arguments_dict, client_id))
-
-        # Fake HTTP POST manually setting fields required for CSRF check
-
-        os.environ['HTTP_USER_AGENT'] = 'grid cron daemon'
-        os.environ['BACKEND_NAME'] = '%s' % function
-        os.environ['PATH_INFO'] = '%s.py' % function
-        os.environ['REQUEST_METHOD'] = form_method.upper()
-        # We may need a REMOTE_ADDR for gdplog call even if not really enabled
-        os.environ['REMOTE_ADDR'] = '127.0.0.1'
-        (output_objects, (ret_code, ret_msg)) = main(client_id,
-                                                     user_arguments_dict)
-    except Exception as exc:
-        logger.error('(%s) failed to run %s main on %s: %s' %
-                     (pid, function, user_arguments_dict, exc))
-        import traceback
-        logger.info('traceback:\n%s' % traceback.format_exc())
-        raise exc
-    logger.info('(%s) done running command for %s: %s' %
-                (pid, target_path, command_str))
-
-    # logger.debug('(%s) raw output is: %s' % (pid, output_objects))
-
-    try:
-        txt_out = txt_format(configuration, ret_code, ret_msg,
-                             output_objects)
-    except Exception as exc:
-        txt_out = 'internal command output text formatting failed'
-        logger.error('(%s) text formating failed: %s\nraw output is: %s %s %s'
-                     % (pid, exc, ret_code, ret_msg, output_objects))
-    if ret_code != 0:
-        logger.warning('(%s) command finished but with error code %d :\n%s'
-                       % (pid, ret_code, output_objects))
-        raise Exception('command error: %s' % txt_out)
-
-    # logger.debug('(%s) result was %s : %s:\n%s' % (pid, ret_code,
-    #                                               ret_msg, txt_out))
 
 
 class MiGCrontabEventHandler(PatternMatchingEventHandler):
@@ -389,7 +309,7 @@ def __handle_cronjob(configuration, client_id, timestamp, crontab_entry):
                     (argument, filled_argument))
         command_list.append(filled_argument)
     try:
-        run_command(command_list, client_id, crontab_entry, configuration)
+        run_cron_command(command_list, client_id, crontab_entry, configuration)
         logger.info('(%s) done running command for %s: %s' %
                     (pid, client_id, ' '.join(command_list)))
         __cron_info(configuration, client_id,

--- a/mig/server/grid_events.py
+++ b/mig/server/grid_events.py
@@ -61,7 +61,9 @@ except ImportError:
     sys.exit(1)
 
 from mig.lib.daemon import check_stop, register_stop_handler, stop_running
-from mig.lib.events import get_path_expand_map
+from mig.lib.events import CACHE_EXPIRE_SIZE, DEFAULT_PERIOD, DEFAULT_TIME, \
+    MISS_CACHE_TTL, RATE_LIMIT_FIELD, SETTLE_TIME_FIELD, TRIGGER_EVENT, \
+    UNIT_PERIODS, get_path_expand_map
 from mig.shared.base import force_utf8
 from mig.shared.cmdapi import parse_command_args
 from mig.shared.conf import get_configuration_object
@@ -101,27 +103,8 @@ shared_state['file_handler'] = None
 shared_state['rule_handler'] = None
 shared_state['rule_inotify'] = None
 
-# Only cache rule misses for one minute at a time to catch rule updates.
-# Run complete expire cycle if miss cache exceeds expire size.
-
-_miss_cache_ttl = 60
-_cache_expire_size = 10000
-
-# Rate limit helpers
-
-(_rate_limit_field, _settle_time_field) = ('rate_limit', 'settle_time')
-_default_period = 'm'
-_default_time = '0'
-_unit_periods = {
-    's': 1,
-    'm': 60,
-    'h': 60 * 60,
-    'd': 24 * 60 * 60,
-    'w': 7 * 24 * 60 * 60,
-}
 _hits_lock = threading.Lock()
 _rule_monitor_lock = threading.Lock()
-_trigger_event = '_trigger_event'
 (configuration, logger) = (None, None)
 
 
@@ -142,7 +125,7 @@ def make_fake_event(path, state, is_directory=False):
 
     # mark it a trigger event
 
-    setattr(fake, _trigger_event, True)
+    setattr(fake, TRIGGER_EVENT, True)
     return fake
 
 
@@ -151,7 +134,7 @@ def is_fake_event(event):
     system change.
     """
 
-    return getattr(event, _trigger_event, False)
+    return getattr(event, TRIGGER_EVENT, False)
 
 
 def extract_time_in_secs(rule, field):
@@ -164,26 +147,26 @@ def extract_time_in_secs(rule, field):
 
     limit_str = rule.get(field, '')
     if not limit_str:
-        limit_str = "%s" % _default_time
+        limit_str = "%s" % DEFAULT_TIME
 
     # NOTE: format is 3(s) or 52m
     # extract unit suffix letter and fall back to a raw value with default unit
 
-    unit_key = _default_period
+    unit_key = DEFAULT_PERIOD
     if not limit_str[-1:].isdigit():
         val_str = limit_str[:-1]
-        if limit_str[-1] in _unit_periods:
+        if limit_str[-1] in UNIT_PERIODS:
             unit_key = limit_str[-1]
         else:
 
             # print "ERROR: invalid time value %s ... fall back to defaults" % \
             #      limit_str
 
-            (unit_key, val_str) = (_default_period, _default_time)
+            (unit_key, val_str) = (DEFAULT_PERIOD, DEFAULT_TIME)
     else:
         val_str = limit_str
     try:
-        secs = float(val_str) * _unit_periods[unit_key]
+        secs = float(val_str) * UNIT_PERIODS[unit_key]
     except Exception as exc:
         print('(%s) ERROR: failed to parse time %s (%s)!' % (pid,
                                                              limit_str, exc))
@@ -203,13 +186,13 @@ def extract_hit_limit(rule, field):
     # NOTE: format is 3(/m) or 52/h
     # split string on slash and fall back to no limit and default unit
 
-    parts = (limit_str.split('/', 1) + [_default_period])[:2]
+    parts = (limit_str.split('/', 1) + [DEFAULT_PERIOD])[:2]
     (number, unit) = parts
     if not number.isdigit():
         number = '-1'
-    if unit not in _unit_periods:
-        unit = _default_period
-    return (int(number), _unit_periods[unit])
+    if unit not in UNIT_PERIODS:
+        unit = DEFAULT_PERIOD
+    return (int(number), UNIT_PERIODS[unit])
 
 
 def update_rule_hits(
@@ -225,8 +208,8 @@ def update_rule_hits(
     """
 
     pid = multiprocessing.current_process().pid
-    (_, hit_period) = extract_hit_limit(rule, _rate_limit_field)
-    settle_period = extract_time_in_secs(rule, _settle_time_field)
+    (_, hit_period) = extract_hit_limit(rule, RATE_LIMIT_FIELD)
+    settle_period = extract_time_in_secs(rule, SETTLE_TIME_FIELD)
 
     # logger.debug('(%s) update rule hits at %s for %s and %s %s %s' % (
     #    pid,
@@ -255,9 +238,9 @@ def get_rule_hits(rule, limit_field):
 
     pid = multiprocessing.current_process().pid
 
-    if limit_field == _rate_limit_field:
+    if limit_field == RATE_LIMIT_FIELD:
         (hit_count, hit_period) = extract_hit_limit(rule, limit_field)
-    elif limit_field == _settle_time_field:
+    elif limit_field == SETTLE_TIME_FIELD:
         (hit_count, hit_period) = (1, extract_time_in_secs(rule, limit_field))
     else:
         logger.error('(%s) get_rule_hits invalid limit_field %s' %
@@ -341,7 +324,7 @@ def wait_settled(
 
     pid = multiprocessing.current_process().pid
 
-    limit_field = _settle_time_field
+    limit_field = SETTLE_TIME_FIELD
     (path_history, _, hit_period) = get_path_hits(rule, path,
                                                   limit_field)
     period_history = [i for i in path_history if time_stamp - i[3]
@@ -797,8 +780,8 @@ class MiGFileEventHandler(PatternMatchingEventHandler):
 
         # Run settle time check first to only trigger rate limit if settled
 
-        for (name, field) in [('settle time', _settle_time_field),
-                              ('rate limit', _rate_limit_field)]:
+        for (name, field) in [('settle time', SETTLE_TIME_FIELD),
+                              ('rate limit', RATE_LIMIT_FIELD)]:
             if above_path_limit(rule, src_path, field, time_stamp):
                 above_limit = True
                 logger.warning('(%s) skip %s due to %s: %s' %
@@ -834,7 +817,7 @@ class MiGFileEventHandler(PatternMatchingEventHandler):
         self.__workflow_info(configuration, rule['vgrid_name'],
                              'handle %s for %s %s' % (rule['action'],
                                                       state, rel_src))
-        settle_secs = extract_time_in_secs(rule, _settle_time_field)
+        settle_secs = extract_time_in_secs(rule, SETTLE_TIME_FIELD)
         if settle_secs > 0.0:
             wait_secs = settle_secs
         else:
@@ -1193,7 +1176,7 @@ class MiGFileEventHandler(PatternMatchingEventHandler):
             # event_id))
             return
 
-        if len(miss_cache) < _cache_expire_size:
+        if len(miss_cache) < CACHE_EXPIRE_SIZE:
             return
 
         logger.info('(%s) expire all old entries in miss cache' % pid)
@@ -1202,7 +1185,7 @@ class MiGFileEventHandler(PatternMatchingEventHandler):
         # NOTE: we need to iterate over a copy of keys for in-place edits
         for event_id in list(miss_cache):
             time_stamp = miss_cache[event_id]
-            if time_stamp + _miss_cache_ttl < now:
+            if time_stamp + MISS_CACHE_TTL < now:
                 del miss_cache[event_id]
         logger.info('(%s) miss cache entries left after expire: %d' %
                     (pid, len(miss_cache)))
@@ -1215,7 +1198,7 @@ class MiGFileEventHandler(PatternMatchingEventHandler):
         pid = multiprocessing.current_process().pid
         event_id = self._get_event_id(event)
         recent = miss_cache.get(event_id, -1)
-        if recent + _miss_cache_ttl > time.time():
+        if recent + MISS_CACHE_TTL > time.time():
             # logger.debug('(%s) found recent miss for %s: %s' % (pid, event_id,
             #                                                     recent))
             return True

--- a/mig/server/grid_events.py
+++ b/mig/server/grid_events.py
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -59,27 +60,23 @@ except ImportError:
     print('ERROR: the python watchdog module is required for this daemon')
     sys.exit(1)
 
-try:
-    from mig.shared.base import force_utf8
-    from mig.shared.cmdapi import parse_command_args
-    from mig.shared.conf import get_configuration_object
-    from mig.shared.defaults import valid_trigger_changes, workflows_log_name, \
-        workflows_log_size, workflows_log_cnt, csrf_field, default_vgrid
-    from mig.shared.events import get_path_expand_map
-    from mig.shared.fileio import makedirs_rec, pickle, unpickle, scandir, walk
-    from mig.shared.handlers import get_csrf_limit, make_csrf_token
-    from mig.shared.job import fill_mrsl_template, new_job
-    from mig.shared.listhandling import frange
-    from mig.shared.logger import daemon_logger, register_hangup_handler
-    from mig.shared.safeinput import PARAM_START, PARAM_STOP, PARAM_JUMP
-    from mig.shared.serial import load
-    from mig.shared.vgrid import vgrid_valid_entities, vgrid_add_workflow_jobs, \
-        JOB_ID, JOB_CLIENT
-    from mig.shared.vgridaccess import check_vgrid_access
-    from mig.shared.workflows import get_wp_map, CONF
-except ImportError as ioe:
-    print("could not import mig modules!")
-    exit(1)
+from mig.lib.events import get_path_expand_map
+from mig.shared.base import force_utf8
+from mig.shared.cmdapi import parse_command_args
+from mig.shared.conf import get_configuration_object
+from mig.shared.defaults import valid_trigger_changes, workflows_log_name, \
+    workflows_log_size, workflows_log_cnt, csrf_field, default_vgrid
+from mig.shared.fileio import makedirs_rec, pickle, unpickle, scandir, walk
+from mig.shared.handlers import get_csrf_limit, make_csrf_token
+from mig.shared.job import fill_mrsl_template, new_job
+from mig.shared.listhandling import frange
+from mig.shared.logger import daemon_logger, register_hangup_handler
+from mig.shared.safeinput import PARAM_START, PARAM_STOP, PARAM_JUMP
+from mig.shared.serial import load
+from mig.shared.vgrid import vgrid_valid_entities, vgrid_add_workflow_jobs, \
+    JOB_ID, JOB_CLIENT
+from mig.shared.vgridaccess import check_vgrid_access
+from mig.shared.workflows import get_wp_map, CONF
 
 # Global trigger rule dictionaries with rules for all VGrids
 

--- a/mig/server/grid_events.py
+++ b/mig/server/grid_events.py
@@ -60,6 +60,7 @@ except ImportError:
     print('ERROR: the python watchdog module is required for this daemon')
     sys.exit(1)
 
+from mig.lib.daemon import check_stop, register_stop_handler, stop_running
 from mig.lib.events import get_path_expand_map
 from mig.shared.base import force_utf8
 from mig.shared.cmdapi import parse_command_args
@@ -121,15 +122,7 @@ _unit_periods = {
 _hits_lock = threading.Lock()
 _rule_monitor_lock = threading.Lock()
 _trigger_event = '_trigger_event'
-stop_running = multiprocessing.Event()
 (configuration, logger) = (None, None)
-
-
-def stop_handler(sig, frame):
-    """A simple signal handler to quit on Ctrl+C (SIGINT) in main"""
-    # Print blank line to avoid mix with Ctrl-C line
-    print('')
-    stop_running.set()
 
 
 def make_fake_event(path, state, is_directory=False):
@@ -1874,10 +1867,10 @@ def monitor(configuration, vgrid_name):
         if not load_status:
             logger.error('(%s) Failed to load / generate dir cache for: %s'
                          % (pid, vgrid_name))
-            stop_running.set()
+            stop_running()
 
     activated = False
-    while not stop_running.is_set():
+    while not check_stop():
 
         # NOTE: We delay launch of actual monitors until any rules are active,
         #       in order to avoid excessive load from vgrids without triggers.
@@ -1915,7 +1908,7 @@ def monitor(configuration, vgrid_name):
         except KeyboardInterrupt:
             print('(%s) caught interrupt' % pid)
             logger.info('(%s) caught interrupt' % pid)
-            stop_running.set()
+            stop_running()
 
     # Only save cache if rules were actually activated so dirs were monitored
     if activated:
@@ -1948,7 +1941,7 @@ if __name__ == '__main__':
     register_hangup_handler(configuration)
 
     # Allow clean shutdown on SIGINT only to main process
-    signal.signal(signal.SIGINT, stop_handler)
+    register_stop_handler(configuration)
 
     if not configuration.site_enable_events:
         err_msg = "Event trigger support is disabled in configuration!"
@@ -1997,14 +1990,14 @@ unless it is available in mig/server/MiGserver.conf
 
     logger.debug('(%s) Starting main loop' % main_pid)
     print("%s: Start main loop" % os.getpid())
-    while not stop_running.is_set():
+    while not check_stop():
         try:
 
             # Throttle down
 
             time.sleep(1)
         except KeyboardInterrupt:
-            stop_running.set()
+            stop_running()
             # NOTE: we can't be sure if SIGINT was sent to only main process
             #       so we make sure to propagate to all monitor children
             print("Interrupt requested - close monitors and shutdown")

--- a/mig/server/grid_events.py
+++ b/mig/server/grid_events.py
@@ -63,14 +63,12 @@ except ImportError:
 from mig.lib.daemon import check_stop, register_stop_handler, stop_running
 from mig.lib.events import CACHE_EXPIRE_SIZE, DEFAULT_PERIOD, DEFAULT_TIME, \
     MISS_CACHE_TTL, RATE_LIMIT_FIELD, SETTLE_TIME_FIELD, TRIGGER_EVENT, \
-    UNIT_PERIODS, get_path_expand_map
+    UNIT_PERIODS, get_path_expand_map, run_events_command
 from mig.shared.base import force_utf8
-from mig.shared.cmdapi import parse_command_args
 from mig.shared.conf import get_configuration_object
 from mig.shared.defaults import valid_trigger_changes, workflows_log_name, \
-    workflows_log_size, workflows_log_cnt, csrf_field, default_vgrid
+    workflows_log_size, workflows_log_cnt, default_vgrid
 from mig.shared.fileio import makedirs_rec, pickle, unpickle, scandir, walk
-from mig.shared.handlers import get_csrf_limit, make_csrf_token
 from mig.shared.job import fill_mrsl_template, new_job
 from mig.shared.listhandling import frange
 from mig.shared.logger import daemon_logger, register_hangup_handler
@@ -372,82 +370,6 @@ def recently_modified(path, time_stamp, slack=2.0):
         # logger.debug('(%s) OSError: %s' % (pid, exc))
 
     return result
-
-
-def run_command(
-    command_list,
-    target_path,
-    rule,
-    configuration,
-):
-    """Run backend command built from command_list on behalf of user from
-    rule and with args mapped to the backend variables.
-    """
-
-    pid = multiprocessing.current_process().pid
-    client_id = rule['run_as']
-    command_str = ' '.join(command_list)
-    logger.info('(%s) run command for %s: %s' % (pid, target_path,
-                                                 command_list))
-
-    # logger.debug('(%s) run %s on behalf of %s' % (pid, command_str,
-    #             client_id))
-
-    (function, user_arguments_dict) = parse_command_args(configuration,
-                                                         command_list)
-
-    form_method = 'post'
-    target_op = "%s" % function
-    csrf_limit = get_csrf_limit(configuration)
-    csrf_token = make_csrf_token(configuration, form_method, target_op,
-                                 client_id, csrf_limit)
-    user_arguments_dict[csrf_field] = [csrf_token]
-
-    # logger.debug('(%s) import main from %s' % (pid, function))
-
-    main = id
-    txt_format = id
-    try:
-        exec('from mig.shared.functionality.%s import main' % function)
-        exec('from mig.shared.output import txt_format')
-
-        # logger.debug('(%s) run %s on %s for %s' % \
-        #              (pid, function, user_arguments_dict, client_id))
-
-        # Fake HTTP POST manually setting fields required for CSRF check
-
-        os.environ['HTTP_USER_AGENT'] = 'grid events daemon'
-        os.environ['PATH_INFO'] = '%s.py' % function
-        os.environ['REQUEST_METHOD'] = form_method.upper()
-        # We may need a REMOTE_ADDR for gdplog call even if not really enabled
-        os.environ['REMOTE_ADDR'] = '127.0.0.1'
-        (output_objects, (ret_code, ret_msg)) = main(client_id,
-                                                     user_arguments_dict)
-    except Exception as exc:
-        logger.error('(%s) failed to run %s main on %s: %s' %
-                     (pid, function, user_arguments_dict, exc))
-        import traceback
-        logger.info('traceback:\n%s' % traceback.format_exc())
-        raise exc
-    logger.info('(%s) done running command for %s: %s' %
-                (pid, target_path, command_str))
-
-    # logger.debug('(%s) raw output is: %s' % (pid, output_objects))
-
-    try:
-        txt_out = txt_format(configuration, ret_code, ret_msg,
-                             output_objects)
-    except Exception as exc:
-        txt_out = 'internal command output text formatting failed'
-        logger.error('(%s) text formating failed: %s\nraw output is: %s %s %s'
-                     % (pid, exc, ret_code, ret_msg, output_objects))
-    if ret_code != 0:
-        logger.warning('(%s) command finished but with error code %d :\n%s'
-                       % (pid, ret_code, output_objects))
-        raise Exception('command error: %s' % txt_out)
-
-    # logger.debug('(%s) result was %s : %s:\n%s' % (pid, ret_code,
-    #                                               ret_msg, txt_out))
 
 
 def strip_base_dirs(path):
@@ -987,7 +909,8 @@ class MiGFileEventHandler(PatternMatchingEventHandler):
                                      (argument, filled_argument))
                 command_list.append(filled_argument)
             try:
-                run_command(command_list, target_path, rule, configuration)
+                run_events_command(command_list, target_path, rule,
+                                   configuration)
                 logger.info('(%s) done running command for %s: %s' %
                             (pid, target_path, ' '.join(command_list)))
                 self.__workflow_info(configuration, rule['vgrid_name'],

--- a/mig/shared/functionality/addcrontab.py
+++ b/mig/shared/functionality/addcrontab.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # addcrontab - schedule new cron/at user tasks back end
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -33,9 +34,9 @@ xmlrpc/jsonrpc.
 
 from __future__ import absolute_import
 
+from mig.lib.events import load_crontab, load_atjobs, parse_and_save_crontab, \
+    parse_and_save_atjobs
 from mig.shared import returnvalues
-from mig.shared.events import load_crontab, load_atjobs, \
-    parse_and_save_crontab, parse_and_save_atjobs
 from mig.shared.functional import validate_input_and_cert
 from mig.shared.handlers import safe_handler, get_csrf_limit
 from mig.shared.init import initialize_main_variables, find_entry
@@ -85,7 +86,7 @@ Please contact the %s site support (%s) if you think it should be enabled.
         return (output_objects, returnvalues.OK)
 
     logger.info('%s from %s' % (op_name, client_id))
-    #logger.debug('%s from %s: %s' % (op_name, client_id, accepted))
+    # logger.debug('%s from %s: %s' % (op_name, client_id, accepted))
 
     if not atjobs and not cronjobs:
         output_objects.append({'object_type': 'error_text', 'text':

--- a/mig/shared/functionality/crontab.py
+++ b/mig/shared/functionality/crontab.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # crontab - user task scheduling back end
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -47,14 +48,14 @@ import os
 import re
 import time
 
+from mig.lib.events import get_time_expand_map, load_crontab, load_atjobs, \
+    parse_and_save_crontab, parse_and_save_atjobs
 from mig.shared.base import client_id_dir
 from mig.shared.cmdapi import get_usage_map
 from mig.shared.defaults import crontab_name, cron_log_cnt, cron_output_dir, \
     cron_log_name, csrf_field
 from mig.shared import returnvalues
 from mig.shared.editing import cm_css, cm_javascript, cm_options, wrap_edit_area
-from mig.shared.events import get_time_expand_map, load_crontab, load_atjobs, \
-    parse_and_save_crontab, parse_and_save_atjobs
 from mig.shared.fileio import makedirs_rec
 from mig.shared.functional import validate_input_and_cert, REJECT_UNSET
 from mig.shared.handlers import safe_handler, get_csrf_limit, make_csrf_token
@@ -264,7 +265,7 @@ Please contact the %s site support (%s) if you think it should be enabled.
 
             # Make page with manage crontab and log tab
 
-            output_objects.append({'object_type': 'html_form', 'text':  '''
+            output_objects.append({'object_type': 'html_form', 'text': '''
     <div id="wrap-tabs" class="crontab-tabs">
 <ul>
 <li><a href="#manage-tab">Manage Tasks</a></li>
@@ -274,7 +275,7 @@ Please contact the %s site support (%s) if you think it should be enabled.
 
             # Display existing crontab in form to edit
 
-            output_objects.append({'object_type': 'html_form', 'text':  '''
+            output_objects.append({'object_type': 'html_form', 'text': '''
 <div id="manage-tab">
 '''})
 
@@ -399,13 +400,13 @@ and so on. You have the following commands at your disposal:<br/>
             output_objects.append({'object_type': 'html_form', 'text':
                                    html % fill_helpers})
 
-            output_objects.append({'object_type': 'html_form', 'text':  '''
+            output_objects.append({'object_type': 'html_form', 'text': '''
 </div>
 '''})
 
             # Display recent logs for this vgrid
 
-            output_objects.append({'object_type': 'html_form', 'text':  '''
+            output_objects.append({'object_type': 'html_form', 'text': '''
     <div id="log-tab">
 '''})
             output_objects.append({'object_type': 'sectionheader',
@@ -415,7 +416,7 @@ and so on. You have the following commands at your disposal:<br/>
 
             output_objects.append({'object_type': 'crontab_log', 'log_content':
                                    log_content})
-            output_objects.append({'object_type': 'html_form', 'text':  '''
+            output_objects.append({'object_type': 'html_form', 'text': '''
 </div>
 </div>
 <div class="col-lg-12" style="height: 100px;"></div>

--- a/mig/shared/functionality/lscrontab.py
+++ b/mig/shared/functionality/lscrontab.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # lscrontab - list scheduled cron/at user tasks back end
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -30,11 +31,12 @@ alternative to the full crontab back end, which expects a complete crontab or
 atjobs textarea and therefore is a bit cumbersome to use from e.g.
 xmlrpc/jsonrpc.
 """
+
 from __future__ import absolute_import
 
+from mig.lib.events import load_crontab, load_atjobs
 from mig.shared.defaults import keyword_all, csrf_field
 from mig.shared import returnvalues
-from mig.shared.events import load_crontab, load_atjobs
 from mig.shared.functional import validate_input_and_cert
 from mig.shared.handlers import get_csrf_limit, make_csrf_token
 from mig.shared.init import initialize_main_variables, find_entry
@@ -81,7 +83,7 @@ Please contact the %s site support (%s) if you think it should be enabled.
         return (output_objects, returnvalues.OK)
 
     logger.info('%s from %s' % (op_name, client_id))
-    #logger.debug('%s from %s: %s' % (op_name, client_id, accepted))
+    # logger.debug('%s from %s: %s' % (op_name, client_id, accepted))
 
     # Include handy CSRF helpers for use in subsequent client crontab changes
     csrf_helpers = {'csrf_field': csrf_field}

--- a/mig/shared/functionality/rmcrontab.py
+++ b/mig/shared/functionality/rmcrontab.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # rmcrontab - remove scheduled cron/at user tasks back end
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -33,9 +34,9 @@ xmlrpc/jsonrpc.
 
 from __future__ import absolute_import
 
+from mig.lib.events import load_crontab, load_atjobs, parse_and_save_crontab, \
+    parse_and_save_atjobs
 from mig.shared import returnvalues
-from mig.shared.events import load_crontab, load_atjobs, \
-    parse_and_save_crontab, parse_and_save_atjobs
 from mig.shared.functional import validate_input_and_cert
 from mig.shared.handlers import safe_handler, get_csrf_limit
 from mig.shared.init import initialize_main_variables, find_entry
@@ -85,7 +86,7 @@ Please contact the %s site support (%s) if you think it should be enabled.
         return (output_objects, returnvalues.OK)
 
     logger.info('%s from %s' % (op_name, client_id))
-    #logger.debug('%s from %s: %s' % (op_name, client_id, accepted))
+    # logger.debug('%s from %s: %s' % (op_name, client_id, accepted))
 
     if not atjobs and not cronjobs:
         output_objects.append({'object_type': 'error_text', 'text':

--- a/mig/shared/functionality/vgridworkflows.py
+++ b/mig/shared/functionality/vgridworkflows.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # vgridworkflows - data-driven workflows for owners and members
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -31,6 +32,7 @@ anywhere in their VGrid shared directory.
 Triggers are personal but the workflows page allows sharing of trigger job
 status and so on to ease workflow collaboration.
 """
+
 from __future__ import absolute_import
 
 from future import standard_library
@@ -40,13 +42,13 @@ import os
 import re
 import time
 
+from mig.lib.events import get_path_expand_map
 from mig.shared import returnvalues
 from mig.shared.base import client_id_dir
 from mig.shared.cmdapi import get_usage_map
 from mig.shared.defaults import keyword_all, keyword_auto, \
     valid_trigger_changes, valid_trigger_actions, workflows_log_name, \
     workflows_log_cnt, pending_states, final_states
-from mig.shared.events import get_path_expand_map
 from mig.shared.fileio import unpickle, makedirs_rec, move_file
 from mig.shared.functional import validate_input_and_cert, REJECT_UNSET
 from mig.shared.htmlgen import man_base_js, man_base_html
@@ -318,7 +320,7 @@ your disposal:<br/>
 
         # Make page with manage triggers tab and active jobs and log tab
 
-        output_objects.append({'object_type': 'html_form', 'text':  '''
+        output_objects.append({'object_type': 'html_form', 'text': '''
     <div id="wrap-tabs" class="workflow-tabs">
 <ul>
 <li><a href="#manage-tab">Manage Triggers</a></li>
@@ -328,7 +330,7 @@ your disposal:<br/>
 
         # Display existing triggers and form to add new ones
 
-        output_objects.append({'object_type': 'html_form', 'text':  '''
+        output_objects.append({'object_type': 'html_form', 'text': '''
 <div id="manage-tab">
 '''})
 
@@ -339,23 +341,23 @@ your disposal:<br/>
             {'object_type': 'html_form', 'text': helper_html})
 
         if configuration.site_enable_crontab:
-            output_objects.append({'object_type': 'html_form', 'text':  '''
+            output_objects.append({'object_type': 'html_form', 'text': '''
 <p>You can combine these workflows with the personal '''})
             output_objects.append({'object_type': 'link',
                                    'destination': 'crontab.py',
                                    'class': 'crontablink iconspace',
                                    'text': 'schedule task'})
-            output_objects.append({'object_type': 'html_form', 'text':  '''
+            output_objects.append({'object_type': 'html_form', 'text': '''
 facilities in case you want to trigger flows at given times rather than only
 in reaction to file system events.</p>
 '''})
-        output_objects.append({'object_type': 'html_form', 'text':  '''
+        output_objects.append({'object_type': 'html_form', 'text': '''
 </div>
 '''})
 
         # Display active trigger jobs and recent logs for this vgrid
 
-        output_objects.append({'object_type': 'html_form', 'text':  '''
+        output_objects.append({'object_type': 'html_form', 'text': '''
     <div id="jobs-tab">
     '''})
         output_objects.append({'object_type': 'sectionheader',
@@ -374,11 +376,11 @@ in reaction to file system events.</p>
     output_objects.append({'object_type': 'trigger_log', 'log_content':
                            log_content})
     if operation in show_operations:
-        output_objects.append({'object_type': 'html_form', 'text':  '''
+        output_objects.append({'object_type': 'html_form', 'text': '''
 </div>
 '''})
 
-        output_objects.append({'object_type': 'html_form', 'text':  '''
+        output_objects.append({'object_type': 'html_form', 'text': '''
 </div>
 '''})
     return (output_objects, returnvalues.OK)

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -29,8 +29,6 @@
 
 import datetime
 import os
-import shutil
-import time
 import unittest
 
 from mig.lib.events import _restore_env, _save_env, at_remain, cron_match, \
@@ -39,7 +37,6 @@ from mig.lib.events import main as events_main
 from mig.lib.events import parse_and_save_atjobs, parse_and_save_crontab, \
     parse_atjobs, parse_atjobs_contents, parse_crontab, \
     parse_crontab_contents, run_cron_command, run_events_command
-from mig.shared.base import distinguished_name_to_user
 from tests.support import MigTestCase, ensure_dirs_exist
 
 DUMMY_USER_DN = "/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com"
@@ -518,7 +515,7 @@ class MigLibEvents(MigTestCase):
         trigger_path = ""
         rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
         with self.assertRaises(ValueError):
-            expanded = get_path_expand_map(trigger_path, rule, "modified")
+            get_path_expand_map(trigger_path, rule, "modified")
 
     def test_get_time_expand_map_leap_year(self):
         """Test time expansion with leap year"""
@@ -1884,7 +1881,7 @@ invalid line
         }
         # NOTE: throws exception before log since values must be strings
         with self.assertRaises(Exception):
-            result = cron_match(self.configuration, now, test_job)
+            cron_match(self.configuration, now, test_job)
 
     # NOTE: no datetime support https://github.com/python/cpython/issues/67762
     @unittest.skip("enable if leap second handling is ever implemented")
@@ -1997,7 +1994,7 @@ invalid line
         }
         # NOTE: throws exception before log since values must be strings
         with self.assertRaises(Exception):
-            result = cron_match(self.configuration, now, test_job)
+            cron_match(self.configuration, now, test_job)
 
     # NOTE: no datetime support https://github.com/python/cpython/issues/67762
     @unittest.skip("enable if leap second handling is ever implemented")
@@ -2121,7 +2118,7 @@ invalid line
         }
         # NOTE: throws exception before log since values must be strings
         with self.assertRaises(Exception):
-            result = cron_match(self.configuration, now, test_job)
+            cron_match(self.configuration, now, test_job)
 
     def test_at_remain_with_future_leap_year(self):
         """Test at_remain with future leap year"""
@@ -2201,7 +2198,7 @@ invalid line
         }
         # NOTE: throws exception before log since values must be strings
         with self.assertRaises(Exception):
-            result = cron_match(self.configuration, now, test_job)
+            cron_match(self.configuration, now, test_job)
 
     def test_at_remain_with_past_leap_year(self):
         """Test at_remain with past leap year"""

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -80,7 +80,7 @@ class MigLibEvents(MigTestCase):
         """Test loading crontab from file"""
         crontab_path = os.path.join(self.configuration.user_settings,
                                     DUMMY_CLIENT_DIR, DUMMY_CRONTAB_NAME)
-        os.makedirs(os.path.dirname(crontab_path), exist_ok=True)
+        ensure_dirs_exist(os.path.dirname(crontab_path))
         with open(crontab_path, 'w') as fd:
             fd.write(DUMMY_CRONTAB_CONTENT)
 
@@ -91,7 +91,7 @@ class MigLibEvents(MigTestCase):
         """Test loading atjobs from file"""
         atjobs_path = os.path.join(self.configuration.user_settings,
                                    DUMMY_CLIENT_DIR, DUMMY_ATJOBS_NAME)
-        os.makedirs(os.path.dirname(atjobs_path), exist_ok=True)
+        ensure_dirs_exist(os.path.dirname(atjobs_path))
         with open(atjobs_path, 'w') as fd:
             fd.write(DUMMY_ATJOBS_CONTENT)
 
@@ -189,7 +189,7 @@ class MigLibEvents(MigTestCase):
         """Test parsing valid crontab file"""
         crontab_path = os.path.join(self.configuration.user_settings,
                                     DUMMY_CLIENT_DIR, DUMMY_CRONTAB_NAME)
-        os.makedirs(os.path.dirname(crontab_path), exist_ok=True)
+        ensure_dirs_exist(os.path.dirname(crontab_path))
         with open(crontab_path, 'w') as fd:
             fd.write(DUMMY_CRONTAB_CONTENT)
 
@@ -201,7 +201,7 @@ class MigLibEvents(MigTestCase):
         """Test parsing empty crontab file"""
         crontab_path = os.path.join(self.configuration.user_settings,
                                     DUMMY_CLIENT_DIR, DUMMY_CRONTAB_NAME)
-        os.makedirs(os.path.dirname(crontab_path), exist_ok=True)
+        ensure_dirs_exist(os.path.dirname(crontab_path))
         open(crontab_path, 'a').close()  # Create empty file
 
         parsed = parse_crontab(self.configuration, DUMMY_USER_DN, crontab_path)
@@ -211,7 +211,7 @@ class MigLibEvents(MigTestCase):
         """Test parsing valid atjobs file"""
         atjobs_path = os.path.join(self.configuration.user_settings,
                                    DUMMY_CLIENT_DIR, DUMMY_ATJOBS_NAME)
-        os.makedirs(os.path.dirname(atjobs_path), exist_ok=True)
+        ensure_dirs_exist(os.path.dirname(atjobs_path))
         with open(atjobs_path, 'w') as fd:
             fd.write(DUMMY_ATJOBS_CONTENT)
 
@@ -223,7 +223,7 @@ class MigLibEvents(MigTestCase):
         """Test parsing empty atjobs file"""
         atjobs_path = os.path.join(self.configuration.user_settings,
                                    DUMMY_CLIENT_DIR, DUMMY_ATJOBS_NAME)
-        os.makedirs(os.path.dirname(atjobs_path), exist_ok=True)
+        ensure_dirs_exist(os.path.dirname(atjobs_path))
         open(atjobs_path, 'a').close()  # Create empty file
 
         parsed = parse_atjobs(self.configuration, DUMMY_USER_DN, atjobs_path)

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# test_mig_lib_events - unit tests for evetns/cron helper functions
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# -- END_HEADER ---
+#
+
+"""Unit tests for events/cron helper functions"""
+
+import datetime
+import os
+import shutil
+import time
+import unittest
+
+from mig.lib.events import parse_crontab, cron_match, parse_atjobs, at_remain, \
+    run_cron_command
+from tests.support import MigTestCase, ensure_dirs_exist
+
+DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com'
+DUMMY_FULL_NAME = "Test User"
+DUMMY_ORGANIZATION = "Test Org"
+DUMMY_EMAIL = "test@example.com"
+DUMMY_SKIP_EMAIL = ''
+DUMMY_CLIENT_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.com'
+DUMMY_CRON_JOB = {'command': ['echo', 'test'], 'run_as': DUMMY_USER_DN,
+                  # 'minute': '*', 'hour': '*', 'dayofmonth': '*', 'month': '*',
+                  # 'dayofweek': '*'
+                  }
+DUMMY_CRONTAB_NAME = 'crontab'
+DUMMY_ATJOBS_NAME = 'atjobs'
+DUMMY_CRONTAB_CONTENT = """* * * * * /bin/test_command
+30 2 * * * /usr/bin/another_command"""
+DUMMY_ATJOBS_CONTENT = """2042-01-01 12:34:56 /bin/future_command"""
+
+
+class MigLibCron(MigTestCase):
+    """Unit tests for cron helper functions"""
+
+    def _provide_configuration(self):
+        """Prepare isolated test config"""
+        return 'testconfig'
+
+    def before_each(self):
+        """Set up test configuration and reset state before each test"""
+
+        # TODO: can we remove this hack?
+        # Pass configuration and logger to cron module
+        # mig.lib.events.configuration = self.configuration
+        # mig.lib.events.logger = self.configuration.logger
+
+        # Enable cron in configuration
+        self.configuration.site_enable_crontab = True
+
+        ensure_dirs_exist(self.configuration.user_db_home)
+        ensure_dirs_exist(self.configuration.user_home)
+        ensure_dirs_exist(self.configuration.user_settings)
+        ensure_dirs_exist(self.configuration.user_cache)
+        ensure_dirs_exist(self.configuration.mig_system_files)
+
+        # Prepare user DB with a single dummy user for all tests
+        self._provision_test_user(self, DUMMY_USER_DN)
+
+    def test_parse_valid_crontab(self):
+        """Test parsing of valid crontab content"""
+        # Create dummy crontab file
+        crontab_path = os.path.join(self.configuration.user_settings,
+                                    DUMMY_CLIENT_DIR, DUMMY_CRONTAB_NAME)
+        os.makedirs(os.path.dirname(crontab_path), exist_ok=True)
+        with open(crontab_path, 'w') as f:
+            f.write(DUMMY_CRONTAB_CONTENT)
+
+        parsed = parse_crontab(self.configuration, DUMMY_USER_DN, crontab_path)
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+
+    def test_parse_empty_crontab(self):
+        """Test handling of empty crontab file"""
+        crontab_path = os.path.join(self.configuration.user_settings,
+                                    DUMMY_CLIENT_DIR, DUMMY_CRONTAB_NAME)
+        os.makedirs(os.path.dirname(crontab_path), exist_ok=True)
+        open(crontab_path, 'a').close()  # Create empty file
+
+        parsed = parse_crontab(self.configuration, DUMMY_USER_DN, crontab_path)
+        self.assertEqual(parsed, [])
+
+    def test_cron_match_current_minute(self):
+        """Test cron_match identifies current time match"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '*', 'hour': '*',
+                    'day': '*', 'month': '*', 'dayofweek': '*',
+                    'dayofmonth': '*'}
+        self.assertTrue(cron_match(self.configuration, now, test_job))
+
+    def test_cron_match_specific_time(self):
+        """Test cron_match rejects non-matching time"""
+        now = datetime.datetime.now().replace(hour=3, minute=15, second=0, microsecond=0)
+        test_job = {'minute': '30', 'hour': '2',
+                    'day': '*', 'month': '*', 'dayofweek': '*',
+                    'dayofmonth': '*'}
+        self.assertFalse(cron_match(self.configuration, now, test_job))
+
+    def test_parse_atjobs_future_job(self):
+        """Test parse_atjobs recognizes future jobs"""
+        # Create dummy atjobs file
+        atjobs_path = os.path.join(self.configuration.user_settings,
+                                   DUMMY_CLIENT_DIR, DUMMY_ATJOBS_NAME)
+        os.makedirs(os.path.dirname(atjobs_path), exist_ok=True)
+        with open(atjobs_path, 'w') as f:
+            f.write(DUMMY_ATJOBS_CONTENT)
+
+        parsed = parse_atjobs(self.configuration, DUMMY_USER_DN, atjobs_path)
+        self.assertEqual(len(parsed), 1)
+        self.assertTrue(parsed[0]['time_stamp'] > datetime.datetime.now())
+
+    @unittest.skip("enable once run_cron_handler is migrated")
+    def test_run_cron_handler_valid_job(self):
+        """Test run_cron_handler creates worker for valid job without crash"""
+        timestamp = datetime.datetime.now()
+        caught = None
+        try:
+            run_cron_handler(self.configuration, DUMMY_USER_DN, timestamp,
+                             DUMMY_CRON_JOB)
+        except Exception as exc:
+            caught = exc
+        self.assertEqual(caught, None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -296,6 +296,209 @@ class MigLibEvents(MigTestCase):
                 any('failed to run' in msg or 'failed to lookup' in msg
                     for msg in log_capture.output))
 
+    def test_cron_match_edge_cases(self):
+        """Test cron_match with edge case times"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_cases = [
+            ({'minute': '0', 'hour': '0', 'dayofmonth': '1', 'month': '1', 'dayofweek': '0'},
+             now.replace(hour=0, minute=0, day=1, month=1)),
+            ({'minute': '59', 'hour': '23', 'dayofmonth': '31', 'month': '12', 'dayofweek': '6'},
+             now.replace(hour=23, minute=59, day=31, month=12)),
+        ]
+        for job, match_time in test_cases:
+            self.assertEqual(cron_match(self.configuration, match_time, job),
+                             match_time == now)
+
+    def test_at_remain_edge_cases(self):
+        """Test at_remain with edge case times"""
+        now = datetime.datetime.now()
+        test_cases = [
+            (now + datetime.timedelta(seconds=30), 0),  # Less than 1 minute
+            # 1 minute 30 seconds
+            (now + datetime.timedelta(minutes=1, seconds=30), 1),
+            (now + datetime.timedelta(hours=1), 60),  # 1 hour
+            (now + datetime.timedelta(days=1), 1440),  # 1 day
+        ]
+        for future_time, expected_minutes in test_cases:
+            test_job = {'time_stamp': future_time}
+            remaining = at_remain(self.configuration, now, test_job)
+            self.assertEqual(remaining, expected_minutes)
+
+    def test_get_path_expand_map_empty_path(self):
+        """Test path expansion with empty path"""
+        trigger_path = ''
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        with self.assertRaises(ValueError):
+            expanded = get_path_expand_map(trigger_path, rule, 'modified')
+
+    def test_get_time_expand_map_leap_year(self):
+        """Test time expansion with leap year"""
+        timestamp = datetime.datetime(2024, 2, 29, 12, 0)  # Leap day
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '29')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '02')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2024')
+
+    def test_run_cron_command_with_special_chars(self):
+        """Test running cron command with special characters"""
+        target_path = 'test file with spaces.txt'
+        command_list = ['touch', target_path]
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        try:
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail("run_cron_command raised an exception: %s" % exc)
+
+    def test_run_events_command_with_special_chars(self):
+        """Test running events command with special characters"""
+        target_path = 'test file with spaces.txt'
+        command_list = ['touch', target_path]
+        rule = {'run_as': DUMMY_USER_DN}
+        try:
+            run_events_command(command_list, target_path, rule,
+                               self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail("run_events_command raised an exception: %s" % exc)
+
+    def test_parse_crontab_with_comments(self):
+        """Test parsing crontab with comments"""
+        crontab_content = """# This is a comment
+* * * * * /bin/test_command
+# Another comment
+30 2 * * * /usr/bin/another_command"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+
+    def test_parse_atjobs_with_comments(self):
+        """Test parsing atjobs with comments"""
+        atjobs_content = """# This is a comment
+2042-01-01 12:34:56 /bin/future_command
+# Another comment"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'], ['/bin/future_command'])
+
+    def test_cron_match_with_wildcards(self):
+        """Test cron_match with various wildcard combinations"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_cases = [
+            ({'minute': '*', 'hour': '*', 'dayofmonth': '*', 'month': '*', 'dayofweek': '*'},
+             True),
+            ({'minute': '15', 'hour': '*', 'dayofmonth': '*', 'month': '*', 'dayofweek': '*'},
+             now.minute == 15),
+            ({'minute': '*', 'hour': '3', 'dayofmonth': '*', 'month': '*', 'dayofweek': '*'},
+             now.hour == 3),
+            ({'minute': '*', 'hour': '*', 'dayofmonth': '15', 'month': '*', 'dayofweek': '*'},
+             now.day == 15),
+            ({'minute': '*', 'hour': '*', 'dayofmonth': '*', 'month': '6', 'dayofweek': '*'},
+             now.month == 6),
+            ({'minute': '*', 'hour': '*', 'dayofmonth': '*', 'month': '*', 'dayofweek': '0'},
+             now.weekday() == 0),
+        ]
+        for job, expected in test_cases:
+            self.assertEqual(cron_match(
+                self.configuration, now, job), expected)
+
+    @unittest.skip("enable next if ever relevant - fails with TypeError")
+    def test_at_remain_with_timezones(self):
+        """Test at_remain with different timezones"""
+        now = datetime.datetime.now()
+        test_cases = [
+            (now.astimezone(datetime.timezone.utc) +
+             datetime.timedelta(minutes=30), 30),
+            (now.astimezone(datetime.timezone.utc) -
+             datetime.timedelta(minutes=30), -30),
+        ]
+        for future_time, expected_minutes in test_cases:
+            test_job = {'time_stamp': future_time}
+            remaining = at_remain(self.configuration, now, test_job)
+            self.assertEqual(remaining, expected_minutes)
+
+    def test_get_path_expand_map_with_relative_path(self):
+        """Test path expansion with relative path"""
+        trigger_path = '../relative/path/file.txt'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertEqual(expanded['+TRIGGERPATH+'],
+                         '../relative/path/file.txt')
+        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file.txt')
+        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
+        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+
+    def test_get_time_expand_map_with_milliseconds(self):
+        """Test time expansion with milliseconds"""
+        timestamp = datetime.datetime(2023, 1, 2, 9, 2, 30, 123456)
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDSECOND+'], '30')
+        self.assertEqual(expanded['+SCHEDMINUTE+'], '02')
+        self.assertEqual(expanded['+SCHEDHOUR+'], '09')
+        self.assertEqual(expanded['+SCHEDDAY+'], '02')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+        self.assertEqual(expanded['+SCHEDDAYOFWEEK+'], '0')
+
+    def test_run_cron_command_with_long_command(self):
+        """Test running cron command with long command"""
+        target_path = 'test.txt'
+        long_command = ['touch'] + ['arg'] * 100
+        command_list = long_command
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        try:
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail("run_cron_command raised an exception: %s" % exc)
+
+    def test_run_events_command_with_long_command(self):
+        """Test running events command with long command"""
+        target_path = 'test.txt'
+        long_command = ['touch'] + ['arg'] * 100
+        command_list = long_command
+        rule = {'run_as': DUMMY_USER_DN}
+        try:
+            run_events_command(command_list, target_path, rule,
+                               self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail("run_events_command raised an exception: %s" % exc)
+
+    def test_parse_crontab_with_invalid_lines(self):
+        """Test parsing crontab with invalid lines"""
+        crontab_content = """* * * * * /bin/test_command
+invalid line
+30 2 * * * /usr/bin/another_command"""
+        crontab_lines = crontab_content.splitlines()
+        with self.assertLogs(level='WARNING') as log_capture:
+            parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                            crontab_lines)
+            self.assertEqual(len(parsed), 2)
+            self.assertTrue(any('Skip invalid crontab line' in msg
+                                for msg in log_capture.output))
+
+    def test_parse_atjobs_with_invalid_lines(self):
+        """Test parsing atjobs with invalid lines"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/future_command
+invalid line
+2042-01-02 12:34:56 /bin/another_command"""
+        atjobs_lines = atjobs_content.splitlines()
+        with self.assertLogs(level='WARNING') as log_capture:
+            parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                           atjobs_lines)
+            self.assertEqual(len(parsed), 2)
+            self.assertTrue(any('Skip invalid atjobs line' in msg
+                                for msg in log_capture.output))
+
 
 class MigLibEvents__legacy_main(MigTestCase):
     """Unit tests for legacy events self-checks"""

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -2,7 +2,7 @@
 #
 # --- BEGIN_HEADER ---
 #
-# test_mig_lib_events - unit tests for evetns/cron helper functions
+# test_mig_lib_events - unit tests for events/cron helper functions
 # Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
@@ -25,7 +25,7 @@
 # -- END_HEADER ---
 #
 
-"""Unit tests for events/cron helper functions"""
+"""Unit tests for shared events helper functions"""
 
 import datetime
 import os
@@ -34,7 +34,11 @@ import time
 import unittest
 
 from mig.lib.events import parse_crontab, cron_match, parse_atjobs, at_remain, \
-    run_cron_command
+    get_path_expand_map, get_time_expand_map, load_crontab, load_atjobs, \
+    parse_crontab_contents, parse_atjobs_contents, parse_and_save_crontab, \
+    parse_and_save_atjobs, run_cron_command, run_events_command, \
+    main as events_main
+from mig.shared.base import distinguished_name_to_user
 from tests.support import MigTestCase, ensure_dirs_exist
 
 DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com'
@@ -43,10 +47,7 @@ DUMMY_ORGANIZATION = "Test Org"
 DUMMY_EMAIL = "test@example.com"
 DUMMY_SKIP_EMAIL = ''
 DUMMY_CLIENT_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.com'
-DUMMY_CRON_JOB = {'command': ['echo', 'test'], 'run_as': DUMMY_USER_DN,
-                  # 'minute': '*', 'hour': '*', 'dayofmonth': '*', 'month': '*',
-                  # 'dayofweek': '*'
-                  }
+DUMMY_CRON_JOB = {'command': ['touch', 'test.txt'], 'run_as': DUMMY_USER_DN}
 DUMMY_CRONTAB_NAME = 'crontab'
 DUMMY_ATJOBS_NAME = 'atjobs'
 DUMMY_CRONTAB_CONTENT = """* * * * * /bin/test_command
@@ -54,8 +55,8 @@ DUMMY_CRONTAB_CONTENT = """* * * * * /bin/test_command
 DUMMY_ATJOBS_CONTENT = """2042-01-01 12:34:56 /bin/future_command"""
 
 
-class MigLibCron(MigTestCase):
-    """Unit tests for cron helper functions"""
+class MigLibEvents(MigTestCase):
+    """Unit tests for events helper functions"""
 
     def _provide_configuration(self):
         """Prepare isolated test config"""
@@ -63,13 +64,7 @@ class MigLibCron(MigTestCase):
 
     def before_each(self):
         """Set up test configuration and reset state before each test"""
-
-        # TODO: can we remove this hack?
-        # Pass configuration and logger to cron module
-        # mig.lib.events.configuration = self.configuration
-        # mig.lib.events.logger = self.configuration.logger
-
-        # Enable cron in configuration
+        # Enable events in configuration
         self.configuration.site_enable_crontab = True
 
         ensure_dirs_exist(self.configuration.user_db_home)
@@ -81,27 +76,157 @@ class MigLibCron(MigTestCase):
         # Prepare user DB with a single dummy user for all tests
         self._provision_test_user(self, DUMMY_USER_DN)
 
-    def test_parse_valid_crontab(self):
-        """Test parsing of valid crontab content"""
-        # Create dummy crontab file
+    def test_load_crontab(self):
+        """Test loading crontab from file"""
         crontab_path = os.path.join(self.configuration.user_settings,
                                     DUMMY_CLIENT_DIR, DUMMY_CRONTAB_NAME)
         os.makedirs(os.path.dirname(crontab_path), exist_ok=True)
-        with open(crontab_path, 'w') as f:
-            f.write(DUMMY_CRONTAB_CONTENT)
+        with open(crontab_path, 'w') as fd:
+            fd.write(DUMMY_CRONTAB_CONTENT)
+
+        crontab = load_crontab(DUMMY_USER_DN, self.configuration)
+        self.assertIn('* * * * * /bin/test_command', crontab)
+
+    def test_load_atjobs(self):
+        """Test loading atjobs from file"""
+        atjobs_path = os.path.join(self.configuration.user_settings,
+                                   DUMMY_CLIENT_DIR, DUMMY_ATJOBS_NAME)
+        os.makedirs(os.path.dirname(atjobs_path), exist_ok=True)
+        with open(atjobs_path, 'w') as fd:
+            fd.write(DUMMY_ATJOBS_CONTENT)
+
+        atjobs = load_atjobs(DUMMY_USER_DN, self.configuration)
+        self.assertIn('2042-01-01 12:34:56 /bin/future_command', atjobs)
+
+    def test_parse_crontab_contents(self):
+        """Test parsing crontab content lines"""
+        crontab_lines = DUMMY_CRONTAB_CONTENT.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+
+    def test_parse_atjobs_contents(self):
+        """Test parsing atjobs content lines"""
+        atjobs_lines = DUMMY_ATJOBS_CONTENT.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'], ['/bin/future_command'])
+
+    def test_parse_and_save_crontab(self):
+        """Test parsing and saving crontab"""
+        crontab = DUMMY_CRONTAB_CONTENT
+        status, msg = parse_and_save_crontab(crontab, DUMMY_USER_DN,
+                                             self.configuration)
+        self.assertTrue(status)
+        self.assertIn('valid crontab entries', msg)
+
+    def test_parse_and_save_atjobs(self):
+        """Test parsing and saving atjobs"""
+        atjobs = DUMMY_ATJOBS_CONTENT
+        status, msg = parse_and_save_atjobs(atjobs, DUMMY_USER_DN,
+                                            self.configuration)
+        self.assertTrue(status)
+        self.assertIn('valid atjobs entries', msg)
+
+    def test_cron_match(self):
+        """Test cron time matching"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '*', 'hour': '*',
+                    'dayofmonth': '*', 'month': '*', 'dayofweek': '*'}
+        self.assertTrue(cron_match(self.configuration, now, test_job))
+
+    def test_at_remain(self):
+        """Test at job remaining time calculation"""
+        now = datetime.datetime.now()
+        future_time = now + datetime.timedelta(minutes=30)
+        test_job = {'time_stamp': future_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, 30)
+
+    def test_get_path_expand_map(self):
+        """Test path expansion map generation"""
+        trigger_path = '/test/path/file.txt'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertIn('+TRIGGERPATH+', expanded)
+        self.assertEqual(expanded['+TRIGGERPATH+'], trigger_path)
+
+    def test_get_time_expand_map(self):
+        """Test time expansion map generation"""
+        timestamp = datetime.datetime(2023, 1, 2, 9, 2)
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertIn('+SCHEDYEAR+', expanded)
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+
+    def test_run_cron_command(self):
+        """Test running cron command"""
+        target_path = 'test.txt'
+        command_list = ['touch', target_path]
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        try:
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail("run_cron_command raised an exception: %s" % exc)
+
+    def test_run_events_command(self):
+        """Test running events command"""
+        target_path = 'test.txt'
+        command_list = ['touch', target_path]
+        rule = {'run_as': DUMMY_USER_DN}
+        try:
+            run_events_command(command_list, target_path, rule,
+                               self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail("run_events_command raised an exception: %s" % exc)
+
+    def test_parse_valid_crontab_file(self):
+        """Test parsing valid crontab file"""
+        crontab_path = os.path.join(self.configuration.user_settings,
+                                    DUMMY_CLIENT_DIR, DUMMY_CRONTAB_NAME)
+        os.makedirs(os.path.dirname(crontab_path), exist_ok=True)
+        with open(crontab_path, 'w') as fd:
+            fd.write(DUMMY_CRONTAB_CONTENT)
 
         parsed = parse_crontab(self.configuration, DUMMY_USER_DN, crontab_path)
         self.assertEqual(len(parsed), 2)
         self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
 
-    def test_parse_empty_crontab(self):
-        """Test handling of empty crontab file"""
+    def test_parse_empty_crontab_file(self):
+        """Test parsing empty crontab file"""
         crontab_path = os.path.join(self.configuration.user_settings,
                                     DUMMY_CLIENT_DIR, DUMMY_CRONTAB_NAME)
         os.makedirs(os.path.dirname(crontab_path), exist_ok=True)
         open(crontab_path, 'a').close()  # Create empty file
 
         parsed = parse_crontab(self.configuration, DUMMY_USER_DN, crontab_path)
+        self.assertEqual(parsed, [])
+
+    def test_parse_valid_atjobs_file(self):
+        """Test parsing valid atjobs file"""
+        atjobs_path = os.path.join(self.configuration.user_settings,
+                                   DUMMY_CLIENT_DIR, DUMMY_ATJOBS_NAME)
+        os.makedirs(os.path.dirname(atjobs_path), exist_ok=True)
+        with open(atjobs_path, 'w') as fd:
+            fd.write(DUMMY_ATJOBS_CONTENT)
+
+        parsed = parse_atjobs(self.configuration, DUMMY_USER_DN, atjobs_path)
+        self.assertEqual(len(parsed), 1)
+        self.assertTrue(parsed[0]['time_stamp'] > datetime.datetime.now())
+
+    def test_parse_empty_atjobs_file(self):
+        """Test parsing empty atjobs file"""
+        atjobs_path = os.path.join(self.configuration.user_settings,
+                                   DUMMY_CLIENT_DIR, DUMMY_ATJOBS_NAME)
+        os.makedirs(os.path.dirname(atjobs_path), exist_ok=True)
+        open(atjobs_path, 'a').close()  # Create empty file
+
+        parsed = parse_atjobs(self.configuration, DUMMY_USER_DN, atjobs_path)
         self.assertEqual(parsed, [])
 
     def test_cron_match_current_minute(self):
@@ -116,34 +241,80 @@ class MigLibCron(MigTestCase):
         """Test cron_match rejects non-matching time"""
         now = datetime.datetime.now().replace(hour=3, minute=15, second=0, microsecond=0)
         test_job = {'minute': '30', 'hour': '2',
-                    'day': '*', 'month': '*', 'dayofweek': '*',
-                    'dayofmonth': '*'}
+                    'dayofmonth': '*', 'month': '*', 'dayofweek': '*'}
         self.assertFalse(cron_match(self.configuration, now, test_job))
 
-    def test_parse_atjobs_future_job(self):
-        """Test parse_atjobs recognizes future jobs"""
-        # Create dummy atjobs file
-        atjobs_path = os.path.join(self.configuration.user_settings,
-                                   DUMMY_CLIENT_DIR, DUMMY_ATJOBS_NAME)
-        os.makedirs(os.path.dirname(atjobs_path), exist_ok=True)
-        with open(atjobs_path, 'w') as f:
-            f.write(DUMMY_ATJOBS_CONTENT)
+    def test_at_remain_past_job(self):
+        """Test at_remain with past job"""
+        now = datetime.datetime.now()
+        past_time = now - datetime.timedelta(minutes=30)
+        test_job = {'time_stamp': past_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, -30)
 
-        parsed = parse_atjobs(self.configuration, DUMMY_USER_DN, atjobs_path)
-        self.assertEqual(len(parsed), 1)
-        self.assertTrue(parsed[0]['time_stamp'] > datetime.datetime.now())
+    def test_get_path_expand_map_with_special_chars(self):
+        """Test path expansion with special characters"""
+        trigger_path = '/test/path/file with spaces.txt'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertIn('+TRIGGERFILENAME+', expanded)
+        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file with spaces.txt')
 
-    @unittest.skip("enable once run_cron_handler is migrated")
-    def test_run_cron_handler_valid_job(self):
-        """Test run_cron_handler creates worker for valid job without crash"""
-        timestamp = datetime.datetime.now()
-        caught = None
-        try:
-            run_cron_handler(self.configuration, DUMMY_USER_DN, timestamp,
-                             DUMMY_CRON_JOB)
-        except Exception as exc:
-            caught = exc
-        self.assertEqual(caught, None)
+    def test_get_time_expand_map_edge_cases(self):
+        """Test time expansion with edge cases"""
+        timestamp = datetime.datetime(2023, 12, 31, 23, 59)
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '31')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '12')
+        self.assertEqual(expanded['+SCHEDHOUR+'], '23')
+        self.assertEqual(expanded['+SCHEDMINUTE+'], '59')
+
+    def test_run_cron_command_with_invalid_command(self):
+        """Test running cron command with invalid command"""
+        target_path = 'test.txt'
+        command_list = ['invalid_command', target_path]
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='DEBUG') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_run_events_command_with_invalid_command(self):
+        """Test running events command with invalid command"""
+        command_list = ['invalid_command', 'test']
+        target_path = '/test/path'
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+
+class MigLibEvents__legacy_main(MigTestCase):
+    """Unit tests for legacy events self-checks"""
+
+    def test_existing_main(self):
+        def raise_on_error_exit(exit_code):
+            if exit_code != 0:
+                if raise_on_error_exit.last_print is not None:
+                    identifying_message = raise_on_error_exit.last_print
+                else:
+                    identifying_message = 'unknown'
+                raise AssertionError(
+                    'failure in unittest/testcore: %s' % (identifying_message,))
+        raise_on_error_exit.last_print = None
+
+        def record_last_print(value):
+            raise_on_error_exit.last_print = value
+
+        events_main(_exit=raise_on_error_exit, _print=record_last_print)
 
 
 if __name__ == '__main__':

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -106,36 +106,34 @@ class MigLibEvents(MigTestCase):
 
     def test_parse_crontab_contents(self):
         """Test parsing crontab content lines"""
-        crontab_lines = DUMMY_CRONTAB_CONTENT.splitlines()
         parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
+            self.configuration, DUMMY_USER_DN,
+            DUMMY_CRONTAB_CONTENT.splitlines()
         )
         self.assertEqual(len(parsed), 2)
         self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
 
     def test_parse_atjobs_contents(self):
         """Test parsing atjobs content lines"""
-        atjobs_lines = DUMMY_ATJOBS_CONTENT.splitlines()
         parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
+            self.configuration, DUMMY_USER_DN,
+            DUMMY_ATJOBS_CONTENT.splitlines()
         )
         self.assertEqual(len(parsed), 1)
         self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
 
     def test_parse_and_save_crontab(self):
         """Test parsing and saving crontab"""
-        crontab = DUMMY_CRONTAB_CONTENT
         status, msg = parse_and_save_crontab(
-            crontab, DUMMY_USER_DN, self.configuration
+            DUMMY_CRONTAB_CONTENT, DUMMY_USER_DN, self.configuration
         )
         self.assertTrue(status)
         self.assertIn("valid crontab entries", msg)
 
     def test_parse_and_save_atjobs(self):
         """Test parsing and saving atjobs"""
-        atjobs = DUMMY_ATJOBS_CONTENT
         status, msg = parse_and_save_atjobs(
-            atjobs, DUMMY_USER_DN, self.configuration
+            DUMMY_ATJOBS_CONTENT, DUMMY_USER_DN, self.configuration
         )
         self.assertTrue(status)
         self.assertIn("valid atjobs entries", msg)
@@ -671,7 +669,8 @@ class MigLibEvents(MigTestCase):
             ),
         ]
         for job, expected in test_cases:
-            self.assertEqual(cron_match(self.configuration, now, job), expected)
+            self.assertEqual(cron_match(
+                self.configuration, now, job), expected)
 
     @unittest.skip("enable next if ever relevant - fails with TypeError")
     def test_at_remain_with_timezones(self):
@@ -699,7 +698,8 @@ class MigLibEvents(MigTestCase):
         trigger_path = "../relative/path/file.txt"
         rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
         expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertEqual(expanded["+TRIGGERPATH+"], "../relative/path/file.txt")
+        self.assertEqual(expanded["+TRIGGERPATH+"],
+                         "../relative/path/file.txt")
         self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
         self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
         self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -37,7 +37,7 @@ from mig.lib.events import parse_crontab, cron_match, parse_atjobs, at_remain, \
     get_path_expand_map, get_time_expand_map, load_crontab, load_atjobs, \
     parse_crontab_contents, parse_atjobs_contents, parse_and_save_crontab, \
     parse_and_save_atjobs, run_cron_command, run_events_command, \
-    main as events_main
+    _save_env, _restore_env, main as events_main
 from mig.shared.base import distinguished_name_to_user
 from tests.support import MigTestCase, ensure_dirs_exist
 
@@ -53,6 +53,8 @@ DUMMY_ATJOBS_NAME = 'atjobs'
 DUMMY_CRONTAB_CONTENT = """* * * * * /bin/test_command
 30 2 * * * /usr/bin/another_command"""
 DUMMY_ATJOBS_CONTENT = """2042-01-01 12:34:56 /bin/future_command"""
+MUST_PRESERVE_OS_ENV = ['MIG_CONF', 'HOME', 'USER', 'PATH', 'PWD']
+DUMMY_ENV = {'TEST_VAR': 'test_value', 'ANOTHER_VAR': 'another_value'}
 
 
 class MigLibEvents(MigTestCase):
@@ -185,6 +187,112 @@ class MigLibEvents(MigTestCase):
         except Exception as exc:
             self.fail("run_events_command raised an exception: %s" % exc)
 
+    def test_save_env(self):
+        """Test saving (custom) environment"""
+        original_env = {}
+
+        test_env = original_env.copy()
+        test_env.update(DUMMY_ENV)
+        # Save the test environment
+        saved_env = _save_env(test_env)
+
+        # Verify that the environment was saved correctly
+        self.assertEqual(saved_env, test_env)
+        self.assertEqual(saved_env, DUMMY_ENV)
+        self.assertEqual(len(original_env), 0)
+
+    def test_save_env_with_no_arguments(self):
+        """Test saving (default) environment with no arguments"""
+        original_env = os.environ.copy()
+
+        # Removing certain essential os.environ breaks conf, etc.
+        for name in os.environ:
+            if name not in MUST_PRESERVE_OS_ENV:
+                del os.environ[name]
+        # Save the current default environment
+        saved_env = _save_env()
+
+        self.assertEqual(saved_env, os.environ)
+        self.assertNotEqual(saved_env, original_env)
+        self.assertTrue(len(saved_env) <= len(MUST_PRESERVE_OS_ENV))
+
+        # Restore the original environment to prevent side effects
+        _restore_env(saved_env)
+
+    def test_restore_env(self):
+        """Test restoring (custom) environment"""
+        original_env = DUMMY_ENV.copy()
+
+        test_env = original_env.copy()
+        del test_env[list(original_env)[-1]]
+        test_env['NEWKEY'] = 'NEWVAL'
+        self.assertNotEqual(test_env, original_env)
+
+        # Restore the original environment
+        restored_env = _restore_env(original_env, test_env)
+
+        # Verify that the environment was restored correctly
+        self.assertEqual(restored_env, original_env)
+        self.assertEqual(restored_env, test_env)
+        self.assertEqual(original_env, DUMMY_ENV)
+
+    def test_restore_env_with_no_arguments(self):
+        """Test restoring (default) environment with no arguments"""
+        original_env = os.environ.copy()
+
+        os.environ.update(DUMMY_ENV)
+
+        # Restore the original environment without arguments
+        restored_env = _restore_env(original_env)
+
+        # Verify that the environment was restored correctly
+        self.assertEqual(restored_env, original_env)
+        self.assertEqual(os.environ, original_env)
+
+    def test_save_and_restore_env_lifecycle(self):
+        """Test saving and restoring (custom) environment"""
+        original_env = {}
+
+        test_env = original_env.copy()
+        test_env.update(DUMMY_ENV)
+        # Save the test environment
+        saved_env = _save_env(test_env)
+
+        # Verify that the environment was saved correctly
+        self.assertEqual(saved_env, test_env)
+        self.assertEqual(saved_env, DUMMY_ENV)
+        self.assertEqual(len(original_env), 0)
+
+        # Restore the original environment
+        restored_env = _restore_env(original_env, test_env)
+
+        # Verify that the environment was restored correctly
+        self.assertEqual(restored_env, original_env)
+        self.assertEqual(restored_env, test_env)
+        self.assertEqual(len(original_env), 0)
+
+    def test_save_and_restore_env_with_no_arguments_lifecycle(self):
+        """Test saving and restoring (default) environment"""
+        original_env = os.environ.copy()
+
+        # Removing certain essential os.environ breaks conf, etc.
+        for name in os.environ:
+            if name not in MUST_PRESERVE_OS_ENV:
+                del os.environ[name]
+        # Save the current default environment
+        saved_env = _save_env()
+
+        self.assertEqual(saved_env, os.environ)
+        self.assertNotEqual(saved_env, original_env)
+        self.assertTrue(len(saved_env) <= len(MUST_PRESERVE_OS_ENV))
+
+        # Restore the original environment
+        restored_env = _restore_env(original_env)
+
+        # Verify that the default environment was restored correctly
+        self.assertEqual(restored_env, original_env)
+        self.assertEqual(original_env, os.environ)
+
     def test_parse_valid_crontab_file(self):
         """Test parsing valid crontab file"""
         crontab_path = os.path.join(self.configuration.user_settings,
@@ -252,8 +360,8 @@ class MigLibEvents(MigTestCase):
         remaining = at_remain(self.configuration, now, test_job)
         self.assertEqual(remaining, -30)
 
-    def test_get_path_expand_map_with_special_chars(self):
-        """Test path expansion with special characters"""
+    def test_get_path_expand_map_with_spaces(self):
+        """Test path expansion with spaces"""
         trigger_path = '/test/path/file with spaces.txt'
         rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
         expanded = get_path_expand_map(trigger_path, rule, 'modified')
@@ -275,7 +383,7 @@ class MigLibEvents(MigTestCase):
         target_path = 'test.txt'
         command_list = ['invalid_command', target_path]
         crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='DEBUG') as log_capture:
+        with self.assertLogs(level='ERROR') as log_capture:
             with self.assertRaises(Exception):
                 run_cron_command(command_list, target_path, crontab_entry,
                                  self.configuration)
@@ -340,8 +448,8 @@ class MigLibEvents(MigTestCase):
         self.assertEqual(expanded['+SCHEDMONTH+'], '02')
         self.assertEqual(expanded['+SCHEDYEAR+'], '2024')
 
-    def test_run_cron_command_with_special_chars(self):
-        """Test running cron command with special characters"""
+    def test_run_cron_command_with_spaces(self):
+        """Test running cron command with spaces"""
         target_path = 'test file with spaces.txt'
         command_list = ['touch', target_path]
         crontab_entry = {'run_as': DUMMY_USER_DN}
@@ -352,8 +460,18 @@ class MigLibEvents(MigTestCase):
         except Exception as exc:
             self.fail("run_cron_command raised an exception: %s" % exc)
 
-    def test_run_events_command_with_special_chars(self):
-        """Test running events command with special characters"""
+    def test_run_cron_command_with_special_chars(self):
+        """Test running cron command with special characters"""
+        target_path = '/test/path/file@name#with$special&chars.txt'
+        command_list = ['touch', target_path]
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+
+    def test_run_events_command_with_spaces(self):
+        """Test running events command with spaces"""
         target_path = 'test file with spaces.txt'
         command_list = ['touch', target_path]
         rule = {'run_as': DUMMY_USER_DN}
@@ -363,6 +481,19 @@ class MigLibEvents(MigTestCase):
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_events_command raised an exception: %s" % exc)
+
+    def test_run_events_command_with_special_chars(self):
+        """Test running events command with special characters"""
+        target_path = '/test/path/file@name#with$special&chars.txt'
+        command_list = ['touch', target_path]
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('found invalid character' in msg
+                    for msg in log_capture.output))
 
     def test_parse_crontab_with_comments(self):
         """Test parsing crontab with comments"""
@@ -498,6 +629,1827 @@ invalid line
             self.assertEqual(len(parsed), 2)
             self.assertTrue(any('Skip invalid atjobs line' in msg
                                 for msg in log_capture.output))
+
+    def test_parse_crontab_with_empty_lines(self):
+        """Test parsing crontab with empty lines"""
+        crontab_content = """* * * * * /bin/test_command
+
+30 2 * * * /usr/bin/another_command
+"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+
+    def test_parse_atjobs_with_empty_lines(self):
+        """Test parsing atjobs with empty lines"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/future_command
+
+2042-01-02 12:34:56 /bin/another_command
+"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]['command'], ['/bin/future_command'])
+
+    def test_cron_match_with_single_digit_values(self):
+        """Test cron_match with single digit values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_cases = [
+            ({'minute': '5', 'hour': '3', 'dayofmonth': '7', 'month': '6', 'dayofweek': '1'},
+             now.replace(minute=5, hour=3, day=7, month=6)),
+            ({'minute': '0', 'hour': '0', 'dayofmonth': '1', 'month': '1', 'dayofweek': '0'},
+             now.replace(minute=0, hour=0, day=1, month=1)),
+        ]
+        for job, match_time in test_cases:
+            self.assertEqual(cron_match(self.configuration, match_time, job),
+                             match_time == now)
+
+    def test_at_remain_with_same_minute_but_earlier(self):
+        """Test at_remain with same minute but a few seconds earlier"""
+        now = datetime.datetime.now()
+        now = now.replace(second=30)
+        same_minute_time = now.replace(second=42)
+        test_job = {'time_stamp': same_minute_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, 0)
+
+    def test_at_remain_with_same_minute_but_later(self):
+        """Test at_remain with same minute but a few seconds later"""
+        now = datetime.datetime.now()
+        now = now.replace(second=30)
+        same_minute_time = now.replace(second=22)
+        test_job = {'time_stamp': same_minute_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, -1)
+
+    def test_at_remain_with_same_minute_exactly(self):
+        """Test at_remain with same minute exactly"""
+        now = datetime.datetime.now()
+        now = now.replace(second=30)
+        same_minute_time = now
+        test_job = {'time_stamp': same_minute_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, 0)
+
+    def test_get_path_expand_map_with_no_extension(self):
+        """Test path expansion with no extension"""
+        trigger_path = '/test/path/file'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file')
+        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
+        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '')
+
+    def test_get_time_expand_map_with_first_day(self):
+        """Test time expansion with first day of month"""
+        timestamp = datetime.datetime(2023, 1, 1, 0, 0)
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '01')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+
+    def test_run_cron_command_with_no_arguments(self):
+        """Test running cron command with no arguments"""
+        target_path = 'dummy'
+        command_list = ['touch']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+
+    def test_run_events_command_with_no_arguments(self):
+        """Test running events command with no arguments"""
+        target_path = 'dummy'
+        command_list = ['touch']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('path: is required' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_trailing_whitespace(self):
+        """Test parsing crontab with trailing whitespace"""
+        crontab_content = """* * * * * /bin/test_command   \n"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+
+    def test_parse_atjobs_with_trailing_whitespace(self):
+        """Test parsing atjobs with trailing whitespace"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/future_command   \n"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'], ['/bin/future_command'])
+
+    def test_cron_match_with_all_wildcards(self):
+        """Test cron_match with all wildcards"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '*', 'hour': '*', 'dayofmonth': '*',
+                    'month': '*', 'dayofweek': '*'}
+        self.assertTrue(cron_match(self.configuration, now, test_job))
+
+    def test_at_remain_with_future_year(self):
+        """Test at_remain with future year"""
+        now = datetime.datetime.now()
+        future_year = now.replace(year=now.year + 1, month=1, day=1,
+                                  hour=0, minute=0, second=0)
+        test_job = {'time_stamp': future_year}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_year - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_get_path_expand_map_with_leading_slash(self):
+        """Test path expansion with leading slash"""
+        trigger_path = '/file.txt'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertEqual(expanded['+TRIGGERPATH+'], '/file.txt')
+        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file.txt')
+        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
+        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+
+    def test_get_time_expand_map_with_last_day(self):
+        """Test time expansion with last day of month"""
+        timestamp = datetime.datetime(2023, 1, 31, 23, 59)
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '31')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+
+    def test_run_cron_command_with_output_redirection(self):
+        """Test running cron command with output redirection"""
+        target_path = 'test.txt'
+        command_list = ['touch', 'test', '>', target_path]
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+
+    def test_run_events_command_with_output_redirection(self):
+        """Test running events command with output redirection"""
+        target_path = 'test.txt'
+        command_list = ['touch', 'test', '>', target_path]
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('found invalid character' in msg
+                    for msg in log_capture.output))
+
+    @unittest.skip("enable next if we ever allow multispace")
+    def test_parse_crontab_with_multiple_spaces(self):
+        """Test parsing crontab with multiple spaces"""
+        crontab_content = """*  *  *  *  *  /bin/test_command"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+
+    @unittest.skip("enable next if we ever allow multispace")
+    def test_parse_atjobs_with_multiple_spaces(self):
+        """Test parsing atjobs with multiple spaces"""
+        atjobs_content = """2042-01-01  12:34:56  /bin/future_command"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'], ['/bin/future_command'])
+
+    # TODO: invert next when we implement feature at some point
+    def test_cron_match_with_range_values(self):
+        """Test cron_match with range values (not supported yet)"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '10-20', 'hour': '2', 'dayofmonth': '*',
+                    'month': '*', 'dayofweek': '*'}
+        # Should fail since ranges aren't supported, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_past_year(self):
+        """Test at_remain with past year"""
+        now = datetime.datetime.now()
+        past_year = now.replace(year=now.year - 1)
+        test_job = {'time_stamp': past_year}
+        remaining = at_remain(self.configuration, now, test_job)
+        # Approximately -1 year in minutes
+        self.assertEqual(remaining, -525600)
+
+    def test_at_remain_with_next_year(self):
+        """Test at_remain with next year"""
+        now = datetime.datetime.now()
+        past_year = now.replace(year=now.year + 1)
+        test_job = {'time_stamp': past_year}
+        remaining = at_remain(self.configuration, now, test_job)
+        # Approximately 1 year in minutes
+        self.assertEqual(remaining, 525600)
+
+    def test_get_path_expand_map_with_special_chars(self):
+        """Test path expansion with special characters"""
+        trigger_path = '/test/path/file@name#with$special&chars.txt'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertEqual(expanded['+TRIGGERFILENAME+'],
+                         'file@name#with$special&chars.txt')
+        self.assertEqual(expanded['+TRIGGERPREFIX+'],
+                         'file@name#with$special&chars')
+        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+
+    def test_get_time_expand_map_with_summer_time(self):
+        """Test time expansion with summer time (DST)"""
+        # This test may fail depending on the system's timezone and DST rules
+        # Summer in Northern Hemisphere
+        timestamp = datetime.datetime(2023, 7, 1, 12, 0)
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '01')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '07')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+
+    def test_run_cron_command_with_pipe(self):
+        """Test running cron command with pipe"""
+        target_path = 'test.txt'
+        command_list = ['touch', 'test', '|', 'grep', 'test']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+
+    def test_run_events_command_with_pipe(self):
+        """Test running events command with pipe"""
+        target_path = 'test.txt'
+        command_list = ['touch', 'test', '|', 'grep', 'test']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('found invalid character' in msg
+                    for msg in log_capture.output))
+
+    @unittest.skip("enable next if we ever allow tab sep")
+    def test_parse_crontab_with_tab_separated(self):
+        """Test parsing crontab with tab-separated values"""
+        crontab_content = "*\t*\t*\t*\t*\t/bin/test_command"
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+
+    @unittest.skip("enable next if we ever allow tab sep")
+    def test_parse_atjobs_with_tab_separated(self):
+        """Test parsing atjobs with tab-separated values"""
+        atjobs_content = "2042-01-01\t12:34:56\t/bin/future_command"
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'], ['/bin/future_command'])
+
+    def test_cron_match_with_step_values(self):
+        """Test cron_match with step values (not supported but should handle)"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '*/5', 'hour': '2', 'dayofmonth': '*',
+                    'month': '*', 'dayofweek': '*'}
+        # Should fail since steps aren't supported, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_leap_year(self):
+        """Test at_remain with leap year"""
+        now = datetime.datetime.now()
+        leap_day = datetime.datetime(
+            now.year + 4 - now.year // 4, 2, 29, 12, 0)  # Next leap year
+        test_job = {'time_stamp': leap_day}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (leap_day - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_get_path_expand_map_with_unicode(self):
+        """Test path expansion with unicode characters"""
+        trigger_path = '/test/path/файл.txt'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'файл.txt')
+        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'файл')
+        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+
+    def test_get_time_expand_map_with_dst_transition(self):
+        """Test time expansion with DST transition"""
+        # This test may fail depending on the system's timezone and DST rules
+        timestamp = datetime.datetime(
+            2023, 3, 12, 2, 30)  # DST transition in US
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '12')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '03')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+
+    def test_run_cron_command_with_background(self):
+        """Test running cron command with background execution"""
+        target_path = 'test.txt'
+        command_list = ['touch', target_path, '&']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        # NOTE: touch succeeds treating ampersand as filename
+        try:
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail("run_cron_command raised an exception: %s" % exc)
+
+    def test_run_events_command_with_background(self):
+        """Test running events command with background execution"""
+        target_path = 'test.txt'
+        command_list = ['sleep', '1', '&']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_multiple_commands(self):
+        """Test parsing crontab with multiple commands"""
+        crontab_content = """* * * * * /bin/command1 && /bin/command2"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '&&', '/bin/command2'])
+
+    def test_parse_atjobs_with_multiple_commands(self):
+        """Test parsing atjobs with multiple commands"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 && /bin/command2"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '&&', '/bin/command2'])
+
+    @unittest.skip("implement value range check in function and enable next")
+    def test_cron_match_with_invalid_values(self):
+        """Test cron_match with invalid values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '60', 'hour': '25', 'dayofmonth': '32',
+                    'month': '13', 'dayofweek': '7'}
+        # Should fail since values are invalid, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_past_time(self):
+        """Test at_remain with past time"""
+        now = datetime.datetime.now()
+        past_time = now - datetime.timedelta(minutes=5)
+        test_job = {'time_stamp': past_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, -5)
+
+    def test_get_path_expand_map_with_no_path(self):
+        """Test path expansion with no path (just filename)"""
+        trigger_path = 'file.txt'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertEqual(expanded['+TRIGGERPATH+'], 'file.txt')
+        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file.txt')
+        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
+        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+
+    def test_get_time_expand_map_with_zero_values(self):
+        """Test time expansion with zero values"""
+        timestamp = datetime.datetime(2023, 1, 1, 0, 0)
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDSECOND+'], '00')
+        self.assertEqual(expanded['+SCHEDMINUTE+'], '00')
+        self.assertEqual(expanded['+SCHEDHOUR+'], '00')
+        self.assertEqual(expanded['+SCHEDDAY+'], '01')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+        self.assertEqual(expanded['+SCHEDDAYOFWEEK+'], '6')  # Sunday
+
+    def test_run_cron_command_with_quotes(self):
+        """Test running cron command with quotes"""
+        target_path = 'test.txt'
+        command_list = ['touch', '"test with spaces"']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+
+    def test_run_events_command_with_quotes(self):
+        """Test running events command with quotes"""
+        target_path = 'test.txt'
+        command_list = ['touch', '"test with spaces"']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+        self.assertTrue(
+            any('found invalid character' in msg
+                for msg in log_capture.output))
+
+    def test_parse_crontab_with_semicolon(self):
+        """Test parsing crontab with semicolon"""
+        crontab_content = """* * * * * /bin/command1; /bin/command2"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1;', '/bin/command2'])
+
+    def test_parse_atjobs_with_semicolon(self):
+        """Test parsing atjobs with semicolon"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1; /bin/command2"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1;', '/bin/command2'])
+
+    # TODO: invert next when we implement feature at some point
+    def test_cron_match_with_division_values(self):
+        """Test cron_match with division values (not supported yet)"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '*', 'hour': '*', 'dayofmonth': '*',
+                    'month': '*/1', 'dayofweek': '*'}
+        # Should fail since divide format is not yet allowed
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_future_time(self):
+        """Test at_remain with future time"""
+        now = datetime.datetime.now()
+        future_time = now + datetime.timedelta(minutes=5)
+        test_job = {'time_stamp': future_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, 5)
+
+    def test_get_path_expand_map_with_windows_path(self):
+        """Test path expansion with Windows path"""
+        trigger_path = 'C:\\path\\to\\file.txt'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertEqual(expanded['+TRIGGERPATH+'], 'C:\\path\\to\\file.txt')
+        self.assertEqual(expanded['+TRIGGERFILENAME+'],
+                         'C:\\path\\to\\file.txt')
+        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'C:\\path\\to\\file')
+        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+
+    def test_get_time_expand_map_with_dst_start(self):
+        """Test time expansion with DST start"""
+        # This test may fail depending on the system's timezone and DST rules
+        timestamp = datetime.datetime(2023, 3, 12, 3, 0)  # DST start in US
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '12')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '03')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+
+    def test_run_cron_command_with_environment_variable(self):
+        """Test running cron command with environment variable"""
+        target_path = 'test.txt'
+        command_list = ['touch', '$HOME']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        try:
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail("run_cron_command raised an exception: %s" % exc)
+
+    def test_run_events_command_with_environment_variable(self):
+        """Test running events command with environment variable"""
+        target_path = 'test.txt'
+        command_list = ['touch', '$HOME']
+        rule = {'run_as': DUMMY_USER_DN}
+        try:
+            run_events_command(command_list, target_path, rule,
+                               self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail("run_events_command raised an exception: %s" % exc)
+
+    def test_parse_crontab_with_backticks(self):
+        """Test parsing crontab with backticks"""
+        crontab_content = """* * * * * /bin/command1 `touch test`"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '`touch', 'test`'])
+
+    def test_parse_atjobs_with_backticks(self):
+        """Test parsing atjobs with backticks"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 `touch test`"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '`touch', 'test`'])
+
+    @unittest.skip("implement extra value check in function and enable next")
+    def test_cron_match_with_extra_fields(self):
+        """Test cron_match with extra fields"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '*', 'hour': '*', 'dayofmonth': '*',
+                    'month': '*', 'dayofweek': '*',
+                    'extra_field': 'value'}
+        # Should fail since extra fields are present, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    # NOTE: no datetime support https://github.com/python/cpython/issues/67762
+    @unittest.skip("enable if leap second handling is ever implemented")
+    def test_at_remain_with_leap_second(self):
+        """Test at_remain with leap second"""
+        # December 31, 2016, had a leap second to include time 23:59:60
+        now = datetime.datetime.now(datetime.timezone.utc)
+        t_minus_sixty = now.replace(year=2016, month=12, day=31, hour=23,
+                                    minute=59, second=0, microsecond=0)
+        leap_second = t_minus_sixty + datetime.timedelta(seconds=60)
+        t_plus_sixty = now.replace(year=2017, month=1, day=1, hour=0,
+                                   minute=0, second=59, microsecond=0)
+        self.assertEqual((t_plus_sixty - t_minus_sixty).total_seconds(), 120,
+                         "Leap second does not appear supported")
+        test_job = {'time_stamp': t_plus_sixty}
+        remaining = at_remain(self.configuration, leap_second, test_job)
+        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
+        #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
+        self.assertEqual(remaining, 1)
+
+    def test_get_path_expand_map_with_url(self):
+        """Test path expansion with URL"""
+        trigger_path = 'http://example.com/file.txt'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertEqual(expanded['+TRIGGERPATH+'],
+                         'http://example.com/file.txt')
+        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file.txt')
+        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
+        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+
+    def test_get_time_expand_map_with_new_year(self):
+        """Test time expansion with New Year"""
+        timestamp = datetime.datetime(2023, 1, 1, 0, 0)
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '01')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+
+    def test_parse_crontab_with_parentheses(self):
+        """Test parsing crontab with parentheses"""
+        crontab_content = """* * * * * /bin/command1 (arg1 arg2)"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '(arg1', 'arg2)'])
+
+    def test_parse_atjobs_with_parentheses(self):
+        """Test parsing atjobs with parentheses"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 (arg1 arg2)"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '(arg1', 'arg2)'])
+
+    def test_cron_match_with_invalid_chars(self):
+        """Test cron_match with invalid characters"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '*', 'hour': '*', 'dayofmonth': '*',
+                    'month': '*', 'dayofweek': 'Sunday'}
+        # Should fail since invalid characters are present, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_dst_end(self):
+        """Test at_remain with DST end"""
+        # This test may fail depending on the system's timezone and DST rules
+        now = datetime.datetime.now()
+        dst_end_time = now.replace(month=11, day=5, hour=1, minute=30)
+        test_job = {'time_stamp': dst_end_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (dst_end_time - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_get_path_expand_map_with_query_string(self):
+        """Test path expansion with query string"""
+        trigger_path = '/test/path/file.txt?param=value'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertEqual(expanded['+TRIGGERPATH+'],
+                         '/test/path/file.txt?param=value')
+        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file.txt?param=value')
+        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
+        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt?param=value')
+
+    def test_get_time_expand_map_with_leap_year_start(self):
+        """Test time expansion with leap year start"""
+        timestamp = datetime.datetime(2024, 1, 1, 0, 0)  # Leap year
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '01')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2024')
+
+    def test_run_cron_command_with_escaped_chars(self):
+        """Test running cron command with escaped characters"""
+        target_path = 'test.txt'
+        command_list = ['touch', 'test\\ with\\ spaces']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+
+    def test_run_events_command_with_escaped_chars(self):
+        """Test running events command with escaped characters"""
+        target_path = 'test.txt'
+        command_list = ['touch', 'test\\ with\\ spaces']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('found invalid character' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_brackets(self):
+        """Test parsing crontab with brackets"""
+        crontab_content = """* * * * * /bin/command1 [arg1 arg2]"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '[arg1', 'arg2]'])
+
+    def test_parse_atjobs_with_brackets(self):
+        """Test parsing atjobs with brackets"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 [arg1 arg2]"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '[arg1', 'arg2]'])
+
+    def test_cron_match_with_extra_whitespace(self):
+        """Test cron_match with extra whitespace"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': ' * ', 'hour': ' * ', 'dayofmonth': ' * ',
+                    'month': ' * ', 'dayofweek': ' * '}
+        # Should fail since extra whitespace isn't allowed
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_future_dst_transition(self):
+        """Test at_remain with future DST transition"""
+        # This test may fail depending on the system's timezone and DST rules
+        now = datetime.datetime.now()
+        future_dst_time = now.replace(month=3, day=12, hour=2, minute=30)
+        test_job = {'time_stamp': future_dst_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_dst_time - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_get_path_expand_map_with_fragment(self):
+        """Test path expansion with fragment"""
+        trigger_path = '/test/path/file.txt#fragment'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertEqual(expanded['+TRIGGERPATH+'],
+                         '/test/path/file.txt#fragment')
+        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file.txt#fragment')
+        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
+        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt#fragment')
+
+    def test_get_time_expand_map_with_century_year(self):
+        """Test time expansion with century year"""
+        timestamp = datetime.datetime(2100, 1, 1, 0, 0)  # Year 2100
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '01')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2100')
+
+    def test_run_cron_command_with_multiple_commands(self):
+        """Test running cron command with multiple commands"""
+        target_path = 'test.txt'
+        command_list = ['touch', 'test1', '&&', 'touch', 'test2']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        try:
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail("run_cron_command raised an exception: %s" % exc)
+
+    def test_run_events_command_with_multiple_commands(self):
+        """Test running events command with multiple commands"""
+        target_path = 'test.txt'
+        command_list = ['touch', 'test1', '&&', 'touch', 'test2']
+        rule = {'run_as': DUMMY_USER_DN}
+        try:
+            run_events_command(command_list, target_path, rule,
+                               self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail("run_events_command raised an exception: %s" % exc)
+
+    def test_parse_crontab_with_quotes(self):
+        """Test parsing crontab with quotes"""
+        crontab_content = '''* * * * * /bin/command1 "arg1 with spaces"'''
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', 'arg1 with spaces'])
+
+    def test_parse_atjobs_with_quotes(self):
+        """Test parsing atjobs with quotes"""
+        atjobs_content = '''2042-01-01 12:34:56 /bin/command1 "arg1 with spaces"'''
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', 'arg1 with spaces'])
+
+    @unittest.skip("implement extra value check in function and enable next")
+    def test_cron_match_with_invalid_field_count(self):
+        """Test cron_match with invalid field count"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '*', 'hour': '*', 'dayofmonth': '*',
+                    'month': '*', 'dayofweek': '*',
+                    'extra_field': '*'}
+        # Should fail since field count is invalid, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_past_dst_transition(self):
+        """Test at_remain with past DST transition"""
+        # This test may fail depending on the system's timezone and DST rules
+        now = datetime.datetime.now()
+        past_dst_time = now.replace(month=11, day=5, hour=1, minute=30)
+        test_job = {'time_stamp': past_dst_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (past_dst_time - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_get_path_expand_map_with_encoded_chars(self):
+        """Test path expansion with encoded characters"""
+        trigger_path = '/test/path/file%20with%20spaces.txt'
+        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, 'modified')
+        self.assertEqual(expanded['+TRIGGERPATH+'],
+                         '/test/path/file%20with%20spaces.txt')
+        self.assertEqual(expanded['+TRIGGERFILENAME+'],
+                         'file%20with%20spaces.txt')
+        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file%20with%20spaces')
+        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+
+    def test_get_time_expand_map_with_millennium_year(self):
+        """Test time expansion with millennium year"""
+        timestamp = datetime.datetime(2000, 1, 1, 0, 0)  # Year 2000
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '01')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '2000')
+
+    def test_run_cron_command_with_input_redirection(self):
+        """Test running cron command with input redirection"""
+        target_path = 'test.txt'
+        command_list = ['chksum', 'md5', '<', 'input.txt']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+
+    def test_run_events_command_with_input_redirection(self):
+        """Test running events command with input redirection"""
+        target_path = 'test.txt'
+        command_list = ['chksum', 'md5', '<', 'input.txt']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('found invalid character' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_single_quotes(self):
+        """Test parsing crontab with single quotes"""
+        crontab_content = """* * * * * /bin/command1 'arg1 with spaces'"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', "arg1 with spaces"])
+
+    def test_parse_atjobs_with_single_quotes(self):
+        """Test parsing atjobs with single quotes"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 'arg1 with spaces'"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', "arg1 with spaces"])
+
+    def test_cron_match_with_missing_fields(self):
+        """Test cron_match with missing fields"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '*', 'hour': '*', 'dayofmonth': '*',
+                    'dayofweek': '*'}
+        # NOTE: throws exception before log since values must be strings
+        with self.assertRaises(Exception):
+            result = cron_match(self.configuration, now, test_job)
+
+    # NOTE: no datetime support https://github.com/python/cpython/issues/67762
+    @unittest.skip("enable if leap second handling is ever implemented")
+    def test_at_remain_with_future_leap_second(self):
+        """Test at_remain with future leap second"""
+        # December 31, 2016, had a leap second to include time 23:59:60
+        now = datetime.datetime.now(datetime.timezone.utc)
+        t_minus_sixty = now.replace(year=2016, month=12, day=31, hour=23,
+                                    minute=59, second=0, microsecond=0)
+        leap_second = t_minus_sixty + \
+            datetime.timedelta(seconds=60)
+        t_plus_sixty = now.replace(year=2017, month=1, day=1, hour=0,
+                                   minute=0, second=59, microsecond=0)
+        self.assertEqual((t_plus_sixty - t_minus_sixty).total_seconds(), 120,
+                         "Leap second does not appear supported")
+        test_job = {'time_stamp': leap_second}
+        remaining = at_remain(self.configuration, t_minus_sixty, test_job)
+        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
+        #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
+        self.assertEqual(remaining, 1)
+
+    def test_get_time_expand_map_with_year_zero(self):
+        """Test time expansion with year zero"""
+        timestamp = datetime.datetime(1, 1, 1, 0, 0)  # Year 1
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '01')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '1')
+
+    def test_run_cron_command_with_here_document(self):
+        """Test running cron command with here document"""
+        target_path = 'test.txt'
+        command_list = ['cat', '<<EOF', 'test content', 'EOF']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_run_events_command_with_here_document(self):
+        """Test running events command with here document"""
+        target_path = 'test.txt'
+        command_list = ['cat', '<<EOF', 'test content', 'EOF']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_backslash(self):
+        """Test parsing crontab with backslash"""
+        crontab_content = """* * * * * /bin/command1 arg1\\ arg2"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', 'arg1 arg2'])
+
+    def test_parse_atjobs_with_backslash(self):
+        """Test parsing atjobs with backslash"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 arg1\\ arg2"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', 'arg1 arg2'])
+
+    def test_cron_match_with_non_string_values(self):
+        """Test cron_match with non-string values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': 15, 'hour': 3, 'dayofmonth': 7,
+                    'month': 6, 'dayofweek': 1}
+        # NOTE: throws exception before log since values must be strings
+        with self.assertRaises(Exception):
+            result = cron_match(self.configuration, now, test_job)
+
+    # NOTE: no datetime support https://github.com/python/cpython/issues/67762
+    @unittest.skip("enable if leap second handling is ever implemented")
+    def test_at_remain_with_past_leap_second(self):
+        """Test at_remain with past leap second"""
+        # December 31, 2016, had a leap second to include time 23:59:60
+        now = datetime.datetime.now(datetime.timezone.utc)
+        t_minus_sixty = now.replace(year=2016, month=12, day=31, hour=23,
+                                    minute=59, second=0, microsecond=0)
+        leap_second = t_minus_sixty + datetime.timedelta(seconds=60)
+        t_plus_sixty = now.replace(year=2017, month=1, day=1, hour=0,
+                                   minute=0, second=59, microsecond=0)
+        t_plus_sixtyone = now.replace(year=2017, month=1, day=1, hour=0,
+                                      minute=1, second=0, microsecond=0)
+        self.assertEqual((t_plus_sixty - t_minus_sixty).total_seconds(), 120,
+                         "Leap second does not appear supported")
+        test_job = {'time_stamp': leap_second}
+        remaining = at_remain(self.configuration, t_plus_sixty, test_job)
+        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
+        #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
+        self.assertEqual(remaining, -1)
+        remaining = at_remain(self.configuration, t_plus_sixtyone, test_job)
+        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
+        #      (t_minus_sixty, leap_second, t_plus_sixtyone, remaining))
+        self.assertEqual(remaining, -2)
+
+    def test_get_time_expand_map_with_year_9999(self):
+        """Test time expansion with year 9999"""
+        timestamp = datetime.datetime(9999, 12, 31, 23, 59)
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '31')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '12')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '9999')
+
+    def test_run_cron_command_with_subshell(self):
+        """Test running cron command with subshell"""
+        target_path = 'test.txt'
+        command_list = ['(touch', 'test1; touch', 'test2)']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_run_events_command_with_subshell(self):
+        """Test running events command with subshell"""
+        target_path = 'test.txt'
+        command_list = ['(touch', 'test1; touch', 'test2)']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_double_backslash(self):
+        """Test parsing crontab with double backslash"""
+        crontab_content = """* * * * * /bin/command1 arg1\\\\ arg2"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', 'arg1\\', 'arg2'])
+
+    def test_parse_atjobs_with_double_backslash(self):
+        """Test parsing atjobs with double backslash"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 arg1\\\\ arg2"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', 'arg1\\', 'arg2'])
+
+    def test_cron_match_with_boolean_values(self):
+        """Test cron_match with boolean values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': True, 'hour': False, 'dayofmonth': True,
+                    'month': False, 'dayofweek': True}
+        # NOTE: throws exception before log since values must be strings
+        with self.assertRaises(Exception):
+            result = cron_match(self.configuration, now, test_job)
+
+    def test_at_remain_with_future_leap_year(self):
+        """Test at_remain with future leap year"""
+        now = datetime.datetime.now()
+        future_leap_year = now.replace(year=2096, month=2, day=29,
+                                       hour=12, minute=0)
+        test_job = {'time_stamp': future_leap_year}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_leap_year - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_get_time_expand_map_with_year_0001(self):
+        """Test time expansion with year 0001"""
+        timestamp = datetime.datetime(1, 1, 1, 0, 0)  # Year 1
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '01')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '1')
+
+    def test_run_cron_command_with_command_substitution(self):
+        """Test running cron command with command substitution"""
+        target_path = 'test.txt'
+        command_list = ['touch', '$(date)']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        try:
+            run_cron_command(command_list, target_path, crontab_entry,
+                             self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail(
+                "run_cron_command raised an exception: %s" % exc)
+
+    def test_run_events_command_with_command_substitution(self):
+        """Test running events command with command substitution"""
+        target_path = 'test.txt'
+        command_list = ['touch', '$(date)']
+        rule = {'run_as': DUMMY_USER_DN}
+        try:
+            run_events_command(command_list, target_path, rule,
+                               self.configuration)
+            self.assertTrue(True)  # If no exception, test passes
+        except Exception as exc:
+            self.fail(
+                "run_events_command raised an exception: %s" % exc)
+
+    def test_parse_crontab_with_caret(self):
+        """Test parsing crontab with caret"""
+        crontab_content = """* * * * * /bin/command1 ^arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '^arg1'])
+
+    def test_parse_atjobs_with_caret(self):
+        """Test parsing atjobs with caret"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 ^arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '^arg1'])
+
+    def test_cron_match_with_none_values(self):
+        """Test cron_match with none values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': None, 'hour': None, 'dayofmonth': None,
+                    'month': None, 'dayofweek': None}
+        # NOTE: throws exception before log since values must be strings
+        with self.assertRaises(Exception):
+            result = cron_match(self.configuration, now, test_job)
+
+    def test_at_remain_with_past_leap_year(self):
+        """Test at_remain with past leap year"""
+        now = datetime.datetime.now()
+        past_leap_year = now.replace(year=2000, month=2, day=29,
+                                     hour=12, minute=0)
+        test_job = {'time_stamp': past_leap_year}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (past_leap_year - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_get_time_expand_map_with_year_9999_end(self):
+        """Test time expansion with year 9999 end"""
+        timestamp = datetime.datetime(9999, 12, 31, 23, 59)
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '31')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '12')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '9999')
+
+    def test_run_cron_command_with_true_command(self):
+        """Test running cron command with true command"""
+        target_path = 'test.txt'
+        command_list = ['true']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_run_events_command_with_true_command(self):
+        """Test running events command with true command"""
+        target_path = 'test.txt'
+        command_list = ['true']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_hash(self):
+        """Test parsing crontab with hash"""
+        crontab_content = """* * * * * /bin/command1 #arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1'])
+
+    def test_parse_atjobs_with_hash(self):
+        """Test parsing atjobs with hash"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 #arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1'])
+
+    def test_cron_match_with_tab_values(self):
+        """Test cron_match with tab values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '\t', 'hour': '\t', 'dayofmonth': '\t',
+                    'month': '\t', 'dayofweek': '\t'}
+        # Should fail since values are tabs, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_future_millennium(self):
+        """Test at_remain with future millennium"""
+        now = datetime.datetime.now()
+        future_millennium = now.replace(year=now.year + 1000, month=1, day=1,
+                                        hour=0, minute=0)
+        test_job = {'time_stamp': future_millennium}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_millennium - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_get_time_expand_map_with_year_0001_end(self):
+        """Test time expansion with year 0001 end"""
+        timestamp = datetime.datetime(1, 12, 31, 23, 59)  # Year 1
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '31')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '12')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '1')
+
+    def test_run_cron_command_with_false_command(self):
+        """Test running cron command with false command"""
+        target_path = 'test.txt'
+        command_list = ['false']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_run_events_command_with_false_command(self):
+        """Test running events command with false command"""
+        target_path = 'test.txt'
+        command_list = ['false']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_dollar(self):
+        """Test parsing crontab with dollar"""
+        crontab_content = """* * * * * /bin/command1 $arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '$arg1'])
+
+    def test_parse_atjobs_with_dollar(self):
+        """Test parsing atjobs with dollar"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 $arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '$arg1'])
+
+    def test_cron_match_with_newline_values(self):
+        """Test cron_match with newline values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '\n', 'hour': '\n', 'dayofmonth': '\n',
+                    'month': '\n', 'dayofweek': '\n'}
+        # Should fail since values are newlines, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_past_millennium(self):
+        """Test at_remain with past millennium"""
+        now = datetime.datetime.now()
+        past_millennium = now.replace(year=now.year - 1000, month=1, day=1,
+                                      hour=0, minute=0)
+        test_job = {'time_stamp': past_millennium}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (past_millennium - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_run_cron_command_with_null_command(self):
+        """Test running cron command with null command"""
+        target_path = 'test.txt'
+        command_list = [':']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_run_events_command_with_null_command(self):
+        """Test running events command with null command"""
+        target_path = 'test.txt'
+        command_list = [':']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_percent(self):
+        """Test parsing crontab with percent"""
+        crontab_content = """* * * * * /bin/command1 %arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '%arg1'])
+
+    def test_parse_atjobs_with_percent(self):
+        """Test parsing atjobs with percent"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 %arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '%arg1'])
+
+    def test_cron_match_with_carriage_return_values(self):
+        """Test cron_match with carriage return values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '\r', 'hour': '\r', 'dayofmonth': '\r',
+                    'month': '\r', 'dayofweek': '\r'}
+        # Should fail since values are carriage returns, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_future_millennium_end(self):
+        """Test at_remain with future millennium end"""
+        now = datetime.datetime.now()
+        future_millennium_end = now.replace(year=now.year + 1000,
+                                            month=12, day=31,
+                                            hour=23, minute=59)
+        test_job = {'time_stamp': future_millennium_end}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_millennium_end - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_get_time_expand_map_with_year_0001_start(self):
+        """Test time expansion with year 0001 start"""
+        timestamp = datetime.datetime(1, 1, 1, 0, 0)  # Year 1
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '01')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '1')
+
+    def test_run_cron_command_with_builtin_command(self):
+        """Test running cron command with builtin command"""
+        target_path = 'test.txt'
+        command_list = ['builtin', 'command']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_run_events_command_with_builtin_command(self):
+        """Test running events command with builtin command"""
+        target_path = 'test.txt'
+        command_list = ['builtin', 'command']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_ampersand(self):
+        """Test parsing crontab with ampersand"""
+        crontab_content = """* * * * * /bin/command1 &arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '&arg1'])
+
+    def test_parse_atjobs_with_ampersand(self):
+        """Test parsing atjobs with ampersand"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 &arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '&arg1'])
+
+    def test_cron_match_with_vertical_tab_values(self):
+        """Test cron_match with vertical tab values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '\v', 'hour': '\v', 'dayofmonth': '\v',
+                    'month': '\v', 'dayofweek': '\v'}
+        # Should fail since values are vertical tabs, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_past_millennium_end(self):
+        """Test at_remain with past millennium end"""
+        now = datetime.datetime.now()
+        past_millennium_end = now.replace(year=now.year - 1000,
+                                          month=12, day=31,
+                                          hour=23, minute=59)
+        test_job = {'time_stamp': past_millennium_end}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (past_millennium_end - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_get_time_expand_map_with_year_9999_start(self):
+        """Test time expansion with year 9999 start"""
+        timestamp = datetime.datetime(9999, 1, 1, 0, 0)  # Year 9999
+        rule = {'run_as': DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded['+SCHEDDAY+'], '01')
+        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
+        self.assertEqual(expanded['+SCHEDYEAR+'], '9999')
+
+    def test_run_cron_command_with_alias_command(self):
+        """Test running cron command with alias command"""
+        target_path = 'test.txt'
+        command_list = ['alias', 'command']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_run_events_command_with_alias_command(self):
+        """Test running events command with alias command"""
+        target_path = 'test.txt'
+        command_list = ['alias', 'command']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_pipe(self):
+        """Test parsing crontab with pipe"""
+        crontab_content = """* * * * * /bin/command1 | /bin/command2"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '|', '/bin/command2'])
+
+    def test_parse_atjobs_with_pipe(self):
+        """Test parsing atjobs with pipe"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 | /bin/command2"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '|', '/bin/command2'])
+
+    def test_cron_match_with_form_feed_values(self):
+        """Test cron_match with form feed values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '\f', 'hour': '\f', 'dayofmonth': '\f',
+                    'month': '\f', 'dayofweek': '\f'}
+        # Should fail since values are form feeds, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_future_century_end(self):
+        """Test at_remain with future century end"""
+        now = datetime.datetime.now()
+        future_century_end = now.replace(year=now.year + 100,
+                                         month=12, day=31,
+                                         hour=23, minute=59)
+        test_job = {'time_stamp': future_century_end}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_century_end - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_run_cron_command_with_function_command(self):
+        """Test running cron command with function command"""
+        target_path = 'test.txt'
+        command_list = ['function', 'name() { command; }']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_run_events_command_with_function_command(self):
+        """Test running events command with function command"""
+        target_path = 'test.txt'
+        command_list = ['function', 'name() { command; }']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_question_mark(self):
+        """Test parsing crontab with question mark"""
+        crontab_content = """* * * * * /bin/command1 ?arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '?arg1'])
+
+    def test_parse_atjobs_with_question_mark(self):
+        """Test parsing atjobs with question mark"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 ?arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '?arg1'])
+
+    def test_cron_match_with_escape_values(self):
+        """Test cron_match with escape values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '\\', 'hour': '\\', 'dayofmonth': '\\',
+                    'month': '\\', 'dayofweek': '\\'}
+        # Should fail since values are escapes, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_past_century_end(self):
+        """Test at_remain with past century end"""
+        now = datetime.datetime.now()
+        past_century_end = now.replace(year=now.year - 100,
+                                       month=12, day=31,
+                                       hour=23, minute=59)
+        test_job = {'time_stamp': past_century_end}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (past_century_end - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_run_cron_command_with_reserved_command(self):
+        """Test running cron command with reserved command"""
+        target_path = 'test.txt'
+        command_list = ['reserved', 'command']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_plus(self):
+        """Test parsing crontab with plus"""
+        crontab_content = """* * * * * /bin/command1 +arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '+arg1'])
+
+    def test_parse_atjobs_with_plus(self):
+        """Test parsing atjobs with plus"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 +arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '+arg1'])
+
+    def test_cron_match_with_delete_values(self):
+        """Test cron_match with delete values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': '\x7f', 'hour': '\x7f', 'dayofmonth': '\x7f',
+                    'month': '\x7f', 'dayofweek': '\x7f'}
+        # Should fail since values are deletes, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_future_century_start(self):
+        """Test at_remain with future century start"""
+        now = datetime.datetime.now()
+        future_century_start = now.replace(year=now.year + 100,
+                                           month=1, day=1,
+                                           hour=0, minute=0)
+        test_job = {'time_stamp': future_century_start}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_century_start - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_run_cron_command_with_dot_command(self):
+        """Test running cron command with dot command"""
+        target_path = 'test.txt'
+        command_list = ['.', 'command']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_run_events_command_with_dot_command(self):
+        """Test running events command with dot command"""
+        target_path = 'test.txt'
+        command_list = ['.', 'command']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_comma(self):
+        """Test parsing crontab with comma"""
+        crontab_content = """* * * * * /bin/command1,arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1,arg1'])
+
+    def test_parse_atjobs_with_comma(self):
+        """Test parsing atjobs with comma"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1,arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1,arg1'])
+
+    def test_cron_match_with_space_values(self):
+        """Test cron_match with space values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {'minute': ' ', 'hour': ' ', 'dayofmonth': ' ',
+                    'month': ' ', 'dayofweek': ' '}
+        # Should fail since values are spaces, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level='WARNING') as log_capture:
+            result = cron_match(self.configuration, now, test_job,
+                                _warn_mismatch=True)
+            self.assertFalse(result)
+            self.assertTrue(any('no cron_match on' in msg
+                                for msg in log_capture.output))
+
+    def test_at_remain_with_past_century_start(self):
+        """Test at_remain with past century start"""
+        now = datetime.datetime.now()
+        past_century_start = now.replace(year=now.year - 100,
+                                         month=1, day=1,
+                                         hour=0, minute=0)
+        test_job = {'time_stamp': past_century_start}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (past_century_start - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_run_cron_command_with_colon_command(self):
+        """Test running cron command with colon command"""
+        target_path = 'test.txt'
+        command_list = [':']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_run_cron_command_with_bracket_command(self):
+        """Test running cron command with bracket command"""
+        target_path = 'test.txt'
+        command_list = ['[', 'test', '-f', 'file', ']']
+        crontab_entry = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_cron_command(command_list, target_path, crontab_entry,
+                                 self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_run_events_command_with_bracket_command(self):
+        """Test running events command with bracket command"""
+        target_path = 'test.txt'
+        command_list = ['[', 'test', '-f', 'file', ']']
+        rule = {'run_as': DUMMY_USER_DN}
+        with self.assertLogs(level='ERROR') as log_capture:
+            with self.assertRaises(Exception):
+                run_events_command(command_list, target_path, rule,
+                                   self.configuration)
+            self.assertTrue(
+                any('failed to run' in msg or 'failed to lookup' in msg
+                    for msg in log_capture.output))
+
+    def test_parse_crontab_with_less_than(self):
+        """Test parsing crontab with less than"""
+        crontab_content = """* * * * * /bin/command1 <arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
+                                        crontab_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '<arg1'])
+
+    def test_parse_atjobs_with_less_than(self):
+        """Test parsing atjobs with less than"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 <arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
+                                       atjobs_lines)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]['command'],
+                         ['/bin/command1', '<arg1'])
 
 
 class MigLibEvents__legacy_main(MigTestCase):

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -55,8 +55,1387 @@ MUST_PRESERVE_OS_ENV = ["MIG_CONF", "HOME", "USER", "PATH", "PWD"]
 DUMMY_ENV = {"TEST_VAR": "test_value", "ANOTHER_VAR": "another_value"}
 
 
-class MigLibEvents(MigTestCase):
-    """Unit tests for events helper functions"""
+class MigLibEvents__timers(MigTestCase):
+    """Unit tests for timer related events helper functions"""
+
+    def _provide_configuration(self):
+        """Prepare isolated test config"""
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test configuration and reset state before each test"""
+        # Enable events in configuration
+        self.configuration.site_enable_crontab = True
+
+    def test_at_remain(self):
+        """Test at job remaining time calculation"""
+        now = datetime.datetime.now()
+        future_time = now + datetime.timedelta(minutes=30)
+        test_job = {"time_stamp": future_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, 30)
+
+    def test_at_remain_edge_cases(self):
+        """Test at_remain with edge case times"""
+        now = datetime.datetime.now()
+        test_cases = [
+            (now + datetime.timedelta(seconds=30), 0),  # Less than 1 minute
+            # 1 minute 30 seconds
+            (now + datetime.timedelta(minutes=1, seconds=30), 1),
+            (now + datetime.timedelta(hours=1), 60),  # 1 hour
+            (now + datetime.timedelta(days=1), 1440),  # 1 day
+        ]
+        for future_time, expected_minutes in test_cases:
+            test_job = {"time_stamp": future_time}
+            remaining = at_remain(self.configuration, now, test_job)
+            self.assertEqual(remaining, expected_minutes)
+
+    def test_at_remain_past_job(self):
+        """Test at_remain with past job"""
+        now = datetime.datetime.now()
+        past_time = now - datetime.timedelta(minutes=30)
+        test_job = {"time_stamp": past_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, -30)
+
+    def test_at_remain_with_future_year(self):
+        """Test at_remain with future year"""
+        now = datetime.datetime.now()
+        future_year = now.replace(
+            year=now.year + 1, month=1, day=1, hour=0, minute=0, second=0
+        )
+        test_job = {"time_stamp": future_year}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_year - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_at_remain_with_next_year(self):
+        """Test at_remain with next year"""
+        now = datetime.datetime.now()
+        past_year = now.replace(year=now.year + 1)
+        test_job = {"time_stamp": past_year}
+        remaining = at_remain(self.configuration, now, test_job)
+        # Approximately 1 year in minutes
+        self.assertEqual(remaining, 525600)
+
+    def test_at_remain_with_past_year(self):
+        """Test at_remain with past year"""
+        now = datetime.datetime.now()
+        past_year = now.replace(year=now.year - 1)
+        test_job = {"time_stamp": past_year}
+        remaining = at_remain(self.configuration, now, test_job)
+        # Approximately -1 year in minutes
+        self.assertEqual(remaining, -525600)
+
+    def test_at_remain_with_same_minute_but_earlier(self):
+        """Test at_remain with same minute but a few seconds earlier"""
+        now = datetime.datetime.now()
+        now = now.replace(second=30)
+        same_minute_time = now.replace(second=42)
+        test_job = {"time_stamp": same_minute_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, 0)
+
+    def test_at_remain_with_same_minute_but_later(self):
+        """Test at_remain with same minute but a few seconds later"""
+        now = datetime.datetime.now()
+        now = now.replace(second=30)
+        same_minute_time = now.replace(second=22)
+        test_job = {"time_stamp": same_minute_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, -1)
+
+    def test_at_remain_with_same_minute_exactly(self):
+        """Test at_remain with same minute exactly"""
+        now = datetime.datetime.now()
+        now = now.replace(second=30)
+        same_minute_time = now
+        test_job = {"time_stamp": same_minute_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, 0)
+
+    def test_cron_match(self):
+        """Test cron time matching"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+        }
+        self.assertTrue(cron_match(self.configuration, now, test_job))
+
+    def test_cron_match_current_minute(self):
+        """Test cron_match identifies current time match"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "day": "*",
+            "month": "*",
+            "dayofweek": "*",
+            "dayofmonth": "*",
+        }
+        self.assertTrue(cron_match(self.configuration, now, test_job))
+
+    def test_cron_match_edge_cases(self):
+        """Test cron_match with edge case times"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_cases = [
+            (
+                {
+                    "minute": "0",
+                    "hour": "0",
+                    "dayofmonth": "1",
+                    "month": "1",
+                    "dayofweek": "0",
+                },
+                now.replace(hour=0, minute=0, day=1, month=1),
+            ),
+            (
+                {
+                    "minute": "59",
+                    "hour": "23",
+                    "dayofmonth": "31",
+                    "month": "12",
+                    "dayofweek": "6",
+                },
+                now.replace(hour=23, minute=59, day=31, month=12),
+            ),
+        ]
+        for job, match_time in test_cases:
+            self.assertEqual(
+                cron_match(self.configuration, match_time, job),
+                match_time == now,
+            )
+
+    def test_cron_match_with_all_wildcards(self):
+        """Test cron_match with all wildcards"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+        }
+        self.assertTrue(cron_match(self.configuration, now, test_job))
+
+    def test_cron_match_with_single_digit_values(self):
+        """Test cron_match with single digit values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_cases = [
+            (
+                {
+                    "minute": "5",
+                    "hour": "3",
+                    "dayofmonth": "7",
+                    "month": "6",
+                    "dayofweek": "1",
+                },
+                now.replace(minute=5, hour=3, day=7, month=6),
+            ),
+            (
+                {
+                    "minute": "0",
+                    "hour": "0",
+                    "dayofmonth": "1",
+                    "month": "1",
+                    "dayofweek": "0",
+                },
+                now.replace(minute=0, hour=0, day=1, month=1),
+            ),
+        ]
+        for job, match_time in test_cases:
+            self.assertEqual(
+                cron_match(self.configuration, match_time, job),
+                match_time == now,
+            )
+
+    def test_cron_match_with_specific_time(self):
+        """Test cron_match rejects non-matching time"""
+        now = datetime.datetime.now().replace(
+            hour=3, minute=15, second=0, microsecond=0
+        )
+        test_job = {
+            "minute": "30",
+            "hour": "2",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+        }
+        self.assertFalse(cron_match(self.configuration, now, test_job))
+
+    def test_cron_match_with_step_values(self):
+        """Test cron_match with step values (not supported but should handle)"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "*/5",
+            "hour": "2",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+        }
+        # Should fail since steps aren't supported, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_cron_match_with_wildcards(self):
+        """Test cron_match with various wildcard combinations"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_cases = [
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                True,
+            ),
+            (
+                {
+                    "minute": "15",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.minute == 15,
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "3",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.hour == 3,
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "15",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.day == 15,
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "6",
+                    "dayofweek": "*",
+                },
+                now.month == 6,
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "0",
+                },
+                now.weekday() == 0,
+            ),
+        ]
+        for job, expected in test_cases:
+            self.assertEqual(cron_match(
+                self.configuration, now, job), expected)
+
+    def test_cron_match_specific_time(self):
+        """Test cron_match rejects non-matching time"""
+        now = datetime.datetime.now().replace(
+            hour=3, minute=15, second=0, microsecond=0
+        )
+        test_job = {
+            "minute": "30",
+            "hour": "2",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+        }
+        self.assertFalse(cron_match(self.configuration, now, test_job))
+
+    @unittest.skip("enable next if ever relevant - fails with TypeError")
+    def test_at_remain_with_timezones(self):
+        """Test at_remain with different timezones"""
+        now = datetime.datetime.now()
+        test_cases = [
+            (
+                now.astimezone(datetime.timezone.utc)
+                + datetime.timedelta(minutes=30),
+                30,
+            ),
+            (
+                now.astimezone(datetime.timezone.utc)
+                - datetime.timedelta(minutes=30),
+                -30,
+            ),
+        ]
+        for future_time, expected_minutes in test_cases:
+            test_job = {"time_stamp": future_time}
+            remaining = at_remain(self.configuration, now, test_job)
+            self.assertEqual(remaining, expected_minutes)
+
+    # TODO: invert next when we implement feature at some point
+    def test_cron_match_with_range_values(self):
+        """Test cron_match with range values (not supported yet)"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "10-20",
+            "hour": "2",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+        }
+        # Should fail since ranges aren't supported, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    @unittest.skip("implement value range check in function and enable next")
+    def test_cron_match_with_invalid_values(self):
+        """Test cron_match with invalid values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "60",
+            "hour": "25",
+            "dayofmonth": "32",
+            "month": "13",
+            "dayofweek": "7",
+        }
+        # Should fail since values are invalid, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_past_time(self):
+        """Test at_remain with past time"""
+        now = datetime.datetime.now()
+        past_time = now - datetime.timedelta(minutes=5)
+        test_job = {"time_stamp": past_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, -5)
+
+    # TODO: invert next when we implement feature at some point
+    def test_cron_match_with_division_values(self):
+        """Test cron_match with division values (not supported yet)"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "month": "*/1",
+            "dayofweek": "*",
+        }
+        # Should fail since divide format is not yet allowed
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_future_time(self):
+        """Test at_remain with future time"""
+        now = datetime.datetime.now()
+        future_time = now + datetime.timedelta(minutes=5)
+        test_job = {"time_stamp": future_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        self.assertEqual(remaining, 5)
+
+    @unittest.skip("implement extra value check in function and enable next")
+    def test_cron_match_with_extra_fields(self):
+        """Test cron_match with extra fields"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+            "extra_field": "value",
+        }
+        # Should fail since extra fields are present, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    # NOTE: no datetime support https://github.com/python/cpython/issues/67762
+    @unittest.skip("enable if leap second handling is ever implemented")
+    def test_at_remain_with_leap_second(self):
+        """Test at_remain with leap second"""
+        # December 31, 2016, had a leap second to include time 23:59:60
+        now = datetime.datetime.now(datetime.timezone.utc)
+        t_minus_sixty = now.replace(
+            year=2016,
+            month=12,
+            day=31,
+            hour=23,
+            minute=59,
+            second=0,
+            microsecond=0,
+        )
+        leap_second = t_minus_sixty + datetime.timedelta(seconds=60)
+        t_plus_sixty = now.replace(
+            year=2017,
+            month=1,
+            day=1,
+            hour=0,
+            minute=0,
+            second=59,
+            microsecond=0,
+        )
+        self.assertEqual(
+            (t_plus_sixty - t_minus_sixty).total_seconds(),
+            120,
+            "Leap second does not appear supported",
+        )
+        test_job = {"time_stamp": t_plus_sixty}
+        remaining = at_remain(self.configuration, leap_second, test_job)
+        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
+        #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
+        self.assertEqual(remaining, 1)
+
+    def test_cron_match_with_invalid_chars(self):
+        """Test cron_match with invalid characters"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "Sunday",
+        }
+        # Should fail since invalid characters are present, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_dst_end(self):
+        """Test at_remain with DST end"""
+        # This test may fail depending on the system's timezone and DST rules
+        now = datetime.datetime.now()
+        dst_end_time = now.replace(month=11, day=5, hour=1, minute=30)
+        test_job = {"time_stamp": dst_end_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (dst_end_time - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_cron_match_with_extra_whitespace(self):
+        """Test cron_match with extra whitespace"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": " * ",
+            "hour": " * ",
+            "dayofmonth": " * ",
+            "month": " * ",
+            "dayofweek": " * ",
+        }
+        # Should fail since extra whitespace isn't allowed
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_future_dst_transition(self):
+        """Test at_remain with future DST transition"""
+        # This test may fail depending on the system's timezone and DST rules
+        now = datetime.datetime.now()
+        future_dst_time = now.replace(month=3, day=12, hour=2, minute=30)
+        test_job = {"time_stamp": future_dst_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_dst_time - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    @unittest.skip("implement extra value check in function and enable next")
+    def test_cron_match_with_invalid_field_count(self):
+        """Test cron_match with invalid field count"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+            "extra_field": "*",
+        }
+        # Should fail since field count is invalid, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_past_dst_transition(self):
+        """Test at_remain with past DST transition"""
+        # This test may fail depending on the system's timezone and DST rules
+        now = datetime.datetime.now()
+        past_dst_time = now.replace(month=11, day=5, hour=1, minute=30)
+        test_job = {"time_stamp": past_dst_time}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (past_dst_time - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_cron_match_with_missing_fields(self):
+        """Test cron_match with missing fields"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "dayofweek": "*",
+        }
+        # NOTE: throws exception before log since values must be strings
+        with self.assertRaises(Exception):
+            cron_match(self.configuration, now, test_job)
+
+    # NOTE: no datetime support https://github.com/python/cpython/issues/67762
+    @unittest.skip("enable if leap second handling is ever implemented")
+    def test_at_remain_with_past_leap_second(self):
+        """Test at_remain with past leap second"""
+        # December 31, 2016, had a leap second to include time 23:59:60
+        now = datetime.datetime.now(datetime.timezone.utc)
+        t_minus_sixty = now.replace(
+            year=2016,
+            month=12,
+            day=31,
+            hour=23,
+            minute=59,
+            second=0,
+            microsecond=0,
+        )
+        leap_second = t_minus_sixty + datetime.timedelta(seconds=60)
+        t_plus_sixty = now.replace(
+            year=2017,
+            month=1,
+            day=1,
+            hour=0,
+            minute=0,
+            second=59,
+            microsecond=0,
+        )
+        t_plus_sixtyone = now.replace(
+            year=2017, month=1, day=1, hour=0, minute=1, second=0, microsecond=0
+        )
+        self.assertEqual(
+            (t_plus_sixty - t_minus_sixty).total_seconds(),
+            120,
+            "Leap second does not appear supported",
+        )
+        test_job = {"time_stamp": leap_second}
+        remaining = at_remain(self.configuration, t_plus_sixty, test_job)
+        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
+        #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
+        self.assertEqual(remaining, -1)
+        remaining = at_remain(self.configuration, t_plus_sixtyone, test_job)
+        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
+        #      (t_minus_sixty, leap_second, t_plus_sixtyone, remaining))
+        self.assertEqual(remaining, -2)
+
+    def test_cron_match_with_non_string_values(self):
+        """Test cron_match with non-string values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": 15,
+            "hour": 3,
+            "dayofmonth": 7,
+            "month": 6,
+            "dayofweek": 1,
+        }
+        # NOTE: throws exception before log since values must be strings
+        with self.assertRaises(Exception):
+            cron_match(self.configuration, now, test_job)
+
+    # NOTE: no datetime support https://github.com/python/cpython/issues/67762
+    @unittest.skip("enable if leap second handling is ever implemented")
+    def test_at_remain_with_future_leap_second(self):
+        """Test at_remain with future leap second"""
+        # December 31, 2016, had a leap second to include time 23:59:60
+        now = datetime.datetime.now(datetime.timezone.utc)
+        t_minus_sixty = now.replace(
+            year=2016,
+            month=12,
+            day=31,
+            hour=23,
+            minute=59,
+            second=0,
+            microsecond=0,
+        )
+        leap_second = t_minus_sixty + datetime.timedelta(seconds=60)
+        t_plus_sixty = now.replace(
+            year=2017,
+            month=1,
+            day=1,
+            hour=0,
+            minute=0,
+            second=59,
+            microsecond=0,
+        )
+        self.assertEqual(
+            (t_plus_sixty - t_minus_sixty).total_seconds(),
+            120,
+            "Leap second does not appear supported",
+        )
+        test_job = {"time_stamp": leap_second}
+        remaining = at_remain(self.configuration, t_minus_sixty, test_job)
+        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
+        #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
+        self.assertEqual(remaining, 1)
+
+    def test_cron_match_with_boolean_values(self):
+        """Test cron_match with boolean values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": True,
+            "hour": False,
+            "dayofmonth": True,
+            "month": False,
+            "dayofweek": True,
+        }
+        # NOTE: throws exception before log since values must be strings
+        with self.assertRaises(Exception):
+            cron_match(self.configuration, now, test_job)
+
+    def test_cron_match_with_none_values(self):
+        """Test cron_match with none values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": None,
+            "hour": None,
+            "dayofmonth": None,
+            "month": None,
+            "dayofweek": None,
+        }
+        # NOTE: throws exception before log since values must be strings
+        with self.assertRaises(Exception):
+            cron_match(self.configuration, now, test_job)
+
+    def test_at_remain_with_leap_year(self):
+        """Test at_remain with leap year"""
+        now = datetime.datetime.now()
+        leap_day = datetime.datetime(
+            now.year + 4 - now.year // 4, 2, 29, 12, 0
+        )  # Next leap year
+        test_job = {"time_stamp": leap_day}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (leap_day - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_at_remain_with_future_leap_year(self):
+        """Test at_remain with future leap year"""
+        now = datetime.datetime.now()
+        future_leap_year = now.replace(
+            year=2096, month=2, day=29, hour=12, minute=0
+        )
+        test_job = {"time_stamp": future_leap_year}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_leap_year - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_at_remain_with_past_leap_year(self):
+        """Test at_remain with past leap year"""
+        now = datetime.datetime.now()
+        past_leap_year = now.replace(
+            year=2000, month=2, day=29, hour=12, minute=0
+        )
+        test_job = {"time_stamp": past_leap_year}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (past_leap_year - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_cron_match_with_tab_values(self):
+        """Test cron_match with tab values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "\t",
+            "hour": "\t",
+            "dayofmonth": "\t",
+            "month": "\t",
+            "dayofweek": "\t",
+        }
+        # Should fail since values are tabs, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_future_millennium(self):
+        """Test at_remain with future millennium"""
+        now = datetime.datetime.now()
+        future_millennium = now.replace(
+            year=now.year + 1000, month=1, day=1, hour=0, minute=0
+        )
+        test_job = {"time_stamp": future_millennium}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_millennium - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_cron_match_with_newline_values(self):
+        """Test cron_match with newline values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "\n",
+            "hour": "\n",
+            "dayofmonth": "\n",
+            "month": "\n",
+            "dayofweek": "\n",
+        }
+        # Should fail since values are newlines, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_past_millennium(self):
+        """Test at_remain with past millennium"""
+        now = datetime.datetime.now()
+        past_millennium = now.replace(
+            year=now.year - 1000, month=1, day=1, hour=0, minute=0
+        )
+        test_job = {"time_stamp": past_millennium}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (past_millennium - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_cron_match_with_carriage_return_values(self):
+        """Test cron_match with carriage return values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "\r",
+            "hour": "\r",
+            "dayofmonth": "\r",
+            "month": "\r",
+            "dayofweek": "\r",
+        }
+        # Should fail since values are carriage returns, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_future_millennium_end(self):
+        """Test at_remain with future millennium end"""
+        now = datetime.datetime.now()
+        future_millennium_end = now.replace(
+            year=now.year + 1000, month=12, day=31, hour=23, minute=59
+        )
+        test_job = {"time_stamp": future_millennium_end}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_millennium_end - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_cron_match_with_vertical_tab_values(self):
+        """Test cron_match with vertical tab values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "\v",
+            "hour": "\v",
+            "dayofmonth": "\v",
+            "month": "\v",
+            "dayofweek": "\v",
+        }
+        # Should fail since values are vertical tabs, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_past_millennium_end(self):
+        """Test at_remain with past millennium end"""
+        now = datetime.datetime.now()
+        past_millennium_end = now.replace(
+            year=now.year - 1000, month=12, day=31, hour=23, minute=59
+        )
+        test_job = {"time_stamp": past_millennium_end}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (past_millennium_end - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_cron_match_with_form_feed_values(self):
+        """Test cron_match with form feed values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "\f",
+            "hour": "\f",
+            "dayofmonth": "\f",
+            "month": "\f",
+            "dayofweek": "\f",
+        }
+        # Should fail since values are form feeds, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_future_century_end(self):
+        """Test at_remain with future century end"""
+        now = datetime.datetime.now()
+        future_century_end = now.replace(
+            year=now.year + 100, month=12, day=31, hour=23, minute=59
+        )
+        test_job = {"time_stamp": future_century_end}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_century_end - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_cron_match_with_escape_values(self):
+        """Test cron_match with escape values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "\\",
+            "hour": "\\",
+            "dayofmonth": "\\",
+            "month": "\\",
+            "dayofweek": "\\",
+        }
+        # Should fail since values are escapes, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_past_century_end(self):
+        """Test at_remain with past century end"""
+        now = datetime.datetime.now()
+        past_century_end = now.replace(
+            year=now.year - 100, month=12, day=31, hour=23, minute=59
+        )
+        test_job = {"time_stamp": past_century_end}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (past_century_end - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_cron_match_with_delete_values(self):
+        """Test cron_match with delete values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": "\x7f",
+            "hour": "\x7f",
+            "dayofmonth": "\x7f",
+            "month": "\x7f",
+            "dayofweek": "\x7f",
+        }
+        # Should fail since values are deletes, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_future_century_start(self):
+        """Test at_remain with future century start"""
+        now = datetime.datetime.now()
+        future_century_start = now.replace(
+            year=now.year + 100, month=1, day=1, hour=0, minute=0
+        )
+        test_job = {"time_stamp": future_century_start}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (future_century_start - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+    def test_cron_match_with_space_values(self):
+        """Test cron_match with space values"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_job = {
+            "minute": " ",
+            "hour": " ",
+            "dayofmonth": " ",
+            "month": " ",
+            "dayofweek": " ",
+        }
+        # Should fail since values are spaces, but shouldn't crash
+        # NOTE: tweak cron_match use for missing debug log access in assertLogs
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
+            self.assertFalse(result)
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
+
+    def test_at_remain_with_past_century_start(self):
+        """Test at_remain with past century start"""
+        now = datetime.datetime.now()
+        past_century_start = now.replace(
+            year=now.year - 100, month=1, day=1, hour=0, minute=0
+        )
+        test_job = {"time_stamp": past_century_start}
+        remaining = at_remain(self.configuration, now, test_job)
+        expected_minutes = (past_century_start - now).total_seconds() // 60
+        self.assertEqual(remaining, expected_minutes)
+
+
+class MigLibEvents__expand_vars(MigTestCase):
+    """Unit tests for variable expansion events helper functions"""
+
+    def _provide_configuration(self):
+        """Prepare isolated test config"""
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test configuration and reset state before each test"""
+        # Enable events in configuration
+        self.configuration.site_enable_crontab = True
+
+    def test_get_path_expand_map(self):
+        """Test path expansion map generation"""
+        trigger_path = "/test/path/file.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertIn("+TRIGGERPATH+", expanded)
+        self.assertEqual(expanded["+TRIGGERPATH+"], trigger_path)
+
+    def test_get_path_expand_map_empty_path(self):
+        """Test path expansion with empty path"""
+        trigger_path = ""
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        with self.assertRaises(ValueError):
+            get_path_expand_map(trigger_path, rule, "modified")
+
+    def test_get_path_expand_map_with_leading_slash(self):
+        """Test path expansion with leading slash"""
+        trigger_path = "/file.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(expanded["+TRIGGERPATH+"], "/file.txt")
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
+
+    def test_get_path_expand_map_with_no_extension(self):
+        """Test path expansion with no extension"""
+        trigger_path = "/test/path/file"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], "")
+
+    def test_get_path_expand_map_with_relative_path(self):
+        """Test path expansion with relative path"""
+        trigger_path = "../relative/path/file.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(expanded["+TRIGGERPATH+"],
+                         "../relative/path/file.txt")
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
+
+    def test_get_path_expand_map_with_spaces(self):
+        """Test path expansion with spaces"""
+        trigger_path = "/test/path/file with spaces.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertIn("+TRIGGERFILENAME+", expanded)
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file with spaces.txt")
+
+    def test_get_path_expand_map_with_special_chars(self):
+        """Test path expansion with special characters"""
+        trigger_path = "/test/path/file@name#with$special&chars.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(
+            expanded["+TRIGGERFILENAME+"], "file@name#with$special&chars.txt"
+        )
+        self.assertEqual(
+            expanded["+TRIGGERPREFIX+"], "file@name#with$special&chars"
+        )
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
+
+    def test_get_path_expand_map_with_unicode(self):
+        """Test path expansion with unicode characters"""
+        trigger_path = "/test/path/файл.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "файл.txt")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "файл")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
+
+    def test_get_path_expand_map_with_url(self):
+        """Test path expansion with URL"""
+        trigger_path = "http://example.com/file.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(
+            expanded["+TRIGGERPATH+"], "http://example.com/file.txt"
+        )
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
+
+    def test_get_path_expand_map_with_windows_path(self):
+        """Test path expansion with Windows path"""
+        trigger_path = "C:\\path\\to\\file.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(expanded["+TRIGGERPATH+"], "C:\\path\\to\\file.txt")
+        self.assertEqual(
+            expanded["+TRIGGERFILENAME+"], "C:\\path\\to\\file.txt"
+        )
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "C:\\path\\to\\file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
+
+    def test_get_path_expand_map_with_query_string(self):
+        """Test path expansion with query string"""
+        trigger_path = "/test/path/file.txt?param=value"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(
+            expanded["+TRIGGERPATH+"], "/test/path/file.txt?param=value"
+        )
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt?param=value")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt?param=value")
+
+    def test_get_path_expand_map_with_encoded_chars(self):
+        """Test path expansion with encoded characters"""
+        trigger_path = "/test/path/file%20with%20spaces.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(
+            expanded["+TRIGGERPATH+"], "/test/path/file%20with%20spaces.txt"
+        )
+        self.assertEqual(
+            expanded["+TRIGGERFILENAME+"], "file%20with%20spaces.txt"
+        )
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file%20with%20spaces")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
+
+    def test_get_time_expand_map(self):
+        """Test time expansion map generation"""
+        timestamp = datetime.datetime(2023, 1, 2, 9, 2)
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertIn("+SCHEDYEAR+", expanded)
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
+
+    def test_get_time_expand_map_edge_cases(self):
+        """Test time expansion with edge cases"""
+        timestamp = datetime.datetime(2023, 12, 31, 23, 59)
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "31")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
+        self.assertEqual(expanded["+SCHEDHOUR+"], "23")
+        self.assertEqual(expanded["+SCHEDMINUTE+"], "59")
+
+    def test_get_time_expand_map_with_milliseconds(self):
+        """Test time expansion with milliseconds"""
+        timestamp = datetime.datetime(2023, 1, 2, 9, 2, 30, 123456)
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDSECOND+"], "30")
+        self.assertEqual(expanded["+SCHEDMINUTE+"], "02")
+        self.assertEqual(expanded["+SCHEDHOUR+"], "09")
+        self.assertEqual(expanded["+SCHEDDAY+"], "02")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
+        self.assertEqual(expanded["+SCHEDDAYOFWEEK+"], "0")
+
+    def test_get_time_expand_map_with_summer_time(self):
+        """Test time expansion with summer time (DST)"""
+        # This test may fail depending on the system's timezone and DST rules
+        # Summer in Northern Hemisphere
+        timestamp = datetime.datetime(2023, 7, 1, 12, 0)
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "07")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
+
+    def test_get_time_expand_map_with_dst_transition(self):
+        """Test time expansion with DST transition"""
+        # This test may fail depending on the system's timezone and DST rules
+        timestamp = datetime.datetime(
+            2023, 3, 12, 2, 30
+        )  # DST transition in US
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "12")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "03")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
+
+    def test_get_time_expand_map_with_dst_start(self):
+        """Test time expansion with DST start"""
+        # This test may fail depending on the system's timezone and DST rules
+        timestamp = datetime.datetime(2023, 3, 12, 3, 0)  # DST start in US
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "12")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "03")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
+
+    def test_get_time_expand_map_with_dst_end(self):
+        """Test time expansion with DST end"""
+        # This test may fail depending on the system's timezone and DST rules
+        timestamp = datetime.datetime(2023, 11, 5, 1, 30)
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "05")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "11")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
+
+    def test_get_time_expand_map_leap_year(self):
+        """Test time expansion with leap year"""
+        timestamp = datetime.datetime(2024, 2, 29, 12, 0)  # Leap day
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "29")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "02")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2024")
+
+    def test_get_time_expand_map_with_leap_year_start(self):
+        """Test time expansion with leap year start"""
+        timestamp = datetime.datetime(2024, 1, 1, 0, 0)  # Leap year
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2024")
+
+    def test_get_time_expand_map_with_leap_year_end(self):
+        """Test time expansion with leap year end"""
+        timestamp = datetime.datetime(2024, 12, 31, 23, 59)  # Leap year
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "31")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2024")
+
+    def test_get_time_expand_map_with_new_year(self):
+        """Test time expansion with New Year"""
+        timestamp = datetime.datetime(2023, 1, 1, 0, 0)
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
+
+    def test_get_time_expand_map_with_first_day(self):
+        """Test time expansion with first day of month"""
+        timestamp = datetime.datetime(2023, 1, 1, 0, 0)
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
+
+    def test_get_time_expand_map_with_last_day(self):
+        """Test time expansion with last day of month"""
+        timestamp = datetime.datetime(2023, 1, 31, 23, 59)
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "31")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
+
+    def test_get_time_expand_map_with_zero_values(self):
+        """Test time expansion with zero values"""
+        timestamp = datetime.datetime(2023, 1, 1, 0, 0)
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDSECOND+"], "00")
+        self.assertEqual(expanded["+SCHEDMINUTE+"], "00")
+        self.assertEqual(expanded["+SCHEDHOUR+"], "00")
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
+        self.assertEqual(expanded["+SCHEDDAYOFWEEK+"], "6")  # Sunday
+
+    def test_get_path_expand_map_with_no_path(self):
+        """Test path expansion with no path (just filename)"""
+        trigger_path = "file.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(expanded["+TRIGGERPATH+"], "file.txt")
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
+
+    def test_get_path_expand_map_with_fragment(self):
+        """Test path expansion with fragment"""
+        trigger_path = "/test/path/file.txt#fragment"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(
+            expanded["+TRIGGERPATH+"], "/test/path/file.txt#fragment"
+        )
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt#fragment")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt#fragment")
+
+    def test_get_time_expand_map_with_century_year(self):
+        """Test time expansion with century year"""
+        timestamp = datetime.datetime(2100, 1, 1, 0, 0)  # Year 2100
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2100")
+
+    def test_get_time_expand_map_with_millennium_year(self):
+        """Test time expansion with millennium year"""
+        timestamp = datetime.datetime(2000, 1, 1, 0, 0)  # Year 2000
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2000")
+
+    def test_get_time_expand_map_with_year_zero(self):
+        """Test time expansion with year zero"""
+        timestamp = datetime.datetime(1, 1, 1, 0, 0)  # Year 1
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "1")
+
+    def test_get_time_expand_map_with_year_0001(self):
+        """Test time expansion with year 0001"""
+        timestamp = datetime.datetime(1, 1, 1, 0, 0)  # Year 1
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "1")
+
+    def test_get_time_expand_map_with_year_0001_end(self):
+        """Test time expansion with year 0001 end"""
+        timestamp = datetime.datetime(1, 12, 31, 23, 59)  # Year 1
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "31")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "1")
+
+    def test_get_time_expand_map_with_year_0001_start(self):
+        """Test time expansion with year 0001 start"""
+        timestamp = datetime.datetime(1, 1, 1, 0, 0)  # Year 1
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "1")
+
+    def test_get_time_expand_map_with_year_9999(self):
+        """Test time expansion with year 9999"""
+        timestamp = datetime.datetime(9999, 12, 31, 23, 59)
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "31")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "9999")
+
+    def test_get_time_expand_map_with_year_9999_start(self):
+        """Test time expansion with year 9999 start"""
+        timestamp = datetime.datetime(9999, 1, 1, 0, 0)  # Year 9999
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "9999")
+
+    def test_get_time_expand_map_with_year_9999_end(self):
+        """Test time expansion with year 9999 end"""
+        timestamp = datetime.datetime(9999, 12, 31, 23, 59)
+        rule = {"run_as": DUMMY_USER_DN}
+        expanded = get_time_expand_map(timestamp, rule)
+        self.assertEqual(expanded["+SCHEDDAY+"], "31")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "9999")
+
+
+class MigLibEvents__schedule(MigTestCase):
+    """Unit tests for schedule events helper functions"""
 
     def _provide_configuration(self):
         """Prepare isolated test config"""
@@ -71,24 +1450,9 @@ class MigLibEvents(MigTestCase):
         ensure_dirs_exist(self.configuration.user_home)
         ensure_dirs_exist(self.configuration.user_settings)
         ensure_dirs_exist(self.configuration.user_cache)
-        ensure_dirs_exist(self.configuration.mig_system_files)
 
         # Prepare user DB with a single dummy user for all tests
         self._provision_test_user(self, DUMMY_USER_DN)
-
-    def test_load_crontab(self):
-        """Test loading crontab from file"""
-        crontab_path = os.path.join(
-            self.configuration.user_settings,
-            DUMMY_CLIENT_DIR,
-            DUMMY_CRONTAB_NAME,
-        )
-        ensure_dirs_exist(os.path.dirname(crontab_path))
-        with open(crontab_path, "w") as fd:
-            fd.write(DUMMY_CRONTAB_CONTENT)
-
-        crontab = load_crontab(DUMMY_USER_DN, self.configuration)
-        self.assertIn("* * * * * /bin/test_command", crontab)
 
     def test_load_atjobs(self):
         """Test loading atjobs from file"""
@@ -104,14 +1468,44 @@ class MigLibEvents(MigTestCase):
         atjobs = load_atjobs(DUMMY_USER_DN, self.configuration)
         self.assertIn("2042-01-01 12:34:56 /bin/future_command", atjobs)
 
-    def test_parse_crontab_contents(self):
-        """Test parsing crontab content lines"""
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN,
-            DUMMY_CRONTAB_CONTENT.splitlines()
+    def test_load_crontab(self):
+        """Test loading crontab from file"""
+        crontab_path = os.path.join(
+            self.configuration.user_settings,
+            DUMMY_CLIENT_DIR,
+            DUMMY_CRONTAB_NAME,
         )
-        self.assertEqual(len(parsed), 2)
-        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
+        ensure_dirs_exist(os.path.dirname(crontab_path))
+        with open(crontab_path, "w") as fd:
+            fd.write(DUMMY_CRONTAB_CONTENT)
+
+        crontab = load_crontab(DUMMY_USER_DN, self.configuration)
+        self.assertIn("* * * * * /bin/test_command", crontab)
+
+    def test_parse_and_save_atjobs(self):
+        """Test parsing and saving atjobs"""
+        status, msg = parse_and_save_atjobs(
+            DUMMY_ATJOBS_CONTENT, DUMMY_USER_DN, self.configuration
+        )
+        self.assertTrue(status)
+        self.assertIn("valid atjobs entries", msg)
+
+    def test_parse_and_save_crontab(self):
+        """Test parsing and saving crontab"""
+        status, msg = parse_and_save_crontab(
+            DUMMY_CRONTAB_CONTENT, DUMMY_USER_DN, self.configuration
+        )
+        self.assertTrue(status)
+        self.assertIn("valid crontab entries", msg)
+
+    def test_parse_atjobs(self):
+        """Test parsing atjobs content lines"""
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN,
+            DUMMY_ATJOBS_CONTENT.splitlines()
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
 
     def test_parse_atjobs_contents(self):
         """Test parsing atjobs content lines"""
@@ -122,96 +1516,665 @@ class MigLibEvents(MigTestCase):
         self.assertEqual(len(parsed), 1)
         self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
 
-    def test_parse_and_save_crontab(self):
-        """Test parsing and saving crontab"""
-        status, msg = parse_and_save_crontab(
-            DUMMY_CRONTAB_CONTENT, DUMMY_USER_DN, self.configuration
+    def test_parse_crontab(self):
+        """Test parsing crontab content lines"""
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN,
+            DUMMY_CRONTAB_CONTENT.splitlines()
         )
-        self.assertTrue(status)
-        self.assertIn("valid crontab entries", msg)
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
 
-    def test_parse_and_save_atjobs(self):
-        """Test parsing and saving atjobs"""
-        status, msg = parse_and_save_atjobs(
-            DUMMY_ATJOBS_CONTENT, DUMMY_USER_DN, self.configuration
+    def test_parse_crontab_contents(self):
+        """Test parsing crontab content lines"""
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN,
+            DUMMY_CRONTAB_CONTENT.splitlines()
         )
-        self.assertTrue(status)
-        self.assertIn("valid atjobs entries", msg)
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
 
-    def test_cron_match(self):
-        """Test cron time matching"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "*",
-            "hour": "*",
-            "dayofmonth": "*",
-            "month": "*",
-            "dayofweek": "*",
-        }
-        self.assertTrue(cron_match(self.configuration, now, test_job))
-
-    def test_at_remain(self):
-        """Test at job remaining time calculation"""
-        now = datetime.datetime.now()
-        future_time = now + datetime.timedelta(minutes=30)
-        test_job = {"time_stamp": future_time}
-        remaining = at_remain(self.configuration, now, test_job)
-        self.assertEqual(remaining, 30)
-
-    def test_get_path_expand_map(self):
-        """Test path expansion map generation"""
-        trigger_path = "/test/path/file.txt"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertIn("+TRIGGERPATH+", expanded)
-        self.assertEqual(expanded["+TRIGGERPATH+"], trigger_path)
-
-    def test_get_time_expand_map(self):
-        """Test time expansion map generation"""
-        timestamp = datetime.datetime(2023, 1, 2, 9, 2)
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertIn("+SCHEDYEAR+", expanded)
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
-
-    def test_run_cron_command_touch_succeeds(self):
-        """Test running cron command touch succeeds"""
-        target_path = "test.txt"
-        command_list = ["touch", target_path]
-        crontab_entry = {"run_as": DUMMY_USER_DN}
-        abs_target_path = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, target_path
+    def test_parse_valid_crontab_file(self):
+        """Test parsing valid crontab file"""
+        crontab_path = os.path.join(
+            self.configuration.user_settings,
+            DUMMY_CLIENT_DIR,
+            DUMMY_CRONTAB_NAME,
         )
-        if os.path.exists(abs_target_path):
-            os.remove(abs_target_path)
-        self.assertFalse(os.path.exists(abs_target_path))
+        ensure_dirs_exist(os.path.dirname(crontab_path))
+        with open(crontab_path, "w") as fd:
+            fd.write(DUMMY_CRONTAB_CONTENT)
 
-        try:
-            run_cron_command(
-                command_list, target_path, crontab_entry, self.configuration
+        parsed = parse_crontab(self.configuration, DUMMY_USER_DN, crontab_path)
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
+
+    def test_parse_empty_crontab_file(self):
+        """Test parsing empty crontab file"""
+        crontab_path = os.path.join(
+            self.configuration.user_settings,
+            DUMMY_CLIENT_DIR,
+            DUMMY_CRONTAB_NAME,
+        )
+        ensure_dirs_exist(os.path.dirname(crontab_path))
+        open(crontab_path, "a").close()  # Create empty file
+
+        parsed = parse_crontab(self.configuration, DUMMY_USER_DN, crontab_path)
+        self.assertEqual(parsed, [])
+
+    def test_parse_valid_atjobs_file(self):
+        """Test parsing valid atjobs file"""
+        atjobs_path = os.path.join(
+            self.configuration.user_settings,
+            DUMMY_CLIENT_DIR,
+            DUMMY_ATJOBS_NAME,
+        )
+        ensure_dirs_exist(os.path.dirname(atjobs_path))
+        with open(atjobs_path, "w") as fd:
+            fd.write(DUMMY_ATJOBS_CONTENT)
+
+        parsed = parse_atjobs(self.configuration, DUMMY_USER_DN, atjobs_path)
+        self.assertEqual(len(parsed), 1)
+        self.assertTrue(parsed[0]["time_stamp"] > datetime.datetime.now())
+
+    def test_parse_empty_atjobs_file(self):
+        """Test parsing empty atjobs file"""
+        atjobs_path = os.path.join(
+            self.configuration.user_settings,
+            DUMMY_CLIENT_DIR,
+            DUMMY_ATJOBS_NAME,
+        )
+        ensure_dirs_exist(os.path.dirname(atjobs_path))
+        open(atjobs_path, "a").close()  # Create empty file
+
+        parsed = parse_atjobs(self.configuration, DUMMY_USER_DN, atjobs_path)
+        self.assertEqual(parsed, [])
+
+    def test_parse_crontab_with_comments(self):
+        """Test parsing crontab with comments"""
+        crontab_content = """# This is a comment
+* * * * * /bin/test_command
+# Another comment
+30 2 * * * /usr/bin/another_command"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
+
+    def test_parse_atjobs_with_comments(self):
+        """Test parsing atjobs with comments"""
+        atjobs_content = """# This is a comment
+2042-01-01 12:34:56 /bin/future_command
+# Another comment"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
+
+    def test_parse_crontab_with_invalid_lines(self):
+        """Test parsing crontab with invalid lines"""
+        crontab_content = """* * * * * /bin/test_command
+invalid line
+30 2 * * * /usr/bin/another_command"""
+        crontab_lines = crontab_content.splitlines()
+        with self.assertLogs(level="WARNING") as log_capture:
+            parsed = parse_crontab_contents(
+                self.configuration, DUMMY_USER_DN, crontab_lines
             )
-            self.assertTrue(True)  # If no exception, test passes
-            self.assertTrue(os.path.exists(abs_target_path))
-        except Exception as exc:
-            self.fail("run_cron_command raised an exception: %s" % exc)
-
-    def test_run_events_command_touch_succeeds(self):
-        """Test running events command touch succeeds"""
-        target_path = "test.txt"
-        command_list = ["touch", target_path]
-        rule = {"run_as": DUMMY_USER_DN}
-        abs_target_path = os.path.join(
-            self.configuration.user_home, DUMMY_CLIENT_DIR, target_path
-        )
-        self.assertFalse(os.path.exists(abs_target_path))
-        try:
-            run_events_command(
-                command_list, target_path, rule, self.configuration
+            self.assertEqual(len(parsed), 2)
+            self.assertTrue(
+                any(
+                    "Skip invalid crontab line" in msg
+                    for msg in log_capture.output
+                )
             )
-            self.assertTrue(True)  # If no exception, test passes
-            self.assertTrue(os.path.exists(abs_target_path))
-        except Exception as exc:
-            self.fail("run_events_command raised an exception: %s" % exc)
+
+    def test_parse_atjobs_with_invalid_lines(self):
+        """Test parsing atjobs with invalid lines"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/future_command
+invalid line
+2042-01-02 12:34:56 /bin/another_command"""
+        atjobs_lines = atjobs_content.splitlines()
+        with self.assertLogs(level="WARNING") as log_capture:
+            parsed = parse_atjobs_contents(
+                self.configuration, DUMMY_USER_DN, atjobs_lines
+            )
+            self.assertEqual(len(parsed), 2)
+            self.assertTrue(
+                any(
+                    "Skip invalid atjobs line" in msg
+                    for msg in log_capture.output
+                )
+            )
+
+    def test_parse_crontab_with_empty_lines(self):
+        """Test parsing crontab with empty lines"""
+        crontab_content = """* * * * * /bin/test_command
+
+30 2 * * * /usr/bin/another_command
+"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
+
+    def test_parse_atjobs_with_empty_lines(self):
+        """Test parsing atjobs with empty lines"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/future_command
+
+2042-01-02 12:34:56 /bin/another_command
+"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
+
+    def test_parse_crontab_with_trailing_whitespace(self):
+        """Test parsing crontab with trailing whitespace"""
+        crontab_content = """* * * * * /bin/test_command   \n"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
+
+    def test_parse_atjobs_with_trailing_whitespace(self):
+        """Test parsing atjobs with trailing whitespace"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/future_command   \n"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
+
+    @unittest.skip("enable next if we ever allow multispace")
+    def test_parse_crontab_with_multiple_spaces(self):
+        """Test parsing crontab with multiple spaces"""
+        crontab_content = """*  *  *  *  *  /bin/test_command"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
+
+    @unittest.skip("enable next if we ever allow multispace")
+    def test_parse_atjobs_with_multiple_spaces(self):
+        """Test parsing atjobs with multiple spaces"""
+        atjobs_content = """2042-01-01  12:34:56  /bin/future_command"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
+
+    @unittest.skip("enable next if we ever allow tab sep")
+    def test_parse_crontab_with_tab_separated(self):
+        """Test parsing crontab with tab-separated values"""
+        crontab_content = "*\t*\t*\t*\t*\t/bin/test_command"
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
+
+    @unittest.skip("enable next if we ever allow tab sep")
+    def test_parse_atjobs_with_tab_separated(self):
+        """Test parsing atjobs with tab-separated values"""
+        atjobs_content = "2042-01-01\t12:34:56\t/bin/future_command"
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
+
+    def test_parse_crontab_with_multiple_commands(self):
+        """Test parsing crontab with multiple commands"""
+        crontab_content = """* * * * * /bin/command1 && /bin/command2"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "&&", "/bin/command2"]
+        )
+
+    def test_parse_atjobs_with_multiple_commands(self):
+        """Test parsing atjobs with multiple commands"""
+        atjobs_content = (
+            """2042-01-01 12:34:56 /bin/command1 && /bin/command2"""
+        )
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "&&", "/bin/command2"]
+        )
+
+    def test_parse_crontab_with_semicolon(self):
+        """Test parsing crontab with semicolon"""
+        crontab_content = """* * * * * /bin/command1; /bin/command2"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1;", "/bin/command2"]
+        )
+
+    def test_parse_atjobs_with_semicolon(self):
+        """Test parsing atjobs with semicolon"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1; /bin/command2"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1;", "/bin/command2"]
+        )
+
+    def test_parse_crontab_with_backticks(self):
+        """Test parsing crontab with backticks"""
+        crontab_content = """* * * * * /bin/command1 `touch test`"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "`touch", "test`"]
+        )
+
+    def test_parse_atjobs_with_backticks(self):
+        """Test parsing atjobs with backticks"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 `touch test`"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "`touch", "test`"]
+        )
+
+    def test_parse_crontab_with_parentheses(self):
+        """Test parsing crontab with parentheses"""
+        crontab_content = """* * * * * /bin/command1 (arg1 arg2)"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "(arg1", "arg2)"]
+        )
+
+    def test_parse_atjobs_with_parentheses(self):
+        """Test parsing atjobs with parentheses"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 (arg1 arg2)"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "(arg1", "arg2)"]
+        )
+
+    def test_parse_crontab_with_brackets(self):
+        """Test parsing crontab with brackets"""
+        crontab_content = """* * * * * /bin/command1 [arg1 arg2]"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "[arg1", "arg2]"]
+        )
+
+    def test_parse_atjobs_with_brackets(self):
+        """Test parsing atjobs with brackets"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 [arg1 arg2]"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "[arg1", "arg2]"]
+        )
+
+    def test_parse_crontab_with_quotes(self):
+        """Test parsing crontab with quotes"""
+        crontab_content = '''* * * * * /bin/command1 "arg1 with spaces"'''
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "arg1 with spaces"]
+        )
+
+    def test_parse_atjobs_with_quotes(self):
+        """Test parsing atjobs with quotes"""
+        atjobs_content = (
+            '''2042-01-01 12:34:56 /bin/command1 "arg1 with spaces"'''
+        )
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "arg1 with spaces"]
+        )
+
+    def test_parse_crontab_with_single_quotes(self):
+        """Test parsing crontab with single quotes"""
+        crontab_content = """* * * * * /bin/command1 'arg1 with spaces'"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "arg1 with spaces"]
+        )
+
+    def test_parse_atjobs_with_single_quotes(self):
+        """Test parsing atjobs with single quotes"""
+        atjobs_content = (
+            """2042-01-01 12:34:56 /bin/command1 'arg1 with spaces'"""
+        )
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "arg1 with spaces"]
+        )
+
+    def test_parse_crontab_with_backslash(self):
+        """Test parsing crontab with backslash"""
+        crontab_content = """* * * * * /bin/command1 arg1\\ arg2"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "arg1 arg2"])
+
+    def test_parse_atjobs_with_backslash(self):
+        """Test parsing atjobs with backslash"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 arg1\\ arg2"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "arg1 arg2"])
+
+    def test_parse_crontab_with_double_backslash(self):
+        """Test parsing crontab with double backslash"""
+        crontab_content = """* * * * * /bin/command1 arg1\\\\ arg2"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "arg1\\", "arg2"]
+        )
+
+    def test_parse_atjobs_with_double_backslash(self):
+        """Test parsing atjobs with double backslash"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 arg1\\\\ arg2"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "arg1\\", "arg2"]
+        )
+
+    def test_parse_crontab_with_caret(self):
+        """Test parsing crontab with caret"""
+        crontab_content = """* * * * * /bin/command1 ^arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "^arg1"])
+
+    def test_parse_atjobs_with_caret(self):
+        """Test parsing atjobs with caret"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 ^arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "^arg1"])
+
+    def test_parse_crontab_with_hash(self):
+        """Test parsing crontab with hash"""
+        crontab_content = """* * * * * /bin/command1 #arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1"])
+
+    def test_parse_atjobs_with_hash(self):
+        """Test parsing atjobs with hash"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 #arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1"])
+
+    def test_parse_crontab_with_dollar(self):
+        """Test parsing crontab with dollar"""
+        crontab_content = """* * * * * /bin/command1 $arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "$arg1"])
+
+    def test_parse_atjobs_with_dollar(self):
+        """Test parsing atjobs with dollar"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 $arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "$arg1"])
+
+    def test_parse_crontab_with_percent(self):
+        """Test parsing crontab with percent"""
+        crontab_content = """* * * * * /bin/command1 %arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "%arg1"])
+
+    def test_parse_atjobs_with_percent(self):
+        """Test parsing atjobs with percent"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 %arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "%arg1"])
+
+    def test_parse_crontab_with_ampersand(self):
+        """Test parsing crontab with ampersand"""
+        crontab_content = """* * * * * /bin/command1 &arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "&arg1"])
+
+    def test_parse_atjobs_with_ampersand(self):
+        """Test parsing atjobs with ampersand"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 &arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "&arg1"])
+
+    def test_parse_crontab_with_pipe(self):
+        """Test parsing crontab with pipe"""
+        crontab_content = """* * * * * /bin/command1 | /bin/command2"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "|", "/bin/command2"]
+        )
+
+    def test_parse_atjobs_with_pipe(self):
+        """Test parsing atjobs with pipe"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 | /bin/command2"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "|", "/bin/command2"]
+        )
+
+    def test_parse_crontab_with_question_mark(self):
+        """Test parsing crontab with question mark"""
+        crontab_content = """* * * * * /bin/command1 ?arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "?arg1"])
+
+    def test_parse_atjobs_with_question_mark(self):
+        """Test parsing atjobs with question mark"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 ?arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "?arg1"])
+
+    def test_parse_crontab_with_plus(self):
+        """Test parsing crontab with plus"""
+        crontab_content = """* * * * * /bin/command1 +arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "+arg1"])
+
+    def test_parse_atjobs_with_plus(self):
+        """Test parsing atjobs with plus"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 +arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "+arg1"])
+
+    def test_parse_crontab_with_comma(self):
+        """Test parsing crontab with comma"""
+        crontab_content = """* * * * * /bin/command1,arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1,arg1"])
+
+    def test_parse_atjobs_with_comma(self):
+        """Test parsing atjobs with comma"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1,arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1,arg1"])
+
+    def test_parse_crontab_with_less_than(self):
+        """Test parsing crontab with less than"""
+        crontab_content = """* * * * * /bin/command1 <arg1"""
+        crontab_lines = crontab_content.splitlines()
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "<arg1"])
+
+    def test_parse_atjobs_with_less_than(self):
+        """Test parsing atjobs with less than"""
+        atjobs_content = """2042-01-01 12:34:56 /bin/command1 <arg1"""
+        atjobs_lines = atjobs_content.splitlines()
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "<arg1"])
+
+
+class MigLibEvents__environ(MigTestCase):
+    """Unit tests for environment events helper functions"""
+
+    def _provide_configuration(self):
+        """Prepare isolated test config"""
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test configuration and reset state before each test"""
+        # Enable events in configuration
+        self.configuration.site_enable_crontab = True
 
     def test_save_env(self):
         """Test saving (custom) environment"""
@@ -319,114 +2282,66 @@ class MigLibEvents(MigTestCase):
         self.assertEqual(restored_env, original_env)
         self.assertEqual(original_env, os.environ)
 
-    def test_parse_valid_crontab_file(self):
-        """Test parsing valid crontab file"""
-        crontab_path = os.path.join(
-            self.configuration.user_settings,
-            DUMMY_CLIENT_DIR,
-            DUMMY_CRONTAB_NAME,
+
+class MigLibEvents__runners(MigTestCase):
+    """Unit tests for task run events helper functions"""
+
+    def _provide_configuration(self):
+        """Prepare isolated test config"""
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test configuration and reset state before each test"""
+        # Enable events in configuration
+        self.configuration.site_enable_crontab = True
+
+        ensure_dirs_exist(self.configuration.user_db_home)
+        ensure_dirs_exist(self.configuration.user_home)
+        ensure_dirs_exist(self.configuration.user_settings)
+        ensure_dirs_exist(self.configuration.user_cache)
+        ensure_dirs_exist(self.configuration.mig_system_files)
+
+        # Prepare user DB with a single dummy user for all tests
+        self._provision_test_user(self, DUMMY_USER_DN)
+
+    def test_run_cron_command_touch_succeeds(self):
+        """Test running cron command touch succeeds"""
+        target_path = "test.txt"
+        command_list = ["touch", target_path]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        abs_target_path = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, target_path
         )
-        ensure_dirs_exist(os.path.dirname(crontab_path))
-        with open(crontab_path, "w") as fd:
-            fd.write(DUMMY_CRONTAB_CONTENT)
+        if os.path.exists(abs_target_path):
+            os.remove(abs_target_path)
+        self.assertFalse(os.path.exists(abs_target_path))
 
-        parsed = parse_crontab(self.configuration, DUMMY_USER_DN, crontab_path)
-        self.assertEqual(len(parsed), 2)
-        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
+        try:
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
+            self.assertTrue(True)  # If no exception, test passes
+            self.assertTrue(os.path.exists(abs_target_path))
+        except Exception as exc:
+            self.fail("run_cron_command raised an exception: %s" % exc)
 
-    def test_parse_empty_crontab_file(self):
-        """Test parsing empty crontab file"""
-        crontab_path = os.path.join(
-            self.configuration.user_settings,
-            DUMMY_CLIENT_DIR,
-            DUMMY_CRONTAB_NAME,
-        )
-        ensure_dirs_exist(os.path.dirname(crontab_path))
-        open(crontab_path, "a").close()  # Create empty file
-
-        parsed = parse_crontab(self.configuration, DUMMY_USER_DN, crontab_path)
-        self.assertEqual(parsed, [])
-
-    def test_parse_valid_atjobs_file(self):
-        """Test parsing valid atjobs file"""
-        atjobs_path = os.path.join(
-            self.configuration.user_settings,
-            DUMMY_CLIENT_DIR,
-            DUMMY_ATJOBS_NAME,
-        )
-        ensure_dirs_exist(os.path.dirname(atjobs_path))
-        with open(atjobs_path, "w") as fd:
-            fd.write(DUMMY_ATJOBS_CONTENT)
-
-        parsed = parse_atjobs(self.configuration, DUMMY_USER_DN, atjobs_path)
-        self.assertEqual(len(parsed), 1)
-        self.assertTrue(parsed[0]["time_stamp"] > datetime.datetime.now())
-
-    def test_parse_empty_atjobs_file(self):
-        """Test parsing empty atjobs file"""
-        atjobs_path = os.path.join(
-            self.configuration.user_settings,
-            DUMMY_CLIENT_DIR,
-            DUMMY_ATJOBS_NAME,
-        )
-        ensure_dirs_exist(os.path.dirname(atjobs_path))
-        open(atjobs_path, "a").close()  # Create empty file
-
-        parsed = parse_atjobs(self.configuration, DUMMY_USER_DN, atjobs_path)
-        self.assertEqual(parsed, [])
-
-    def test_cron_match_current_minute(self):
-        """Test cron_match identifies current time match"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "*",
-            "hour": "*",
-            "day": "*",
-            "month": "*",
-            "dayofweek": "*",
-            "dayofmonth": "*",
-        }
-        self.assertTrue(cron_match(self.configuration, now, test_job))
-
-    def test_cron_match_specific_time(self):
-        """Test cron_match rejects non-matching time"""
-        now = datetime.datetime.now().replace(
-            hour=3, minute=15, second=0, microsecond=0
-        )
-        test_job = {
-            "minute": "30",
-            "hour": "2",
-            "dayofmonth": "*",
-            "month": "*",
-            "dayofweek": "*",
-        }
-        self.assertFalse(cron_match(self.configuration, now, test_job))
-
-    def test_at_remain_past_job(self):
-        """Test at_remain with past job"""
-        now = datetime.datetime.now()
-        past_time = now - datetime.timedelta(minutes=30)
-        test_job = {"time_stamp": past_time}
-        remaining = at_remain(self.configuration, now, test_job)
-        self.assertEqual(remaining, -30)
-
-    def test_get_path_expand_map_with_spaces(self):
-        """Test path expansion with spaces"""
-        trigger_path = "/test/path/file with spaces.txt"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertIn("+TRIGGERFILENAME+", expanded)
-        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file with spaces.txt")
-
-    def test_get_time_expand_map_edge_cases(self):
-        """Test time expansion with edge cases"""
-        timestamp = datetime.datetime(2023, 12, 31, 23, 59)
+    def test_run_events_command_touch_succeeds(self):
+        """Test running events command touch succeeds"""
+        target_path = "test.txt"
+        command_list = ["touch", target_path]
         rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "31")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
-        self.assertEqual(expanded["+SCHEDHOUR+"], "23")
-        self.assertEqual(expanded["+SCHEDMINUTE+"], "59")
+        abs_target_path = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, target_path
+        )
+        self.assertFalse(os.path.exists(abs_target_path))
+        try:
+            run_events_command(
+                command_list, target_path, rule, self.configuration
+            )
+            self.assertTrue(True)  # If no exception, test passes
+            self.assertTrue(os.path.exists(abs_target_path))
+        except Exception as exc:
+            self.fail("run_events_command raised an exception: %s" % exc)
 
     def test_run_cron_command_with_invalid_command(self):
         """Test running cron command with invalid command"""
@@ -461,68 +2376,6 @@ class MigLibEvents(MigTestCase):
                     for msg in log_capture.output
                 )
             )
-
-    def test_cron_match_edge_cases(self):
-        """Test cron_match with edge case times"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_cases = [
-            (
-                {
-                    "minute": "0",
-                    "hour": "0",
-                    "dayofmonth": "1",
-                    "month": "1",
-                    "dayofweek": "0",
-                },
-                now.replace(hour=0, minute=0, day=1, month=1),
-            ),
-            (
-                {
-                    "minute": "59",
-                    "hour": "23",
-                    "dayofmonth": "31",
-                    "month": "12",
-                    "dayofweek": "6",
-                },
-                now.replace(hour=23, minute=59, day=31, month=12),
-            ),
-        ]
-        for job, match_time in test_cases:
-            self.assertEqual(
-                cron_match(self.configuration, match_time, job),
-                match_time == now,
-            )
-
-    def test_at_remain_edge_cases(self):
-        """Test at_remain with edge case times"""
-        now = datetime.datetime.now()
-        test_cases = [
-            (now + datetime.timedelta(seconds=30), 0),  # Less than 1 minute
-            # 1 minute 30 seconds
-            (now + datetime.timedelta(minutes=1, seconds=30), 1),
-            (now + datetime.timedelta(hours=1), 60),  # 1 hour
-            (now + datetime.timedelta(days=1), 1440),  # 1 day
-        ]
-        for future_time, expected_minutes in test_cases:
-            test_job = {"time_stamp": future_time}
-            remaining = at_remain(self.configuration, now, test_job)
-            self.assertEqual(remaining, expected_minutes)
-
-    def test_get_path_expand_map_empty_path(self):
-        """Test path expansion with empty path"""
-        trigger_path = ""
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        with self.assertRaises(ValueError):
-            get_path_expand_map(trigger_path, rule, "modified")
-
-    def test_get_time_expand_map_leap_year(self):
-        """Test time expansion with leap year"""
-        timestamp = datetime.datetime(2024, 2, 29, 12, 0)  # Leap day
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "29")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "02")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2024")
 
     def test_run_cron_command_with_spaces(self):
         """Test running cron command with spaces"""
@@ -578,145 +2431,6 @@ class MigLibEvents(MigTestCase):
                 )
             )
 
-    def test_parse_crontab_with_comments(self):
-        """Test parsing crontab with comments"""
-        crontab_content = """# This is a comment
-* * * * * /bin/test_command
-# Another comment
-30 2 * * * /usr/bin/another_command"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 2)
-        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
-
-    def test_parse_atjobs_with_comments(self):
-        """Test parsing atjobs with comments"""
-        atjobs_content = """# This is a comment
-2042-01-01 12:34:56 /bin/future_command
-# Another comment"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
-
-    def test_cron_match_with_wildcards(self):
-        """Test cron_match with various wildcard combinations"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_cases = [
-            (
-                {
-                    "minute": "*",
-                    "hour": "*",
-                    "dayofmonth": "*",
-                    "month": "*",
-                    "dayofweek": "*",
-                },
-                True,
-            ),
-            (
-                {
-                    "minute": "15",
-                    "hour": "*",
-                    "dayofmonth": "*",
-                    "month": "*",
-                    "dayofweek": "*",
-                },
-                now.minute == 15,
-            ),
-            (
-                {
-                    "minute": "*",
-                    "hour": "3",
-                    "dayofmonth": "*",
-                    "month": "*",
-                    "dayofweek": "*",
-                },
-                now.hour == 3,
-            ),
-            (
-                {
-                    "minute": "*",
-                    "hour": "*",
-                    "dayofmonth": "15",
-                    "month": "*",
-                    "dayofweek": "*",
-                },
-                now.day == 15,
-            ),
-            (
-                {
-                    "minute": "*",
-                    "hour": "*",
-                    "dayofmonth": "*",
-                    "month": "6",
-                    "dayofweek": "*",
-                },
-                now.month == 6,
-            ),
-            (
-                {
-                    "minute": "*",
-                    "hour": "*",
-                    "dayofmonth": "*",
-                    "month": "*",
-                    "dayofweek": "0",
-                },
-                now.weekday() == 0,
-            ),
-        ]
-        for job, expected in test_cases:
-            self.assertEqual(cron_match(
-                self.configuration, now, job), expected)
-
-    @unittest.skip("enable next if ever relevant - fails with TypeError")
-    def test_at_remain_with_timezones(self):
-        """Test at_remain with different timezones"""
-        now = datetime.datetime.now()
-        test_cases = [
-            (
-                now.astimezone(datetime.timezone.utc)
-                + datetime.timedelta(minutes=30),
-                30,
-            ),
-            (
-                now.astimezone(datetime.timezone.utc)
-                - datetime.timedelta(minutes=30),
-                -30,
-            ),
-        ]
-        for future_time, expected_minutes in test_cases:
-            test_job = {"time_stamp": future_time}
-            remaining = at_remain(self.configuration, now, test_job)
-            self.assertEqual(remaining, expected_minutes)
-
-    def test_get_path_expand_map_with_relative_path(self):
-        """Test path expansion with relative path"""
-        trigger_path = "../relative/path/file.txt"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertEqual(expanded["+TRIGGERPATH+"],
-                         "../relative/path/file.txt")
-        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
-        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
-        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
-
-    def test_get_time_expand_map_with_milliseconds(self):
-        """Test time expansion with milliseconds"""
-        timestamp = datetime.datetime(2023, 1, 2, 9, 2, 30, 123456)
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDSECOND+"], "30")
-        self.assertEqual(expanded["+SCHEDMINUTE+"], "02")
-        self.assertEqual(expanded["+SCHEDHOUR+"], "09")
-        self.assertEqual(expanded["+SCHEDDAY+"], "02")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
-        self.assertEqual(expanded["+SCHEDDAYOFWEEK+"], "0")
-
     def test_run_cron_command_with_long_command(self):
         """Test running cron command with long command"""
         target_path = "test.txt"
@@ -745,144 +2459,6 @@ class MigLibEvents(MigTestCase):
         except Exception as exc:
             self.fail("run_events_command raised an exception: %s" % exc)
 
-    def test_parse_crontab_with_invalid_lines(self):
-        """Test parsing crontab with invalid lines"""
-        crontab_content = """* * * * * /bin/test_command
-invalid line
-30 2 * * * /usr/bin/another_command"""
-        crontab_lines = crontab_content.splitlines()
-        with self.assertLogs(level="WARNING") as log_capture:
-            parsed = parse_crontab_contents(
-                self.configuration, DUMMY_USER_DN, crontab_lines
-            )
-            self.assertEqual(len(parsed), 2)
-            self.assertTrue(
-                any(
-                    "Skip invalid crontab line" in msg
-                    for msg in log_capture.output
-                )
-            )
-
-    def test_parse_atjobs_with_invalid_lines(self):
-        """Test parsing atjobs with invalid lines"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/future_command
-invalid line
-2042-01-02 12:34:56 /bin/another_command"""
-        atjobs_lines = atjobs_content.splitlines()
-        with self.assertLogs(level="WARNING") as log_capture:
-            parsed = parse_atjobs_contents(
-                self.configuration, DUMMY_USER_DN, atjobs_lines
-            )
-            self.assertEqual(len(parsed), 2)
-            self.assertTrue(
-                any(
-                    "Skip invalid atjobs line" in msg
-                    for msg in log_capture.output
-                )
-            )
-
-    def test_parse_crontab_with_empty_lines(self):
-        """Test parsing crontab with empty lines"""
-        crontab_content = """* * * * * /bin/test_command
-
-30 2 * * * /usr/bin/another_command
-"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 2)
-        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
-
-    def test_parse_atjobs_with_empty_lines(self):
-        """Test parsing atjobs with empty lines"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/future_command
-
-2042-01-02 12:34:56 /bin/another_command
-"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 2)
-        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
-
-    def test_cron_match_with_single_digit_values(self):
-        """Test cron_match with single digit values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_cases = [
-            (
-                {
-                    "minute": "5",
-                    "hour": "3",
-                    "dayofmonth": "7",
-                    "month": "6",
-                    "dayofweek": "1",
-                },
-                now.replace(minute=5, hour=3, day=7, month=6),
-            ),
-            (
-                {
-                    "minute": "0",
-                    "hour": "0",
-                    "dayofmonth": "1",
-                    "month": "1",
-                    "dayofweek": "0",
-                },
-                now.replace(minute=0, hour=0, day=1, month=1),
-            ),
-        ]
-        for job, match_time in test_cases:
-            self.assertEqual(
-                cron_match(self.configuration, match_time, job),
-                match_time == now,
-            )
-
-    def test_at_remain_with_same_minute_but_earlier(self):
-        """Test at_remain with same minute but a few seconds earlier"""
-        now = datetime.datetime.now()
-        now = now.replace(second=30)
-        same_minute_time = now.replace(second=42)
-        test_job = {"time_stamp": same_minute_time}
-        remaining = at_remain(self.configuration, now, test_job)
-        self.assertEqual(remaining, 0)
-
-    def test_at_remain_with_same_minute_but_later(self):
-        """Test at_remain with same minute but a few seconds later"""
-        now = datetime.datetime.now()
-        now = now.replace(second=30)
-        same_minute_time = now.replace(second=22)
-        test_job = {"time_stamp": same_minute_time}
-        remaining = at_remain(self.configuration, now, test_job)
-        self.assertEqual(remaining, -1)
-
-    def test_at_remain_with_same_minute_exactly(self):
-        """Test at_remain with same minute exactly"""
-        now = datetime.datetime.now()
-        now = now.replace(second=30)
-        same_minute_time = now
-        test_job = {"time_stamp": same_minute_time}
-        remaining = at_remain(self.configuration, now, test_job)
-        self.assertEqual(remaining, 0)
-
-    def test_get_path_expand_map_with_no_extension(self):
-        """Test path expansion with no extension"""
-        trigger_path = "/test/path/file"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file")
-        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
-        self.assertEqual(expanded["+TRIGGEREXTENSION+"], "")
-
-    def test_get_time_expand_map_with_first_day(self):
-        """Test time expansion with first day of month"""
-        timestamp = datetime.datetime(2023, 1, 1, 0, 0)
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "01")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
-
     def test_run_cron_command_with_no_arguments(self):
         """Test running cron command with no arguments"""
         target_path = "dummy"
@@ -907,68 +2483,6 @@ invalid line
             self.assertTrue(
                 any("path: is required" in msg for msg in log_capture.output)
             )
-
-    def test_parse_crontab_with_trailing_whitespace(self):
-        """Test parsing crontab with trailing whitespace"""
-        crontab_content = """* * * * * /bin/test_command   \n"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
-
-    def test_parse_atjobs_with_trailing_whitespace(self):
-        """Test parsing atjobs with trailing whitespace"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/future_command   \n"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
-
-    def test_cron_match_with_all_wildcards(self):
-        """Test cron_match with all wildcards"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "*",
-            "hour": "*",
-            "dayofmonth": "*",
-            "month": "*",
-            "dayofweek": "*",
-        }
-        self.assertTrue(cron_match(self.configuration, now, test_job))
-
-    def test_at_remain_with_future_year(self):
-        """Test at_remain with future year"""
-        now = datetime.datetime.now()
-        future_year = now.replace(
-            year=now.year + 1, month=1, day=1, hour=0, minute=0, second=0
-        )
-        test_job = {"time_stamp": future_year}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (future_year - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
-
-    def test_get_path_expand_map_with_leading_slash(self):
-        """Test path expansion with leading slash"""
-        trigger_path = "/file.txt"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertEqual(expanded["+TRIGGERPATH+"], "/file.txt")
-        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
-        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
-        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
-
-    def test_get_time_expand_map_with_last_day(self):
-        """Test time expansion with last day of month"""
-        timestamp = datetime.datetime(2023, 1, 31, 23, 59)
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "31")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
 
     def test_run_cron_command_with_output_redirection(self):
         """Test running cron command with output redirection"""
@@ -998,92 +2512,6 @@ invalid line
                 )
             )
 
-    @unittest.skip("enable next if we ever allow multispace")
-    def test_parse_crontab_with_multiple_spaces(self):
-        """Test parsing crontab with multiple spaces"""
-        crontab_content = """*  *  *  *  *  /bin/test_command"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
-
-    @unittest.skip("enable next if we ever allow multispace")
-    def test_parse_atjobs_with_multiple_spaces(self):
-        """Test parsing atjobs with multiple spaces"""
-        atjobs_content = """2042-01-01  12:34:56  /bin/future_command"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
-
-    # TODO: invert next when we implement feature at some point
-    def test_cron_match_with_range_values(self):
-        """Test cron_match with range values (not supported yet)"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "10-20",
-            "hour": "2",
-            "dayofmonth": "*",
-            "month": "*",
-            "dayofweek": "*",
-        }
-        # Should fail since ranges aren't supported, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_past_year(self):
-        """Test at_remain with past year"""
-        now = datetime.datetime.now()
-        past_year = now.replace(year=now.year - 1)
-        test_job = {"time_stamp": past_year}
-        remaining = at_remain(self.configuration, now, test_job)
-        # Approximately -1 year in minutes
-        self.assertEqual(remaining, -525600)
-
-    def test_at_remain_with_next_year(self):
-        """Test at_remain with next year"""
-        now = datetime.datetime.now()
-        past_year = now.replace(year=now.year + 1)
-        test_job = {"time_stamp": past_year}
-        remaining = at_remain(self.configuration, now, test_job)
-        # Approximately 1 year in minutes
-        self.assertEqual(remaining, 525600)
-
-    def test_get_path_expand_map_with_special_chars(self):
-        """Test path expansion with special characters"""
-        trigger_path = "/test/path/file@name#with$special&chars.txt"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertEqual(
-            expanded["+TRIGGERFILENAME+"], "file@name#with$special&chars.txt"
-        )
-        self.assertEqual(
-            expanded["+TRIGGERPREFIX+"], "file@name#with$special&chars"
-        )
-        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
-
-    def test_get_time_expand_map_with_summer_time(self):
-        """Test time expansion with summer time (DST)"""
-        # This test may fail depending on the system's timezone and DST rules
-        # Summer in Northern Hemisphere
-        timestamp = datetime.datetime(2023, 7, 1, 12, 0)
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "01")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "07")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
-
     def test_run_cron_command_with_pipe(self):
         """Test running cron command with pipe"""
         target_path = "test.txt"
@@ -1111,81 +2539,6 @@ invalid line
                     for msg in log_capture.output
                 )
             )
-
-    @unittest.skip("enable next if we ever allow tab sep")
-    def test_parse_crontab_with_tab_separated(self):
-        """Test parsing crontab with tab-separated values"""
-        crontab_content = "*\t*\t*\t*\t*\t/bin/test_command"
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
-
-    @unittest.skip("enable next if we ever allow tab sep")
-    def test_parse_atjobs_with_tab_separated(self):
-        """Test parsing atjobs with tab-separated values"""
-        atjobs_content = "2042-01-01\t12:34:56\t/bin/future_command"
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
-
-    def test_cron_match_with_step_values(self):
-        """Test cron_match with step values (not supported but should handle)"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "*/5",
-            "hour": "2",
-            "dayofmonth": "*",
-            "month": "*",
-            "dayofweek": "*",
-        }
-        # Should fail since steps aren't supported, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_leap_year(self):
-        """Test at_remain with leap year"""
-        now = datetime.datetime.now()
-        leap_day = datetime.datetime(
-            now.year + 4 - now.year // 4, 2, 29, 12, 0
-        )  # Next leap year
-        test_job = {"time_stamp": leap_day}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (leap_day - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
-
-    def test_get_path_expand_map_with_unicode(self):
-        """Test path expansion with unicode characters"""
-        trigger_path = "/test/path/файл.txt"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertEqual(expanded["+TRIGGERFILENAME+"], "файл.txt")
-        self.assertEqual(expanded["+TRIGGERPREFIX+"], "файл")
-        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
-
-    def test_get_time_expand_map_with_dst_transition(self):
-        """Test time expansion with DST transition"""
-        # This test may fail depending on the system's timezone and DST rules
-        timestamp = datetime.datetime(
-            2023, 3, 12, 2, 30
-        )  # DST transition in US
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "12")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "03")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
 
     def test_run_cron_command_with_background(self):
         """Test running cron command with background execution"""
@@ -1218,85 +2571,6 @@ invalid line
                 )
             )
 
-    def test_parse_crontab_with_multiple_commands(self):
-        """Test parsing crontab with multiple commands"""
-        crontab_content = """* * * * * /bin/command1 && /bin/command2"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "&&", "/bin/command2"]
-        )
-
-    def test_parse_atjobs_with_multiple_commands(self):
-        """Test parsing atjobs with multiple commands"""
-        atjobs_content = (
-            """2042-01-01 12:34:56 /bin/command1 && /bin/command2"""
-        )
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "&&", "/bin/command2"]
-        )
-
-    @unittest.skip("implement value range check in function and enable next")
-    def test_cron_match_with_invalid_values(self):
-        """Test cron_match with invalid values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "60",
-            "hour": "25",
-            "dayofmonth": "32",
-            "month": "13",
-            "dayofweek": "7",
-        }
-        # Should fail since values are invalid, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_past_time(self):
-        """Test at_remain with past time"""
-        now = datetime.datetime.now()
-        past_time = now - datetime.timedelta(minutes=5)
-        test_job = {"time_stamp": past_time}
-        remaining = at_remain(self.configuration, now, test_job)
-        self.assertEqual(remaining, -5)
-
-    def test_get_path_expand_map_with_no_path(self):
-        """Test path expansion with no path (just filename)"""
-        trigger_path = "file.txt"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertEqual(expanded["+TRIGGERPATH+"], "file.txt")
-        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
-        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
-        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
-
-    def test_get_time_expand_map_with_zero_values(self):
-        """Test time expansion with zero values"""
-        timestamp = datetime.datetime(2023, 1, 1, 0, 0)
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDSECOND+"], "00")
-        self.assertEqual(expanded["+SCHEDMINUTE+"], "00")
-        self.assertEqual(expanded["+SCHEDHOUR+"], "00")
-        self.assertEqual(expanded["+SCHEDDAY+"], "01")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
-        self.assertEqual(expanded["+SCHEDDAYOFWEEK+"], "6")  # Sunday
-
     def test_run_cron_command_with_quotes(self):
         """Test running cron command with quotes"""
         target_path = "test.txt"
@@ -1321,82 +2595,6 @@ invalid line
         self.assertTrue(
             any("found invalid character" in msg for msg in log_capture.output)
         )
-
-    def test_parse_crontab_with_semicolon(self):
-        """Test parsing crontab with semicolon"""
-        crontab_content = """* * * * * /bin/command1; /bin/command2"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1;", "/bin/command2"]
-        )
-
-    def test_parse_atjobs_with_semicolon(self):
-        """Test parsing atjobs with semicolon"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1; /bin/command2"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1;", "/bin/command2"]
-        )
-
-    # TODO: invert next when we implement feature at some point
-    def test_cron_match_with_division_values(self):
-        """Test cron_match with division values (not supported yet)"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "*",
-            "hour": "*",
-            "dayofmonth": "*",
-            "month": "*/1",
-            "dayofweek": "*",
-        }
-        # Should fail since divide format is not yet allowed
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_future_time(self):
-        """Test at_remain with future time"""
-        now = datetime.datetime.now()
-        future_time = now + datetime.timedelta(minutes=5)
-        test_job = {"time_stamp": future_time}
-        remaining = at_remain(self.configuration, now, test_job)
-        self.assertEqual(remaining, 5)
-
-    def test_get_path_expand_map_with_windows_path(self):
-        """Test path expansion with Windows path"""
-        trigger_path = "C:\\path\\to\\file.txt"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertEqual(expanded["+TRIGGERPATH+"], "C:\\path\\to\\file.txt")
-        self.assertEqual(
-            expanded["+TRIGGERFILENAME+"], "C:\\path\\to\\file.txt"
-        )
-        self.assertEqual(expanded["+TRIGGERPREFIX+"], "C:\\path\\to\\file")
-        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
-
-    def test_get_time_expand_map_with_dst_start(self):
-        """Test time expansion with DST start"""
-        # This test may fail depending on the system's timezone and DST rules
-        timestamp = datetime.datetime(2023, 3, 12, 3, 0)  # DST start in US
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "12")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "03")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
 
     def test_run_cron_command_with_environment_variable(self):
         """Test running cron command with environment variable"""
@@ -1423,186 +2621,6 @@ invalid line
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_events_command raised an exception: %s" % exc)
-
-    def test_parse_crontab_with_backticks(self):
-        """Test parsing crontab with backticks"""
-        crontab_content = """* * * * * /bin/command1 `touch test`"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "`touch", "test`"]
-        )
-
-    def test_parse_atjobs_with_backticks(self):
-        """Test parsing atjobs with backticks"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 `touch test`"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "`touch", "test`"]
-        )
-
-    @unittest.skip("implement extra value check in function and enable next")
-    def test_cron_match_with_extra_fields(self):
-        """Test cron_match with extra fields"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "*",
-            "hour": "*",
-            "dayofmonth": "*",
-            "month": "*",
-            "dayofweek": "*",
-            "extra_field": "value",
-        }
-        # Should fail since extra fields are present, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    # NOTE: no datetime support https://github.com/python/cpython/issues/67762
-    @unittest.skip("enable if leap second handling is ever implemented")
-    def test_at_remain_with_leap_second(self):
-        """Test at_remain with leap second"""
-        # December 31, 2016, had a leap second to include time 23:59:60
-        now = datetime.datetime.now(datetime.timezone.utc)
-        t_minus_sixty = now.replace(
-            year=2016,
-            month=12,
-            day=31,
-            hour=23,
-            minute=59,
-            second=0,
-            microsecond=0,
-        )
-        leap_second = t_minus_sixty + datetime.timedelta(seconds=60)
-        t_plus_sixty = now.replace(
-            year=2017,
-            month=1,
-            day=1,
-            hour=0,
-            minute=0,
-            second=59,
-            microsecond=0,
-        )
-        self.assertEqual(
-            (t_plus_sixty - t_minus_sixty).total_seconds(),
-            120,
-            "Leap second does not appear supported",
-        )
-        test_job = {"time_stamp": t_plus_sixty}
-        remaining = at_remain(self.configuration, leap_second, test_job)
-        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
-        #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
-        self.assertEqual(remaining, 1)
-
-    def test_get_path_expand_map_with_url(self):
-        """Test path expansion with URL"""
-        trigger_path = "http://example.com/file.txt"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertEqual(
-            expanded["+TRIGGERPATH+"], "http://example.com/file.txt"
-        )
-        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
-        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
-        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
-
-    def test_get_time_expand_map_with_new_year(self):
-        """Test time expansion with New Year"""
-        timestamp = datetime.datetime(2023, 1, 1, 0, 0)
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "01")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
-
-    def test_parse_crontab_with_parentheses(self):
-        """Test parsing crontab with parentheses"""
-        crontab_content = """* * * * * /bin/command1 (arg1 arg2)"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "(arg1", "arg2)"]
-        )
-
-    def test_parse_atjobs_with_parentheses(self):
-        """Test parsing atjobs with parentheses"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 (arg1 arg2)"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "(arg1", "arg2)"]
-        )
-
-    def test_cron_match_with_invalid_chars(self):
-        """Test cron_match with invalid characters"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "*",
-            "hour": "*",
-            "dayofmonth": "*",
-            "month": "*",
-            "dayofweek": "Sunday",
-        }
-        # Should fail since invalid characters are present, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_dst_end(self):
-        """Test at_remain with DST end"""
-        # This test may fail depending on the system's timezone and DST rules
-        now = datetime.datetime.now()
-        dst_end_time = now.replace(month=11, day=5, hour=1, minute=30)
-        test_job = {"time_stamp": dst_end_time}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (dst_end_time - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
-
-    def test_get_path_expand_map_with_query_string(self):
-        """Test path expansion with query string"""
-        trigger_path = "/test/path/file.txt?param=value"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertEqual(
-            expanded["+TRIGGERPATH+"], "/test/path/file.txt?param=value"
-        )
-        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt?param=value")
-        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
-        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt?param=value")
-
-    def test_get_time_expand_map_with_leap_year_start(self):
-        """Test time expansion with leap year start"""
-        timestamp = datetime.datetime(2024, 1, 1, 0, 0)  # Leap year
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "01")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2024")
 
     def test_run_cron_command_with_escaped_chars(self):
         """Test running cron command with escaped characters"""
@@ -1632,82 +2650,6 @@ invalid line
                 )
             )
 
-    def test_parse_crontab_with_brackets(self):
-        """Test parsing crontab with brackets"""
-        crontab_content = """* * * * * /bin/command1 [arg1 arg2]"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "[arg1", "arg2]"]
-        )
-
-    def test_parse_atjobs_with_brackets(self):
-        """Test parsing atjobs with brackets"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 [arg1 arg2]"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "[arg1", "arg2]"]
-        )
-
-    def test_cron_match_with_extra_whitespace(self):
-        """Test cron_match with extra whitespace"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": " * ",
-            "hour": " * ",
-            "dayofmonth": " * ",
-            "month": " * ",
-            "dayofweek": " * ",
-        }
-        # Should fail since extra whitespace isn't allowed
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_future_dst_transition(self):
-        """Test at_remain with future DST transition"""
-        # This test may fail depending on the system's timezone and DST rules
-        now = datetime.datetime.now()
-        future_dst_time = now.replace(month=3, day=12, hour=2, minute=30)
-        test_job = {"time_stamp": future_dst_time}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (future_dst_time - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
-
-    def test_get_path_expand_map_with_fragment(self):
-        """Test path expansion with fragment"""
-        trigger_path = "/test/path/file.txt#fragment"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertEqual(
-            expanded["+TRIGGERPATH+"], "/test/path/file.txt#fragment"
-        )
-        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt#fragment")
-        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
-        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt#fragment")
-
-    def test_get_time_expand_map_with_century_year(self):
-        """Test time expansion with century year"""
-        timestamp = datetime.datetime(2100, 1, 1, 0, 0)  # Year 2100
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "01")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2100")
-
     def test_run_cron_command_with_multiple_commands(self):
         """Test running cron command with multiple commands"""
         target_path = "test.txt"
@@ -1733,88 +2675,6 @@ invalid line
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_events_command raised an exception: %s" % exc)
-
-    def test_parse_crontab_with_quotes(self):
-        """Test parsing crontab with quotes"""
-        crontab_content = '''* * * * * /bin/command1 "arg1 with spaces"'''
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "arg1 with spaces"]
-        )
-
-    def test_parse_atjobs_with_quotes(self):
-        """Test parsing atjobs with quotes"""
-        atjobs_content = (
-            '''2042-01-01 12:34:56 /bin/command1 "arg1 with spaces"'''
-        )
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "arg1 with spaces"]
-        )
-
-    @unittest.skip("implement extra value check in function and enable next")
-    def test_cron_match_with_invalid_field_count(self):
-        """Test cron_match with invalid field count"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "*",
-            "hour": "*",
-            "dayofmonth": "*",
-            "month": "*",
-            "dayofweek": "*",
-            "extra_field": "*",
-        }
-        # Should fail since field count is invalid, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_past_dst_transition(self):
-        """Test at_remain with past DST transition"""
-        # This test may fail depending on the system's timezone and DST rules
-        now = datetime.datetime.now()
-        past_dst_time = now.replace(month=11, day=5, hour=1, minute=30)
-        test_job = {"time_stamp": past_dst_time}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (past_dst_time - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
-
-    def test_get_path_expand_map_with_encoded_chars(self):
-        """Test path expansion with encoded characters"""
-        trigger_path = "/test/path/file%20with%20spaces.txt"
-        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, "modified")
-        self.assertEqual(
-            expanded["+TRIGGERPATH+"], "/test/path/file%20with%20spaces.txt"
-        )
-        self.assertEqual(
-            expanded["+TRIGGERFILENAME+"], "file%20with%20spaces.txt"
-        )
-        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file%20with%20spaces")
-        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
-
-    def test_get_time_expand_map_with_millennium_year(self):
-        """Test time expansion with millennium year"""
-        timestamp = datetime.datetime(2000, 1, 1, 0, 0)  # Year 2000
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "01")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "2000")
 
     def test_run_cron_command_with_input_redirection(self):
         """Test running cron command with input redirection"""
@@ -1843,90 +2703,6 @@ invalid line
                     for msg in log_capture.output
                 )
             )
-
-    def test_parse_crontab_with_single_quotes(self):
-        """Test parsing crontab with single quotes"""
-        crontab_content = """* * * * * /bin/command1 'arg1 with spaces'"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "arg1 with spaces"]
-        )
-
-    def test_parse_atjobs_with_single_quotes(self):
-        """Test parsing atjobs with single quotes"""
-        atjobs_content = (
-            """2042-01-01 12:34:56 /bin/command1 'arg1 with spaces'"""
-        )
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "arg1 with spaces"]
-        )
-
-    def test_cron_match_with_missing_fields(self):
-        """Test cron_match with missing fields"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "*",
-            "hour": "*",
-            "dayofmonth": "*",
-            "dayofweek": "*",
-        }
-        # NOTE: throws exception before log since values must be strings
-        with self.assertRaises(Exception):
-            cron_match(self.configuration, now, test_job)
-
-    # NOTE: no datetime support https://github.com/python/cpython/issues/67762
-    @unittest.skip("enable if leap second handling is ever implemented")
-    def test_at_remain_with_future_leap_second(self):
-        """Test at_remain with future leap second"""
-        # December 31, 2016, had a leap second to include time 23:59:60
-        now = datetime.datetime.now(datetime.timezone.utc)
-        t_minus_sixty = now.replace(
-            year=2016,
-            month=12,
-            day=31,
-            hour=23,
-            minute=59,
-            second=0,
-            microsecond=0,
-        )
-        leap_second = t_minus_sixty + datetime.timedelta(seconds=60)
-        t_plus_sixty = now.replace(
-            year=2017,
-            month=1,
-            day=1,
-            hour=0,
-            minute=0,
-            second=59,
-            microsecond=0,
-        )
-        self.assertEqual(
-            (t_plus_sixty - t_minus_sixty).total_seconds(),
-            120,
-            "Leap second does not appear supported",
-        )
-        test_job = {"time_stamp": leap_second}
-        remaining = at_remain(self.configuration, t_minus_sixty, test_job)
-        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
-        #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
-        self.assertEqual(remaining, 1)
-
-    def test_get_time_expand_map_with_year_zero(self):
-        """Test time expansion with year zero"""
-        timestamp = datetime.datetime(1, 1, 1, 0, 0)  # Year 1
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "01")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "1")
 
     def test_run_cron_command_with_here_document(self):
         """Test running cron command with here document"""
@@ -1962,92 +2738,6 @@ invalid line
                 )
             )
 
-    def test_parse_crontab_with_backslash(self):
-        """Test parsing crontab with backslash"""
-        crontab_content = """* * * * * /bin/command1 arg1\\ arg2"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "arg1 arg2"])
-
-    def test_parse_atjobs_with_backslash(self):
-        """Test parsing atjobs with backslash"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 arg1\\ arg2"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "arg1 arg2"])
-
-    def test_cron_match_with_non_string_values(self):
-        """Test cron_match with non-string values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": 15,
-            "hour": 3,
-            "dayofmonth": 7,
-            "month": 6,
-            "dayofweek": 1,
-        }
-        # NOTE: throws exception before log since values must be strings
-        with self.assertRaises(Exception):
-            cron_match(self.configuration, now, test_job)
-
-    # NOTE: no datetime support https://github.com/python/cpython/issues/67762
-    @unittest.skip("enable if leap second handling is ever implemented")
-    def test_at_remain_with_past_leap_second(self):
-        """Test at_remain with past leap second"""
-        # December 31, 2016, had a leap second to include time 23:59:60
-        now = datetime.datetime.now(datetime.timezone.utc)
-        t_minus_sixty = now.replace(
-            year=2016,
-            month=12,
-            day=31,
-            hour=23,
-            minute=59,
-            second=0,
-            microsecond=0,
-        )
-        leap_second = t_minus_sixty + datetime.timedelta(seconds=60)
-        t_plus_sixty = now.replace(
-            year=2017,
-            month=1,
-            day=1,
-            hour=0,
-            minute=0,
-            second=59,
-            microsecond=0,
-        )
-        t_plus_sixtyone = now.replace(
-            year=2017, month=1, day=1, hour=0, minute=1, second=0, microsecond=0
-        )
-        self.assertEqual(
-            (t_plus_sixty - t_minus_sixty).total_seconds(),
-            120,
-            "Leap second does not appear supported",
-        )
-        test_job = {"time_stamp": leap_second}
-        remaining = at_remain(self.configuration, t_plus_sixty, test_job)
-        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
-        #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
-        self.assertEqual(remaining, -1)
-        remaining = at_remain(self.configuration, t_plus_sixtyone, test_job)
-        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
-        #      (t_minus_sixty, leap_second, t_plus_sixtyone, remaining))
-        self.assertEqual(remaining, -2)
-
-    def test_get_time_expand_map_with_year_9999(self):
-        """Test time expansion with year 9999"""
-        timestamp = datetime.datetime(9999, 12, 31, 23, 59)
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "31")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "9999")
-
     def test_run_cron_command_with_subshell(self):
         """Test running cron command with subshell"""
         target_path = "test.txt"
@@ -2082,64 +2772,6 @@ invalid line
                 )
             )
 
-    def test_parse_crontab_with_double_backslash(self):
-        """Test parsing crontab with double backslash"""
-        crontab_content = """* * * * * /bin/command1 arg1\\\\ arg2"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "arg1\\", "arg2"]
-        )
-
-    def test_parse_atjobs_with_double_backslash(self):
-        """Test parsing atjobs with double backslash"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 arg1\\\\ arg2"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "arg1\\", "arg2"]
-        )
-
-    def test_cron_match_with_boolean_values(self):
-        """Test cron_match with boolean values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": True,
-            "hour": False,
-            "dayofmonth": True,
-            "month": False,
-            "dayofweek": True,
-        }
-        # NOTE: throws exception before log since values must be strings
-        with self.assertRaises(Exception):
-            cron_match(self.configuration, now, test_job)
-
-    def test_at_remain_with_future_leap_year(self):
-        """Test at_remain with future leap year"""
-        now = datetime.datetime.now()
-        future_leap_year = now.replace(
-            year=2096, month=2, day=29, hour=12, minute=0
-        )
-        test_job = {"time_stamp": future_leap_year}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (future_leap_year - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
-
-    def test_get_time_expand_map_with_year_0001(self):
-        """Test time expansion with year 0001"""
-        timestamp = datetime.datetime(1, 1, 1, 0, 0)  # Year 1
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "01")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "1")
-
     def test_run_cron_command_with_command_substitution(self):
         """Test running cron command with command substitution"""
         target_path = "test.txt"
@@ -2165,60 +2797,6 @@ invalid line
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_events_command raised an exception: %s" % exc)
-
-    def test_parse_crontab_with_caret(self):
-        """Test parsing crontab with caret"""
-        crontab_content = """* * * * * /bin/command1 ^arg1"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "^arg1"])
-
-    def test_parse_atjobs_with_caret(self):
-        """Test parsing atjobs with caret"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 ^arg1"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "^arg1"])
-
-    def test_cron_match_with_none_values(self):
-        """Test cron_match with none values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": None,
-            "hour": None,
-            "dayofmonth": None,
-            "month": None,
-            "dayofweek": None,
-        }
-        # NOTE: throws exception before log since values must be strings
-        with self.assertRaises(Exception):
-            cron_match(self.configuration, now, test_job)
-
-    def test_at_remain_with_past_leap_year(self):
-        """Test at_remain with past leap year"""
-        now = datetime.datetime.now()
-        past_leap_year = now.replace(
-            year=2000, month=2, day=29, hour=12, minute=0
-        )
-        test_job = {"time_stamp": past_leap_year}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (past_leap_year - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
-
-    def test_get_time_expand_map_with_year_9999_end(self):
-        """Test time expansion with year 9999 end"""
-        timestamp = datetime.datetime(9999, 12, 31, 23, 59)
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "31")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "9999")
 
     def test_run_cron_command_with_true_command(self):
         """Test running cron command with true command"""
@@ -2254,67 +2832,6 @@ invalid line
                 )
             )
 
-    def test_parse_crontab_with_hash(self):
-        """Test parsing crontab with hash"""
-        crontab_content = """* * * * * /bin/command1 #arg1"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1"])
-
-    def test_parse_atjobs_with_hash(self):
-        """Test parsing atjobs with hash"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 #arg1"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1"])
-
-    def test_cron_match_with_tab_values(self):
-        """Test cron_match with tab values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "\t",
-            "hour": "\t",
-            "dayofmonth": "\t",
-            "month": "\t",
-            "dayofweek": "\t",
-        }
-        # Should fail since values are tabs, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_future_millennium(self):
-        """Test at_remain with future millennium"""
-        now = datetime.datetime.now()
-        future_millennium = now.replace(
-            year=now.year + 1000, month=1, day=1, hour=0, minute=0
-        )
-        test_job = {"time_stamp": future_millennium}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (future_millennium - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
-
-    def test_get_time_expand_map_with_year_0001_end(self):
-        """Test time expansion with year 0001 end"""
-        timestamp = datetime.datetime(1, 12, 31, 23, 59)  # Year 1
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "31")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "1")
-
     def test_run_cron_command_with_false_command(self):
         """Test running cron command with false command"""
         target_path = "test.txt"
@@ -2348,58 +2865,6 @@ invalid line
                     for msg in log_capture.output
                 )
             )
-
-    def test_parse_crontab_with_dollar(self):
-        """Test parsing crontab with dollar"""
-        crontab_content = """* * * * * /bin/command1 $arg1"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "$arg1"])
-
-    def test_parse_atjobs_with_dollar(self):
-        """Test parsing atjobs with dollar"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 $arg1"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "$arg1"])
-
-    def test_cron_match_with_newline_values(self):
-        """Test cron_match with newline values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "\n",
-            "hour": "\n",
-            "dayofmonth": "\n",
-            "month": "\n",
-            "dayofweek": "\n",
-        }
-        # Should fail since values are newlines, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_past_millennium(self):
-        """Test at_remain with past millennium"""
-        now = datetime.datetime.now()
-        past_millennium = now.replace(
-            year=now.year - 1000, month=1, day=1, hour=0, minute=0
-        )
-        test_job = {"time_stamp": past_millennium}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (past_millennium - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
 
     def test_run_cron_command_with_null_command(self):
         """Test running cron command with null command"""
@@ -2435,67 +2900,6 @@ invalid line
                 )
             )
 
-    def test_parse_crontab_with_percent(self):
-        """Test parsing crontab with percent"""
-        crontab_content = """* * * * * /bin/command1 %arg1"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "%arg1"])
-
-    def test_parse_atjobs_with_percent(self):
-        """Test parsing atjobs with percent"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 %arg1"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "%arg1"])
-
-    def test_cron_match_with_carriage_return_values(self):
-        """Test cron_match with carriage return values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "\r",
-            "hour": "\r",
-            "dayofmonth": "\r",
-            "month": "\r",
-            "dayofweek": "\r",
-        }
-        # Should fail since values are carriage returns, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_future_millennium_end(self):
-        """Test at_remain with future millennium end"""
-        now = datetime.datetime.now()
-        future_millennium_end = now.replace(
-            year=now.year + 1000, month=12, day=31, hour=23, minute=59
-        )
-        test_job = {"time_stamp": future_millennium_end}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (future_millennium_end - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
-
-    def test_get_time_expand_map_with_year_0001_start(self):
-        """Test time expansion with year 0001 start"""
-        timestamp = datetime.datetime(1, 1, 1, 0, 0)  # Year 1
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "01")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "1")
-
     def test_run_cron_command_with_builtin_command(self):
         """Test running cron command with builtin command"""
         target_path = "test.txt"
@@ -2529,67 +2933,6 @@ invalid line
                     for msg in log_capture.output
                 )
             )
-
-    def test_parse_crontab_with_ampersand(self):
-        """Test parsing crontab with ampersand"""
-        crontab_content = """* * * * * /bin/command1 &arg1"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "&arg1"])
-
-    def test_parse_atjobs_with_ampersand(self):
-        """Test parsing atjobs with ampersand"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 &arg1"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "&arg1"])
-
-    def test_cron_match_with_vertical_tab_values(self):
-        """Test cron_match with vertical tab values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "\v",
-            "hour": "\v",
-            "dayofmonth": "\v",
-            "month": "\v",
-            "dayofweek": "\v",
-        }
-        # Should fail since values are vertical tabs, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_past_millennium_end(self):
-        """Test at_remain with past millennium end"""
-        now = datetime.datetime.now()
-        past_millennium_end = now.replace(
-            year=now.year - 1000, month=12, day=31, hour=23, minute=59
-        )
-        test_job = {"time_stamp": past_millennium_end}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (past_millennium_end - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
-
-    def test_get_time_expand_map_with_year_9999_start(self):
-        """Test time expansion with year 9999 start"""
-        timestamp = datetime.datetime(9999, 1, 1, 0, 0)  # Year 9999
-        rule = {"run_as": DUMMY_USER_DN}
-        expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded["+SCHEDDAY+"], "01")
-        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
-        self.assertEqual(expanded["+SCHEDYEAR+"], "9999")
 
     def test_run_cron_command_with_alias_command(self):
         """Test running cron command with alias command"""
@@ -2625,62 +2968,6 @@ invalid line
                 )
             )
 
-    def test_parse_crontab_with_pipe(self):
-        """Test parsing crontab with pipe"""
-        crontab_content = """* * * * * /bin/command1 | /bin/command2"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "|", "/bin/command2"]
-        )
-
-    def test_parse_atjobs_with_pipe(self):
-        """Test parsing atjobs with pipe"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 | /bin/command2"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(
-            parsed[0]["command"], ["/bin/command1", "|", "/bin/command2"]
-        )
-
-    def test_cron_match_with_form_feed_values(self):
-        """Test cron_match with form feed values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "\f",
-            "hour": "\f",
-            "dayofmonth": "\f",
-            "month": "\f",
-            "dayofweek": "\f",
-        }
-        # Should fail since values are form feeds, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_future_century_end(self):
-        """Test at_remain with future century end"""
-        now = datetime.datetime.now()
-        future_century_end = now.replace(
-            year=now.year + 100, month=12, day=31, hour=23, minute=59
-        )
-        test_job = {"time_stamp": future_century_end}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (future_century_end - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
-
     def test_run_cron_command_with_function_command(self):
         """Test running cron command with function command"""
         target_path = "test.txt"
@@ -2715,58 +3002,6 @@ invalid line
                 )
             )
 
-    def test_parse_crontab_with_question_mark(self):
-        """Test parsing crontab with question mark"""
-        crontab_content = """* * * * * /bin/command1 ?arg1"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "?arg1"])
-
-    def test_parse_atjobs_with_question_mark(self):
-        """Test parsing atjobs with question mark"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 ?arg1"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "?arg1"])
-
-    def test_cron_match_with_escape_values(self):
-        """Test cron_match with escape values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "\\",
-            "hour": "\\",
-            "dayofmonth": "\\",
-            "month": "\\",
-            "dayofweek": "\\",
-        }
-        # Should fail since values are escapes, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_past_century_end(self):
-        """Test at_remain with past century end"""
-        now = datetime.datetime.now()
-        past_century_end = now.replace(
-            year=now.year - 100, month=12, day=31, hour=23, minute=59
-        )
-        test_job = {"time_stamp": past_century_end}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (past_century_end - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
-
     def test_run_cron_command_with_reserved_command(self):
         """Test running cron command with reserved command"""
         target_path = "test.txt"
@@ -2783,58 +3018,6 @@ invalid line
                     for msg in log_capture.output
                 )
             )
-
-    def test_parse_crontab_with_plus(self):
-        """Test parsing crontab with plus"""
-        crontab_content = """* * * * * /bin/command1 +arg1"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "+arg1"])
-
-    def test_parse_atjobs_with_plus(self):
-        """Test parsing atjobs with plus"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 +arg1"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "+arg1"])
-
-    def test_cron_match_with_delete_values(self):
-        """Test cron_match with delete values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": "\x7f",
-            "hour": "\x7f",
-            "dayofmonth": "\x7f",
-            "month": "\x7f",
-            "dayofweek": "\x7f",
-        }
-        # Should fail since values are deletes, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_future_century_start(self):
-        """Test at_remain with future century start"""
-        now = datetime.datetime.now()
-        future_century_start = now.replace(
-            year=now.year + 100, month=1, day=1, hour=0, minute=0
-        )
-        test_job = {"time_stamp": future_century_start}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (future_century_start - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
 
     def test_run_cron_command_with_dot_command(self):
         """Test running cron command with dot command"""
@@ -2869,58 +3052,6 @@ invalid line
                     for msg in log_capture.output
                 )
             )
-
-    def test_parse_crontab_with_comma(self):
-        """Test parsing crontab with comma"""
-        crontab_content = """* * * * * /bin/command1,arg1"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1,arg1"])
-
-    def test_parse_atjobs_with_comma(self):
-        """Test parsing atjobs with comma"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1,arg1"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1,arg1"])
-
-    def test_cron_match_with_space_values(self):
-        """Test cron_match with space values"""
-        now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {
-            "minute": " ",
-            "hour": " ",
-            "dayofmonth": " ",
-            "month": " ",
-            "dayofweek": " ",
-        }
-        # Should fail since values are spaces, but shouldn't crash
-        # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level="WARNING") as log_capture:
-            result = cron_match(
-                self.configuration, now, test_job, _warn_mismatch=True
-            )
-            self.assertFalse(result)
-            self.assertTrue(
-                any("no cron_match on" in msg for msg in log_capture.output)
-            )
-
-    def test_at_remain_with_past_century_start(self):
-        """Test at_remain with past century start"""
-        now = datetime.datetime.now()
-        past_century_start = now.replace(
-            year=now.year - 100, month=1, day=1, hour=0, minute=0
-        )
-        test_job = {"time_stamp": past_century_start}
-        remaining = at_remain(self.configuration, now, test_job)
-        expected_minutes = (past_century_start - now).total_seconds() // 60
-        self.assertEqual(remaining, expected_minutes)
 
     def test_run_cron_command_with_colon_command(self):
         """Test running cron command with colon command"""
@@ -2973,31 +3104,21 @@ invalid line
                 )
             )
 
-    def test_parse_crontab_with_less_than(self):
-        """Test parsing crontab with less than"""
-        crontab_content = """* * * * * /bin/command1 <arg1"""
-        crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(
-            self.configuration, DUMMY_USER_DN, crontab_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "<arg1"])
-
-    def test_parse_atjobs_with_less_than(self):
-        """Test parsing atjobs with less than"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 <arg1"""
-        atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(
-            self.configuration, DUMMY_USER_DN, atjobs_lines
-        )
-        self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]["command"], ["/bin/command1", "<arg1"])
-
 
 class MigLibEvents__legacy_main(MigTestCase):
     """Unit tests for legacy events self-checks"""
 
+    def _provide_configuration(self):
+        """Prepare isolated test config"""
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test configuration and reset state before each test"""
+        # Make sure log dir exists
+        ensure_dirs_exist(os.path.dirname(self.configuration.user_cron_log))
+
     def test_existing_main(self):
+        """Wrap existing self-tests"""
         def raise_on_error_exit(exit_code):
             if exit_code != 0:
                 if raise_on_error_exit.last_print is not None:

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -163,27 +163,38 @@ class MigLibEvents(MigTestCase):
         self.assertIn('+SCHEDYEAR+', expanded)
         self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
 
-    def test_run_cron_command(self):
-        """Test running cron command"""
+    def test_run_cron_command_touch_succeeds(self):
+        """Test running cron command touch succeeds"""
         target_path = 'test.txt'
         command_list = ['touch', target_path]
         crontab_entry = {'run_as': DUMMY_USER_DN}
+        abs_target_path = os.path.join(self.configuration.user_home,
+                                       DUMMY_CLIENT_DIR, target_path)
+        if os.path.exists(abs_target_path):
+            os.remove(abs_target_path)
+        self.assertFalse(os.path.exists(abs_target_path))
+
         try:
             run_cron_command(command_list, target_path, crontab_entry,
                              self.configuration)
             self.assertTrue(True)  # If no exception, test passes
+            self.assertTrue(os.path.exists(abs_target_path))
         except Exception as exc:
             self.fail("run_cron_command raised an exception: %s" % exc)
 
-    def test_run_events_command(self):
-        """Test running events command"""
+    def test_run_events_command_touch_succeeds(self):
+        """Test running events command touch succeeds"""
         target_path = 'test.txt'
         command_list = ['touch', target_path]
         rule = {'run_as': DUMMY_USER_DN}
+        abs_target_path = os.path.join(self.configuration.user_home,
+                                       DUMMY_CLIENT_DIR, target_path)
+        self.assertFalse(os.path.exists(abs_target_path))
         try:
             run_events_command(command_list, target_path, rule,
                                self.configuration)
             self.assertTrue(True)  # If no exception, test passes
+            self.assertTrue(os.path.exists(abs_target_path))
         except Exception as exc:
             self.fail("run_events_command raised an exception: %s" % exc)
 

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -33,28 +33,29 @@ import shutil
 import time
 import unittest
 
-from mig.lib.events import parse_crontab, cron_match, parse_atjobs, at_remain, \
-    get_path_expand_map, get_time_expand_map, load_crontab, load_atjobs, \
-    parse_crontab_contents, parse_atjobs_contents, parse_and_save_crontab, \
-    parse_and_save_atjobs, run_cron_command, run_events_command, \
-    _save_env, _restore_env, main as events_main
+from mig.lib.events import _restore_env, _save_env, at_remain, cron_match, \
+    get_path_expand_map, get_time_expand_map, load_atjobs, load_crontab
+from mig.lib.events import main as events_main
+from mig.lib.events import parse_and_save_atjobs, parse_and_save_crontab, \
+    parse_atjobs, parse_atjobs_contents, parse_crontab, \
+    parse_crontab_contents, run_cron_command, run_events_command
 from mig.shared.base import distinguished_name_to_user
 from tests.support import MigTestCase, ensure_dirs_exist
 
-DUMMY_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com'
+DUMMY_USER_DN = "/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com"
 DUMMY_FULL_NAME = "Test User"
 DUMMY_ORGANIZATION = "Test Org"
 DUMMY_EMAIL = "test@example.com"
-DUMMY_SKIP_EMAIL = ''
-DUMMY_CLIENT_DIR = '+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.com'
-DUMMY_CRON_JOB = {'command': ['touch', 'test.txt'], 'run_as': DUMMY_USER_DN}
-DUMMY_CRONTAB_NAME = 'crontab'
-DUMMY_ATJOBS_NAME = 'atjobs'
+DUMMY_SKIP_EMAIL = ""
+DUMMY_CLIENT_DIR = "+C=DK+ST=NA+L=NA+O=Test_Org+OU=NA+CN=Test_User+emailAddress=test@example.com"
+DUMMY_CRON_JOB = {"command": ["touch", "test.txt"], "run_as": DUMMY_USER_DN}
+DUMMY_CRONTAB_NAME = "crontab"
+DUMMY_ATJOBS_NAME = "atjobs"
 DUMMY_CRONTAB_CONTENT = """* * * * * /bin/test_command
 30 2 * * * /usr/bin/another_command"""
 DUMMY_ATJOBS_CONTENT = """2042-01-01 12:34:56 /bin/future_command"""
-MUST_PRESERVE_OS_ENV = ['MIG_CONF', 'HOME', 'USER', 'PATH', 'PWD']
-DUMMY_ENV = {'TEST_VAR': 'test_value', 'ANOTHER_VAR': 'another_value'}
+MUST_PRESERVE_OS_ENV = ["MIG_CONF", "HOME", "USER", "PATH", "PWD"]
+DUMMY_ENV = {"TEST_VAR": "test_value", "ANOTHER_VAR": "another_value"}
 
 
 class MigLibEvents(MigTestCase):
@@ -62,7 +63,7 @@ class MigLibEvents(MigTestCase):
 
     def _provide_configuration(self):
         """Prepare isolated test config"""
-        return 'testconfig'
+        return "testconfig"
 
     def before_each(self):
         """Set up test configuration and reset state before each test"""
@@ -80,103 +81,120 @@ class MigLibEvents(MigTestCase):
 
     def test_load_crontab(self):
         """Test loading crontab from file"""
-        crontab_path = os.path.join(self.configuration.user_settings,
-                                    DUMMY_CLIENT_DIR, DUMMY_CRONTAB_NAME)
+        crontab_path = os.path.join(
+            self.configuration.user_settings,
+            DUMMY_CLIENT_DIR,
+            DUMMY_CRONTAB_NAME,
+        )
         ensure_dirs_exist(os.path.dirname(crontab_path))
-        with open(crontab_path, 'w') as fd:
+        with open(crontab_path, "w") as fd:
             fd.write(DUMMY_CRONTAB_CONTENT)
 
         crontab = load_crontab(DUMMY_USER_DN, self.configuration)
-        self.assertIn('* * * * * /bin/test_command', crontab)
+        self.assertIn("* * * * * /bin/test_command", crontab)
 
     def test_load_atjobs(self):
         """Test loading atjobs from file"""
-        atjobs_path = os.path.join(self.configuration.user_settings,
-                                   DUMMY_CLIENT_DIR, DUMMY_ATJOBS_NAME)
+        atjobs_path = os.path.join(
+            self.configuration.user_settings,
+            DUMMY_CLIENT_DIR,
+            DUMMY_ATJOBS_NAME,
+        )
         ensure_dirs_exist(os.path.dirname(atjobs_path))
-        with open(atjobs_path, 'w') as fd:
+        with open(atjobs_path, "w") as fd:
             fd.write(DUMMY_ATJOBS_CONTENT)
 
         atjobs = load_atjobs(DUMMY_USER_DN, self.configuration)
-        self.assertIn('2042-01-01 12:34:56 /bin/future_command', atjobs)
+        self.assertIn("2042-01-01 12:34:56 /bin/future_command", atjobs)
 
     def test_parse_crontab_contents(self):
         """Test parsing crontab content lines"""
         crontab_lines = DUMMY_CRONTAB_CONTENT.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 2)
-        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
 
     def test_parse_atjobs_contents(self):
         """Test parsing atjobs content lines"""
         atjobs_lines = DUMMY_ATJOBS_CONTENT.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'], ['/bin/future_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
 
     def test_parse_and_save_crontab(self):
         """Test parsing and saving crontab"""
         crontab = DUMMY_CRONTAB_CONTENT
-        status, msg = parse_and_save_crontab(crontab, DUMMY_USER_DN,
-                                             self.configuration)
+        status, msg = parse_and_save_crontab(
+            crontab, DUMMY_USER_DN, self.configuration
+        )
         self.assertTrue(status)
-        self.assertIn('valid crontab entries', msg)
+        self.assertIn("valid crontab entries", msg)
 
     def test_parse_and_save_atjobs(self):
         """Test parsing and saving atjobs"""
         atjobs = DUMMY_ATJOBS_CONTENT
-        status, msg = parse_and_save_atjobs(atjobs, DUMMY_USER_DN,
-                                            self.configuration)
+        status, msg = parse_and_save_atjobs(
+            atjobs, DUMMY_USER_DN, self.configuration
+        )
         self.assertTrue(status)
-        self.assertIn('valid atjobs entries', msg)
+        self.assertIn("valid atjobs entries", msg)
 
     def test_cron_match(self):
         """Test cron time matching"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '*', 'hour': '*',
-                    'dayofmonth': '*', 'month': '*', 'dayofweek': '*'}
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+        }
         self.assertTrue(cron_match(self.configuration, now, test_job))
 
     def test_at_remain(self):
         """Test at job remaining time calculation"""
         now = datetime.datetime.now()
         future_time = now + datetime.timedelta(minutes=30)
-        test_job = {'time_stamp': future_time}
+        test_job = {"time_stamp": future_time}
         remaining = at_remain(self.configuration, now, test_job)
         self.assertEqual(remaining, 30)
 
     def test_get_path_expand_map(self):
         """Test path expansion map generation"""
-        trigger_path = '/test/path/file.txt'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertIn('+TRIGGERPATH+', expanded)
-        self.assertEqual(expanded['+TRIGGERPATH+'], trigger_path)
+        trigger_path = "/test/path/file.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertIn("+TRIGGERPATH+", expanded)
+        self.assertEqual(expanded["+TRIGGERPATH+"], trigger_path)
 
     def test_get_time_expand_map(self):
         """Test time expansion map generation"""
         timestamp = datetime.datetime(2023, 1, 2, 9, 2)
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertIn('+SCHEDYEAR+', expanded)
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+        self.assertIn("+SCHEDYEAR+", expanded)
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
 
     def test_run_cron_command_touch_succeeds(self):
         """Test running cron command touch succeeds"""
-        target_path = 'test.txt'
-        command_list = ['touch', target_path]
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        abs_target_path = os.path.join(self.configuration.user_home,
-                                       DUMMY_CLIENT_DIR, target_path)
+        target_path = "test.txt"
+        command_list = ["touch", target_path]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        abs_target_path = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, target_path
+        )
         if os.path.exists(abs_target_path):
             os.remove(abs_target_path)
         self.assertFalse(os.path.exists(abs_target_path))
 
         try:
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
             self.assertTrue(os.path.exists(abs_target_path))
         except Exception as exc:
@@ -184,15 +202,17 @@ class MigLibEvents(MigTestCase):
 
     def test_run_events_command_touch_succeeds(self):
         """Test running events command touch succeeds"""
-        target_path = 'test.txt'
-        command_list = ['touch', target_path]
-        rule = {'run_as': DUMMY_USER_DN}
-        abs_target_path = os.path.join(self.configuration.user_home,
-                                       DUMMY_CLIENT_DIR, target_path)
+        target_path = "test.txt"
+        command_list = ["touch", target_path]
+        rule = {"run_as": DUMMY_USER_DN}
+        abs_target_path = os.path.join(
+            self.configuration.user_home, DUMMY_CLIENT_DIR, target_path
+        )
         self.assertFalse(os.path.exists(abs_target_path))
         try:
-            run_events_command(command_list, target_path, rule,
-                               self.configuration)
+            run_events_command(
+                command_list, target_path, rule, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
             self.assertTrue(os.path.exists(abs_target_path))
         except Exception as exc:
@@ -236,7 +256,7 @@ class MigLibEvents(MigTestCase):
 
         test_env = original_env.copy()
         del test_env[list(original_env)[-1]]
-        test_env['NEWKEY'] = 'NEWVAL'
+        test_env["NEWKEY"] = "NEWVAL"
         self.assertNotEqual(test_env, original_env)
 
         # Restore the original environment
@@ -306,44 +326,56 @@ class MigLibEvents(MigTestCase):
 
     def test_parse_valid_crontab_file(self):
         """Test parsing valid crontab file"""
-        crontab_path = os.path.join(self.configuration.user_settings,
-                                    DUMMY_CLIENT_DIR, DUMMY_CRONTAB_NAME)
+        crontab_path = os.path.join(
+            self.configuration.user_settings,
+            DUMMY_CLIENT_DIR,
+            DUMMY_CRONTAB_NAME,
+        )
         ensure_dirs_exist(os.path.dirname(crontab_path))
-        with open(crontab_path, 'w') as fd:
+        with open(crontab_path, "w") as fd:
             fd.write(DUMMY_CRONTAB_CONTENT)
 
         parsed = parse_crontab(self.configuration, DUMMY_USER_DN, crontab_path)
         self.assertEqual(len(parsed), 2)
-        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
 
     def test_parse_empty_crontab_file(self):
         """Test parsing empty crontab file"""
-        crontab_path = os.path.join(self.configuration.user_settings,
-                                    DUMMY_CLIENT_DIR, DUMMY_CRONTAB_NAME)
+        crontab_path = os.path.join(
+            self.configuration.user_settings,
+            DUMMY_CLIENT_DIR,
+            DUMMY_CRONTAB_NAME,
+        )
         ensure_dirs_exist(os.path.dirname(crontab_path))
-        open(crontab_path, 'a').close()  # Create empty file
+        open(crontab_path, "a").close()  # Create empty file
 
         parsed = parse_crontab(self.configuration, DUMMY_USER_DN, crontab_path)
         self.assertEqual(parsed, [])
 
     def test_parse_valid_atjobs_file(self):
         """Test parsing valid atjobs file"""
-        atjobs_path = os.path.join(self.configuration.user_settings,
-                                   DUMMY_CLIENT_DIR, DUMMY_ATJOBS_NAME)
+        atjobs_path = os.path.join(
+            self.configuration.user_settings,
+            DUMMY_CLIENT_DIR,
+            DUMMY_ATJOBS_NAME,
+        )
         ensure_dirs_exist(os.path.dirname(atjobs_path))
-        with open(atjobs_path, 'w') as fd:
+        with open(atjobs_path, "w") as fd:
             fd.write(DUMMY_ATJOBS_CONTENT)
 
         parsed = parse_atjobs(self.configuration, DUMMY_USER_DN, atjobs_path)
         self.assertEqual(len(parsed), 1)
-        self.assertTrue(parsed[0]['time_stamp'] > datetime.datetime.now())
+        self.assertTrue(parsed[0]["time_stamp"] > datetime.datetime.now())
 
     def test_parse_empty_atjobs_file(self):
         """Test parsing empty atjobs file"""
-        atjobs_path = os.path.join(self.configuration.user_settings,
-                                   DUMMY_CLIENT_DIR, DUMMY_ATJOBS_NAME)
+        atjobs_path = os.path.join(
+            self.configuration.user_settings,
+            DUMMY_CLIENT_DIR,
+            DUMMY_ATJOBS_NAME,
+        )
         ensure_dirs_exist(os.path.dirname(atjobs_path))
-        open(atjobs_path, 'a').close()  # Create empty file
+        open(atjobs_path, "a").close()  # Create empty file
 
         parsed = parse_atjobs(self.configuration, DUMMY_USER_DN, atjobs_path)
         self.assertEqual(parsed, [])
@@ -351,82 +383,120 @@ class MigLibEvents(MigTestCase):
     def test_cron_match_current_minute(self):
         """Test cron_match identifies current time match"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '*', 'hour': '*',
-                    'day': '*', 'month': '*', 'dayofweek': '*',
-                    'dayofmonth': '*'}
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "day": "*",
+            "month": "*",
+            "dayofweek": "*",
+            "dayofmonth": "*",
+        }
         self.assertTrue(cron_match(self.configuration, now, test_job))
 
     def test_cron_match_specific_time(self):
         """Test cron_match rejects non-matching time"""
-        now = datetime.datetime.now().replace(hour=3, minute=15, second=0, microsecond=0)
-        test_job = {'minute': '30', 'hour': '2',
-                    'dayofmonth': '*', 'month': '*', 'dayofweek': '*'}
+        now = datetime.datetime.now().replace(
+            hour=3, minute=15, second=0, microsecond=0
+        )
+        test_job = {
+            "minute": "30",
+            "hour": "2",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+        }
         self.assertFalse(cron_match(self.configuration, now, test_job))
 
     def test_at_remain_past_job(self):
         """Test at_remain with past job"""
         now = datetime.datetime.now()
         past_time = now - datetime.timedelta(minutes=30)
-        test_job = {'time_stamp': past_time}
+        test_job = {"time_stamp": past_time}
         remaining = at_remain(self.configuration, now, test_job)
         self.assertEqual(remaining, -30)
 
     def test_get_path_expand_map_with_spaces(self):
         """Test path expansion with spaces"""
-        trigger_path = '/test/path/file with spaces.txt'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertIn('+TRIGGERFILENAME+', expanded)
-        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file with spaces.txt')
+        trigger_path = "/test/path/file with spaces.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertIn("+TRIGGERFILENAME+", expanded)
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file with spaces.txt")
 
     def test_get_time_expand_map_edge_cases(self):
         """Test time expansion with edge cases"""
         timestamp = datetime.datetime(2023, 12, 31, 23, 59)
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '31')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '12')
-        self.assertEqual(expanded['+SCHEDHOUR+'], '23')
-        self.assertEqual(expanded['+SCHEDMINUTE+'], '59')
+        self.assertEqual(expanded["+SCHEDDAY+"], "31")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
+        self.assertEqual(expanded["+SCHEDHOUR+"], "23")
+        self.assertEqual(expanded["+SCHEDMINUTE+"], "59")
 
     def test_run_cron_command_with_invalid_command(self):
         """Test running cron command with invalid command"""
-        target_path = 'test.txt'
-        command_list = ['invalid_command', target_path]
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["invalid_command", target_path]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_run_events_command_with_invalid_command(self):
         """Test running events command with invalid command"""
-        command_list = ['invalid_command', 'test']
-        target_path = '/test/path'
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        command_list = ["invalid_command", "test"]
+        target_path = "/test/path"
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_cron_match_edge_cases(self):
         """Test cron_match with edge case times"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
         test_cases = [
-            ({'minute': '0', 'hour': '0', 'dayofmonth': '1', 'month': '1', 'dayofweek': '0'},
-             now.replace(hour=0, minute=0, day=1, month=1)),
-            ({'minute': '59', 'hour': '23', 'dayofmonth': '31', 'month': '12', 'dayofweek': '6'},
-             now.replace(hour=23, minute=59, day=31, month=12)),
+            (
+                {
+                    "minute": "0",
+                    "hour": "0",
+                    "dayofmonth": "1",
+                    "month": "1",
+                    "dayofweek": "0",
+                },
+                now.replace(hour=0, minute=0, day=1, month=1),
+            ),
+            (
+                {
+                    "minute": "59",
+                    "hour": "23",
+                    "dayofmonth": "31",
+                    "month": "12",
+                    "dayofweek": "6",
+                },
+                now.replace(hour=23, minute=59, day=31, month=12),
+            ),
         ]
         for job, match_time in test_cases:
-            self.assertEqual(cron_match(self.configuration, match_time, job),
-                             match_time == now)
+            self.assertEqual(
+                cron_match(self.configuration, match_time, job),
+                match_time == now,
+            )
 
     def test_at_remain_edge_cases(self):
         """Test at_remain with edge case times"""
@@ -439,72 +509,79 @@ class MigLibEvents(MigTestCase):
             (now + datetime.timedelta(days=1), 1440),  # 1 day
         ]
         for future_time, expected_minutes in test_cases:
-            test_job = {'time_stamp': future_time}
+            test_job = {"time_stamp": future_time}
             remaining = at_remain(self.configuration, now, test_job)
             self.assertEqual(remaining, expected_minutes)
 
     def test_get_path_expand_map_empty_path(self):
         """Test path expansion with empty path"""
-        trigger_path = ''
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
+        trigger_path = ""
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
         with self.assertRaises(ValueError):
-            expanded = get_path_expand_map(trigger_path, rule, 'modified')
+            expanded = get_path_expand_map(trigger_path, rule, "modified")
 
     def test_get_time_expand_map_leap_year(self):
         """Test time expansion with leap year"""
         timestamp = datetime.datetime(2024, 2, 29, 12, 0)  # Leap day
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '29')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '02')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2024')
+        self.assertEqual(expanded["+SCHEDDAY+"], "29")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "02")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2024")
 
     def test_run_cron_command_with_spaces(self):
         """Test running cron command with spaces"""
-        target_path = 'test file with spaces.txt'
-        command_list = ['touch', target_path]
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        target_path = "test file with spaces.txt"
+        command_list = ["touch", target_path]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         try:
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_cron_command raised an exception: %s" % exc)
 
     def test_run_cron_command_with_special_chars(self):
         """Test running cron command with special characters"""
-        target_path = '/test/path/file@name#with$special&chars.txt'
-        command_list = ['touch', target_path]
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        target_path = "/test/path/file@name#with$special&chars.txt"
+        command_list = ["touch", target_path]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         # NOTE: touch fails without log in input validation
         with self.assertRaises(Exception):
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
 
     def test_run_events_command_with_spaces(self):
         """Test running events command with spaces"""
-        target_path = 'test file with spaces.txt'
-        command_list = ['touch', target_path]
-        rule = {'run_as': DUMMY_USER_DN}
+        target_path = "test file with spaces.txt"
+        command_list = ["touch", target_path]
+        rule = {"run_as": DUMMY_USER_DN}
         try:
-            run_events_command(command_list, target_path, rule,
-                               self.configuration)
+            run_events_command(
+                command_list, target_path, rule, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_events_command raised an exception: %s" % exc)
 
     def test_run_events_command_with_special_chars(self):
         """Test running events command with special characters"""
-        target_path = '/test/path/file@name#with$special&chars.txt'
-        command_list = ['touch', target_path]
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "/test/path/file@name#with$special&chars.txt"
+        command_list = ["touch", target_path]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('found invalid character' in msg
-                    for msg in log_capture.output))
+                any(
+                    "found invalid character" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_comments(self):
         """Test parsing crontab with comments"""
@@ -513,10 +590,11 @@ class MigLibEvents(MigTestCase):
 # Another comment
 30 2 * * * /usr/bin/another_command"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 2)
-        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
 
     def test_parse_atjobs_with_comments(self):
         """Test parsing atjobs with comments"""
@@ -524,93 +602,148 @@ class MigLibEvents(MigTestCase):
 2042-01-01 12:34:56 /bin/future_command
 # Another comment"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'], ['/bin/future_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
 
     def test_cron_match_with_wildcards(self):
         """Test cron_match with various wildcard combinations"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
         test_cases = [
-            ({'minute': '*', 'hour': '*', 'dayofmonth': '*', 'month': '*', 'dayofweek': '*'},
-             True),
-            ({'minute': '15', 'hour': '*', 'dayofmonth': '*', 'month': '*', 'dayofweek': '*'},
-             now.minute == 15),
-            ({'minute': '*', 'hour': '3', 'dayofmonth': '*', 'month': '*', 'dayofweek': '*'},
-             now.hour == 3),
-            ({'minute': '*', 'hour': '*', 'dayofmonth': '15', 'month': '*', 'dayofweek': '*'},
-             now.day == 15),
-            ({'minute': '*', 'hour': '*', 'dayofmonth': '*', 'month': '6', 'dayofweek': '*'},
-             now.month == 6),
-            ({'minute': '*', 'hour': '*', 'dayofmonth': '*', 'month': '*', 'dayofweek': '0'},
-             now.weekday() == 0),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                True,
+            ),
+            (
+                {
+                    "minute": "15",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.minute == 15,
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "3",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.hour == 3,
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "15",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.day == 15,
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "6",
+                    "dayofweek": "*",
+                },
+                now.month == 6,
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "0",
+                },
+                now.weekday() == 0,
+            ),
         ]
         for job, expected in test_cases:
-            self.assertEqual(cron_match(
-                self.configuration, now, job), expected)
+            self.assertEqual(cron_match(self.configuration, now, job), expected)
 
     @unittest.skip("enable next if ever relevant - fails with TypeError")
     def test_at_remain_with_timezones(self):
         """Test at_remain with different timezones"""
         now = datetime.datetime.now()
         test_cases = [
-            (now.astimezone(datetime.timezone.utc) +
-             datetime.timedelta(minutes=30), 30),
-            (now.astimezone(datetime.timezone.utc) -
-             datetime.timedelta(minutes=30), -30),
+            (
+                now.astimezone(datetime.timezone.utc)
+                + datetime.timedelta(minutes=30),
+                30,
+            ),
+            (
+                now.astimezone(datetime.timezone.utc)
+                - datetime.timedelta(minutes=30),
+                -30,
+            ),
         ]
         for future_time, expected_minutes in test_cases:
-            test_job = {'time_stamp': future_time}
+            test_job = {"time_stamp": future_time}
             remaining = at_remain(self.configuration, now, test_job)
             self.assertEqual(remaining, expected_minutes)
 
     def test_get_path_expand_map_with_relative_path(self):
         """Test path expansion with relative path"""
-        trigger_path = '../relative/path/file.txt'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertEqual(expanded['+TRIGGERPATH+'],
-                         '../relative/path/file.txt')
-        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file.txt')
-        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
-        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+        trigger_path = "../relative/path/file.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(expanded["+TRIGGERPATH+"], "../relative/path/file.txt")
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
 
     def test_get_time_expand_map_with_milliseconds(self):
         """Test time expansion with milliseconds"""
         timestamp = datetime.datetime(2023, 1, 2, 9, 2, 30, 123456)
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDSECOND+'], '30')
-        self.assertEqual(expanded['+SCHEDMINUTE+'], '02')
-        self.assertEqual(expanded['+SCHEDHOUR+'], '09')
-        self.assertEqual(expanded['+SCHEDDAY+'], '02')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
-        self.assertEqual(expanded['+SCHEDDAYOFWEEK+'], '0')
+        self.assertEqual(expanded["+SCHEDSECOND+"], "30")
+        self.assertEqual(expanded["+SCHEDMINUTE+"], "02")
+        self.assertEqual(expanded["+SCHEDHOUR+"], "09")
+        self.assertEqual(expanded["+SCHEDDAY+"], "02")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
+        self.assertEqual(expanded["+SCHEDDAYOFWEEK+"], "0")
 
     def test_run_cron_command_with_long_command(self):
         """Test running cron command with long command"""
-        target_path = 'test.txt'
-        long_command = ['touch'] + ['arg'] * 100
+        target_path = "test.txt"
+        long_command = ["touch"] + ["arg"] * 100
         command_list = long_command
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         try:
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_cron_command raised an exception: %s" % exc)
 
     def test_run_events_command_with_long_command(self):
         """Test running events command with long command"""
-        target_path = 'test.txt'
-        long_command = ['touch'] + ['arg'] * 100
+        target_path = "test.txt"
+        long_command = ["touch"] + ["arg"] * 100
         command_list = long_command
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         try:
-            run_events_command(command_list, target_path, rule,
-                               self.configuration)
+            run_events_command(
+                command_list, target_path, rule, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_events_command raised an exception: %s" % exc)
@@ -621,12 +754,17 @@ class MigLibEvents(MigTestCase):
 invalid line
 30 2 * * * /usr/bin/another_command"""
         crontab_lines = crontab_content.splitlines()
-        with self.assertLogs(level='WARNING') as log_capture:
-            parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                            crontab_lines)
+        with self.assertLogs(level="WARNING") as log_capture:
+            parsed = parse_crontab_contents(
+                self.configuration, DUMMY_USER_DN, crontab_lines
+            )
             self.assertEqual(len(parsed), 2)
-            self.assertTrue(any('Skip invalid crontab line' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any(
+                    "Skip invalid crontab line" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_atjobs_with_invalid_lines(self):
         """Test parsing atjobs with invalid lines"""
@@ -634,12 +772,17 @@ invalid line
 invalid line
 2042-01-02 12:34:56 /bin/another_command"""
         atjobs_lines = atjobs_content.splitlines()
-        with self.assertLogs(level='WARNING') as log_capture:
-            parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                           atjobs_lines)
+        with self.assertLogs(level="WARNING") as log_capture:
+            parsed = parse_atjobs_contents(
+                self.configuration, DUMMY_USER_DN, atjobs_lines
+            )
             self.assertEqual(len(parsed), 2)
-            self.assertTrue(any('Skip invalid atjobs line' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any(
+                    "Skip invalid atjobs line" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_empty_lines(self):
         """Test parsing crontab with empty lines"""
@@ -648,10 +791,11 @@ invalid line
 30 2 * * * /usr/bin/another_command
 """
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 2)
-        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
 
     def test_parse_atjobs_with_empty_lines(self):
         """Test parsing atjobs with empty lines"""
@@ -660,30 +804,49 @@ invalid line
 2042-01-02 12:34:56 /bin/another_command
 """
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 2)
-        self.assertEqual(parsed[0]['command'], ['/bin/future_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
 
     def test_cron_match_with_single_digit_values(self):
         """Test cron_match with single digit values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
         test_cases = [
-            ({'minute': '5', 'hour': '3', 'dayofmonth': '7', 'month': '6', 'dayofweek': '1'},
-             now.replace(minute=5, hour=3, day=7, month=6)),
-            ({'minute': '0', 'hour': '0', 'dayofmonth': '1', 'month': '1', 'dayofweek': '0'},
-             now.replace(minute=0, hour=0, day=1, month=1)),
+            (
+                {
+                    "minute": "5",
+                    "hour": "3",
+                    "dayofmonth": "7",
+                    "month": "6",
+                    "dayofweek": "1",
+                },
+                now.replace(minute=5, hour=3, day=7, month=6),
+            ),
+            (
+                {
+                    "minute": "0",
+                    "hour": "0",
+                    "dayofmonth": "1",
+                    "month": "1",
+                    "dayofweek": "0",
+                },
+                now.replace(minute=0, hour=0, day=1, month=1),
+            ),
         ]
         for job, match_time in test_cases:
-            self.assertEqual(cron_match(self.configuration, match_time, job),
-                             match_time == now)
+            self.assertEqual(
+                cron_match(self.configuration, match_time, job),
+                match_time == now,
+            )
 
     def test_at_remain_with_same_minute_but_earlier(self):
         """Test at_remain with same minute but a few seconds earlier"""
         now = datetime.datetime.now()
         now = now.replace(second=30)
         same_minute_time = now.replace(second=42)
-        test_job = {'time_stamp': same_minute_time}
+        test_job = {"time_stamp": same_minute_time}
         remaining = at_remain(self.configuration, now, test_job)
         self.assertEqual(remaining, 0)
 
@@ -692,7 +855,7 @@ invalid line
         now = datetime.datetime.now()
         now = now.replace(second=30)
         same_minute_time = now.replace(second=22)
-        test_job = {'time_stamp': same_minute_time}
+        test_job = {"time_stamp": same_minute_time}
         remaining = at_remain(self.configuration, now, test_job)
         self.assertEqual(remaining, -1)
 
@@ -701,168 +864,192 @@ invalid line
         now = datetime.datetime.now()
         now = now.replace(second=30)
         same_minute_time = now
-        test_job = {'time_stamp': same_minute_time}
+        test_job = {"time_stamp": same_minute_time}
         remaining = at_remain(self.configuration, now, test_job)
         self.assertEqual(remaining, 0)
 
     def test_get_path_expand_map_with_no_extension(self):
         """Test path expansion with no extension"""
-        trigger_path = '/test/path/file'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file')
-        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
-        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '')
+        trigger_path = "/test/path/file"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], "")
 
     def test_get_time_expand_map_with_first_day(self):
         """Test time expansion with first day of month"""
         timestamp = datetime.datetime(2023, 1, 1, 0, 0)
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '01')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
 
     def test_run_cron_command_with_no_arguments(self):
         """Test running cron command with no arguments"""
-        target_path = 'dummy'
-        command_list = ['touch']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        target_path = "dummy"
+        command_list = ["touch"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         # NOTE: touch fails without log in input validation
         with self.assertRaises(Exception):
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
 
     def test_run_events_command_with_no_arguments(self):
         """Test running events command with no arguments"""
-        target_path = 'dummy'
-        command_list = ['touch']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "dummy"
+        command_list = ["touch"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('path: is required' in msg
-                    for msg in log_capture.output))
+                any("path: is required" in msg for msg in log_capture.output)
+            )
 
     def test_parse_crontab_with_trailing_whitespace(self):
         """Test parsing crontab with trailing whitespace"""
         crontab_content = """* * * * * /bin/test_command   \n"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
 
     def test_parse_atjobs_with_trailing_whitespace(self):
         """Test parsing atjobs with trailing whitespace"""
         atjobs_content = """2042-01-01 12:34:56 /bin/future_command   \n"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'], ['/bin/future_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
 
     def test_cron_match_with_all_wildcards(self):
         """Test cron_match with all wildcards"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '*', 'hour': '*', 'dayofmonth': '*',
-                    'month': '*', 'dayofweek': '*'}
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+        }
         self.assertTrue(cron_match(self.configuration, now, test_job))
 
     def test_at_remain_with_future_year(self):
         """Test at_remain with future year"""
         now = datetime.datetime.now()
-        future_year = now.replace(year=now.year + 1, month=1, day=1,
-                                  hour=0, minute=0, second=0)
-        test_job = {'time_stamp': future_year}
+        future_year = now.replace(
+            year=now.year + 1, month=1, day=1, hour=0, minute=0, second=0
+        )
+        test_job = {"time_stamp": future_year}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (future_year - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
 
     def test_get_path_expand_map_with_leading_slash(self):
         """Test path expansion with leading slash"""
-        trigger_path = '/file.txt'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertEqual(expanded['+TRIGGERPATH+'], '/file.txt')
-        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file.txt')
-        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
-        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+        trigger_path = "/file.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(expanded["+TRIGGERPATH+"], "/file.txt")
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
 
     def test_get_time_expand_map_with_last_day(self):
         """Test time expansion with last day of month"""
         timestamp = datetime.datetime(2023, 1, 31, 23, 59)
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '31')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+        self.assertEqual(expanded["+SCHEDDAY+"], "31")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
 
     def test_run_cron_command_with_output_redirection(self):
         """Test running cron command with output redirection"""
-        target_path = 'test.txt'
-        command_list = ['touch', 'test', '>', target_path]
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        target_path = "test.txt"
+        command_list = ["touch", "test", ">", target_path]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         # NOTE: touch fails without log in input validation
         with self.assertRaises(Exception):
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
 
     def test_run_events_command_with_output_redirection(self):
         """Test running events command with output redirection"""
-        target_path = 'test.txt'
-        command_list = ['touch', 'test', '>', target_path]
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["touch", "test", ">", target_path]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('found invalid character' in msg
-                    for msg in log_capture.output))
+                any(
+                    "found invalid character" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     @unittest.skip("enable next if we ever allow multispace")
     def test_parse_crontab_with_multiple_spaces(self):
         """Test parsing crontab with multiple spaces"""
         crontab_content = """*  *  *  *  *  /bin/test_command"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
 
     @unittest.skip("enable next if we ever allow multispace")
     def test_parse_atjobs_with_multiple_spaces(self):
         """Test parsing atjobs with multiple spaces"""
         atjobs_content = """2042-01-01  12:34:56  /bin/future_command"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'], ['/bin/future_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
 
     # TODO: invert next when we implement feature at some point
     def test_cron_match_with_range_values(self):
         """Test cron_match with range values (not supported yet)"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '10-20', 'hour': '2', 'dayofmonth': '*',
-                    'month': '*', 'dayofweek': '*'}
+        test_job = {
+            "minute": "10-20",
+            "hour": "2",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+        }
         # Should fail since ranges aren't supported, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_past_year(self):
         """Test at_remain with past year"""
         now = datetime.datetime.now()
         past_year = now.replace(year=now.year - 1)
-        test_job = {'time_stamp': past_year}
+        test_job = {"time_stamp": past_year}
         remaining = at_remain(self.configuration, now, test_job)
         # Approximately -1 year in minutes
         self.assertEqual(remaining, -525600)
@@ -871,319 +1058,371 @@ invalid line
         """Test at_remain with next year"""
         now = datetime.datetime.now()
         past_year = now.replace(year=now.year + 1)
-        test_job = {'time_stamp': past_year}
+        test_job = {"time_stamp": past_year}
         remaining = at_remain(self.configuration, now, test_job)
         # Approximately 1 year in minutes
         self.assertEqual(remaining, 525600)
 
     def test_get_path_expand_map_with_special_chars(self):
         """Test path expansion with special characters"""
-        trigger_path = '/test/path/file@name#with$special&chars.txt'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertEqual(expanded['+TRIGGERFILENAME+'],
-                         'file@name#with$special&chars.txt')
-        self.assertEqual(expanded['+TRIGGERPREFIX+'],
-                         'file@name#with$special&chars')
-        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+        trigger_path = "/test/path/file@name#with$special&chars.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(
+            expanded["+TRIGGERFILENAME+"], "file@name#with$special&chars.txt"
+        )
+        self.assertEqual(
+            expanded["+TRIGGERPREFIX+"], "file@name#with$special&chars"
+        )
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
 
     def test_get_time_expand_map_with_summer_time(self):
         """Test time expansion with summer time (DST)"""
         # This test may fail depending on the system's timezone and DST rules
         # Summer in Northern Hemisphere
         timestamp = datetime.datetime(2023, 7, 1, 12, 0)
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '01')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '07')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "07")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
 
     def test_run_cron_command_with_pipe(self):
         """Test running cron command with pipe"""
-        target_path = 'test.txt'
-        command_list = ['touch', 'test', '|', 'grep', 'test']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        target_path = "test.txt"
+        command_list = ["touch", "test", "|", "grep", "test"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         # NOTE: touch fails without log in input validation
         with self.assertRaises(Exception):
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
 
     def test_run_events_command_with_pipe(self):
         """Test running events command with pipe"""
-        target_path = 'test.txt'
-        command_list = ['touch', 'test', '|', 'grep', 'test']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["touch", "test", "|", "grep", "test"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('found invalid character' in msg
-                    for msg in log_capture.output))
+                any(
+                    "found invalid character" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     @unittest.skip("enable next if we ever allow tab sep")
     def test_parse_crontab_with_tab_separated(self):
         """Test parsing crontab with tab-separated values"""
         crontab_content = "*\t*\t*\t*\t*\t/bin/test_command"
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'], ['/bin/test_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/test_command"])
 
     @unittest.skip("enable next if we ever allow tab sep")
     def test_parse_atjobs_with_tab_separated(self):
         """Test parsing atjobs with tab-separated values"""
         atjobs_content = "2042-01-01\t12:34:56\t/bin/future_command"
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'], ['/bin/future_command'])
+        self.assertEqual(parsed[0]["command"], ["/bin/future_command"])
 
     def test_cron_match_with_step_values(self):
         """Test cron_match with step values (not supported but should handle)"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '*/5', 'hour': '2', 'dayofmonth': '*',
-                    'month': '*', 'dayofweek': '*'}
+        test_job = {
+            "minute": "*/5",
+            "hour": "2",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+        }
         # Should fail since steps aren't supported, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_leap_year(self):
         """Test at_remain with leap year"""
         now = datetime.datetime.now()
         leap_day = datetime.datetime(
-            now.year + 4 - now.year // 4, 2, 29, 12, 0)  # Next leap year
-        test_job = {'time_stamp': leap_day}
+            now.year + 4 - now.year // 4, 2, 29, 12, 0
+        )  # Next leap year
+        test_job = {"time_stamp": leap_day}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (leap_day - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
 
     def test_get_path_expand_map_with_unicode(self):
         """Test path expansion with unicode characters"""
-        trigger_path = '/test/path/файл.txt'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'файл.txt')
-        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'файл')
-        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+        trigger_path = "/test/path/файл.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "файл.txt")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "файл")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
 
     def test_get_time_expand_map_with_dst_transition(self):
         """Test time expansion with DST transition"""
         # This test may fail depending on the system's timezone and DST rules
         timestamp = datetime.datetime(
-            2023, 3, 12, 2, 30)  # DST transition in US
-        rule = {'run_as': DUMMY_USER_DN}
+            2023, 3, 12, 2, 30
+        )  # DST transition in US
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '12')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '03')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+        self.assertEqual(expanded["+SCHEDDAY+"], "12")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "03")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
 
     def test_run_cron_command_with_background(self):
         """Test running cron command with background execution"""
-        target_path = 'test.txt'
-        command_list = ['touch', target_path, '&']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        target_path = "test.txt"
+        command_list = ["touch", target_path, "&"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         # NOTE: touch succeeds treating ampersand as filename
         try:
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_cron_command raised an exception: %s" % exc)
 
     def test_run_events_command_with_background(self):
         """Test running events command with background execution"""
-        target_path = 'test.txt'
-        command_list = ['sleep', '1', '&']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["sleep", "1", "&"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_multiple_commands(self):
         """Test parsing crontab with multiple commands"""
         crontab_content = """* * * * * /bin/command1 && /bin/command2"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '&&', '/bin/command2'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "&&", "/bin/command2"]
+        )
 
     def test_parse_atjobs_with_multiple_commands(self):
         """Test parsing atjobs with multiple commands"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 && /bin/command2"""
+        atjobs_content = (
+            """2042-01-01 12:34:56 /bin/command1 && /bin/command2"""
+        )
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '&&', '/bin/command2'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "&&", "/bin/command2"]
+        )
 
     @unittest.skip("implement value range check in function and enable next")
     def test_cron_match_with_invalid_values(self):
         """Test cron_match with invalid values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '60', 'hour': '25', 'dayofmonth': '32',
-                    'month': '13', 'dayofweek': '7'}
+        test_job = {
+            "minute": "60",
+            "hour": "25",
+            "dayofmonth": "32",
+            "month": "13",
+            "dayofweek": "7",
+        }
         # Should fail since values are invalid, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_past_time(self):
         """Test at_remain with past time"""
         now = datetime.datetime.now()
         past_time = now - datetime.timedelta(minutes=5)
-        test_job = {'time_stamp': past_time}
+        test_job = {"time_stamp": past_time}
         remaining = at_remain(self.configuration, now, test_job)
         self.assertEqual(remaining, -5)
 
     def test_get_path_expand_map_with_no_path(self):
         """Test path expansion with no path (just filename)"""
-        trigger_path = 'file.txt'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertEqual(expanded['+TRIGGERPATH+'], 'file.txt')
-        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file.txt')
-        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
-        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+        trigger_path = "file.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(expanded["+TRIGGERPATH+"], "file.txt")
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
 
     def test_get_time_expand_map_with_zero_values(self):
         """Test time expansion with zero values"""
         timestamp = datetime.datetime(2023, 1, 1, 0, 0)
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDSECOND+'], '00')
-        self.assertEqual(expanded['+SCHEDMINUTE+'], '00')
-        self.assertEqual(expanded['+SCHEDHOUR+'], '00')
-        self.assertEqual(expanded['+SCHEDDAY+'], '01')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
-        self.assertEqual(expanded['+SCHEDDAYOFWEEK+'], '6')  # Sunday
+        self.assertEqual(expanded["+SCHEDSECOND+"], "00")
+        self.assertEqual(expanded["+SCHEDMINUTE+"], "00")
+        self.assertEqual(expanded["+SCHEDHOUR+"], "00")
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
+        self.assertEqual(expanded["+SCHEDDAYOFWEEK+"], "6")  # Sunday
 
     def test_run_cron_command_with_quotes(self):
         """Test running cron command with quotes"""
-        target_path = 'test.txt'
-        command_list = ['touch', '"test with spaces"']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        target_path = "test.txt"
+        command_list = ["touch", '"test with spaces"']
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         # NOTE: touch fails without log in input validation
         with self.assertRaises(Exception):
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
 
     def test_run_events_command_with_quotes(self):
         """Test running events command with quotes"""
-        target_path = 'test.txt'
-        command_list = ['touch', '"test with spaces"']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["touch", '"test with spaces"']
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
         self.assertTrue(
-            any('found invalid character' in msg
-                for msg in log_capture.output))
+            any("found invalid character" in msg for msg in log_capture.output)
+        )
 
     def test_parse_crontab_with_semicolon(self):
         """Test parsing crontab with semicolon"""
         crontab_content = """* * * * * /bin/command1; /bin/command2"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1;', '/bin/command2'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1;", "/bin/command2"]
+        )
 
     def test_parse_atjobs_with_semicolon(self):
         """Test parsing atjobs with semicolon"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1; /bin/command2"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1;', '/bin/command2'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1;", "/bin/command2"]
+        )
 
     # TODO: invert next when we implement feature at some point
     def test_cron_match_with_division_values(self):
         """Test cron_match with division values (not supported yet)"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '*', 'hour': '*', 'dayofmonth': '*',
-                    'month': '*/1', 'dayofweek': '*'}
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "month": "*/1",
+            "dayofweek": "*",
+        }
         # Should fail since divide format is not yet allowed
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_future_time(self):
         """Test at_remain with future time"""
         now = datetime.datetime.now()
         future_time = now + datetime.timedelta(minutes=5)
-        test_job = {'time_stamp': future_time}
+        test_job = {"time_stamp": future_time}
         remaining = at_remain(self.configuration, now, test_job)
         self.assertEqual(remaining, 5)
 
     def test_get_path_expand_map_with_windows_path(self):
         """Test path expansion with Windows path"""
-        trigger_path = 'C:\\path\\to\\file.txt'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertEqual(expanded['+TRIGGERPATH+'], 'C:\\path\\to\\file.txt')
-        self.assertEqual(expanded['+TRIGGERFILENAME+'],
-                         'C:\\path\\to\\file.txt')
-        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'C:\\path\\to\\file')
-        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+        trigger_path = "C:\\path\\to\\file.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(expanded["+TRIGGERPATH+"], "C:\\path\\to\\file.txt")
+        self.assertEqual(
+            expanded["+TRIGGERFILENAME+"], "C:\\path\\to\\file.txt"
+        )
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "C:\\path\\to\\file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
 
     def test_get_time_expand_map_with_dst_start(self):
         """Test time expansion with DST start"""
         # This test may fail depending on the system's timezone and DST rules
         timestamp = datetime.datetime(2023, 3, 12, 3, 0)  # DST start in US
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '12')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '03')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+        self.assertEqual(expanded["+SCHEDDAY+"], "12")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "03")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
 
     def test_run_cron_command_with_environment_variable(self):
         """Test running cron command with environment variable"""
-        target_path = 'test.txt'
-        command_list = ['touch', '$HOME']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        target_path = "test.txt"
+        command_list = ["touch", "$HOME"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         try:
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_cron_command raised an exception: %s" % exc)
 
     def test_run_events_command_with_environment_variable(self):
         """Test running events command with environment variable"""
-        target_path = 'test.txt'
-        command_list = ['touch', '$HOME']
-        rule = {'run_as': DUMMY_USER_DN}
+        target_path = "test.txt"
+        command_list = ["touch", "$HOME"]
+        rule = {"run_as": DUMMY_USER_DN}
         try:
-            run_events_command(command_list, target_path, rule,
-                               self.configuration)
+            run_events_command(
+                command_list, target_path, rule, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_events_command raised an exception: %s" % exc)
@@ -1192,37 +1431,48 @@ invalid line
         """Test parsing crontab with backticks"""
         crontab_content = """* * * * * /bin/command1 `touch test`"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '`touch', 'test`'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "`touch", "test`"]
+        )
 
     def test_parse_atjobs_with_backticks(self):
         """Test parsing atjobs with backticks"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 `touch test`"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '`touch', 'test`'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "`touch", "test`"]
+        )
 
     @unittest.skip("implement extra value check in function and enable next")
     def test_cron_match_with_extra_fields(self):
         """Test cron_match with extra fields"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '*', 'hour': '*', 'dayofmonth': '*',
-                    'month': '*', 'dayofweek': '*',
-                    'extra_field': 'value'}
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+            "extra_field": "value",
+        }
         # Should fail since extra fields are present, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     # NOTE: no datetime support https://github.com/python/cpython/issues/67762
     @unittest.skip("enable if leap second handling is ever implemented")
@@ -1230,14 +1480,31 @@ invalid line
         """Test at_remain with leap second"""
         # December 31, 2016, had a leap second to include time 23:59:60
         now = datetime.datetime.now(datetime.timezone.utc)
-        t_minus_sixty = now.replace(year=2016, month=12, day=31, hour=23,
-                                    minute=59, second=0, microsecond=0)
+        t_minus_sixty = now.replace(
+            year=2016,
+            month=12,
+            day=31,
+            hour=23,
+            minute=59,
+            second=0,
+            microsecond=0,
+        )
         leap_second = t_minus_sixty + datetime.timedelta(seconds=60)
-        t_plus_sixty = now.replace(year=2017, month=1, day=1, hour=0,
-                                   minute=0, second=59, microsecond=0)
-        self.assertEqual((t_plus_sixty - t_minus_sixty).total_seconds(), 120,
-                         "Leap second does not appear supported")
-        test_job = {'time_stamp': t_plus_sixty}
+        t_plus_sixty = now.replace(
+            year=2017,
+            month=1,
+            day=1,
+            hour=0,
+            minute=0,
+            second=59,
+            microsecond=0,
+        )
+        self.assertEqual(
+            (t_plus_sixty - t_minus_sixty).total_seconds(),
+            120,
+            "Leap second does not appear supported",
+        )
+        test_job = {"time_stamp": t_plus_sixty}
         remaining = at_remain(self.configuration, leap_second, test_job)
         # print("DEBUG: remaining now %s vs %s vs %s : %s" %
         #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
@@ -1245,195 +1512,227 @@ invalid line
 
     def test_get_path_expand_map_with_url(self):
         """Test path expansion with URL"""
-        trigger_path = 'http://example.com/file.txt'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertEqual(expanded['+TRIGGERPATH+'],
-                         'http://example.com/file.txt')
-        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file.txt')
-        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
-        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+        trigger_path = "http://example.com/file.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(
+            expanded["+TRIGGERPATH+"], "http://example.com/file.txt"
+        )
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
 
     def test_get_time_expand_map_with_new_year(self):
         """Test time expansion with New Year"""
         timestamp = datetime.datetime(2023, 1, 1, 0, 0)
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '01')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2023')
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2023")
 
     def test_parse_crontab_with_parentheses(self):
         """Test parsing crontab with parentheses"""
         crontab_content = """* * * * * /bin/command1 (arg1 arg2)"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '(arg1', 'arg2)'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "(arg1", "arg2)"]
+        )
 
     def test_parse_atjobs_with_parentheses(self):
         """Test parsing atjobs with parentheses"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 (arg1 arg2)"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '(arg1', 'arg2)'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "(arg1", "arg2)"]
+        )
 
     def test_cron_match_with_invalid_chars(self):
         """Test cron_match with invalid characters"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '*', 'hour': '*', 'dayofmonth': '*',
-                    'month': '*', 'dayofweek': 'Sunday'}
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "Sunday",
+        }
         # Should fail since invalid characters are present, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_dst_end(self):
         """Test at_remain with DST end"""
         # This test may fail depending on the system's timezone and DST rules
         now = datetime.datetime.now()
         dst_end_time = now.replace(month=11, day=5, hour=1, minute=30)
-        test_job = {'time_stamp': dst_end_time}
+        test_job = {"time_stamp": dst_end_time}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (dst_end_time - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
 
     def test_get_path_expand_map_with_query_string(self):
         """Test path expansion with query string"""
-        trigger_path = '/test/path/file.txt?param=value'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertEqual(expanded['+TRIGGERPATH+'],
-                         '/test/path/file.txt?param=value')
-        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file.txt?param=value')
-        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
-        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt?param=value')
+        trigger_path = "/test/path/file.txt?param=value"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(
+            expanded["+TRIGGERPATH+"], "/test/path/file.txt?param=value"
+        )
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt?param=value")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt?param=value")
 
     def test_get_time_expand_map_with_leap_year_start(self):
         """Test time expansion with leap year start"""
         timestamp = datetime.datetime(2024, 1, 1, 0, 0)  # Leap year
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '01')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2024')
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2024")
 
     def test_run_cron_command_with_escaped_chars(self):
         """Test running cron command with escaped characters"""
-        target_path = 'test.txt'
-        command_list = ['touch', 'test\\ with\\ spaces']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        target_path = "test.txt"
+        command_list = ["touch", "test\\ with\\ spaces"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         # NOTE: touch fails without log in input validation
         with self.assertRaises(Exception):
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
 
     def test_run_events_command_with_escaped_chars(self):
         """Test running events command with escaped characters"""
-        target_path = 'test.txt'
-        command_list = ['touch', 'test\\ with\\ spaces']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["touch", "test\\ with\\ spaces"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('found invalid character' in msg
-                    for msg in log_capture.output))
+                any(
+                    "found invalid character" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_brackets(self):
         """Test parsing crontab with brackets"""
         crontab_content = """* * * * * /bin/command1 [arg1 arg2]"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '[arg1', 'arg2]'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "[arg1", "arg2]"]
+        )
 
     def test_parse_atjobs_with_brackets(self):
         """Test parsing atjobs with brackets"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 [arg1 arg2]"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '[arg1', 'arg2]'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "[arg1", "arg2]"]
+        )
 
     def test_cron_match_with_extra_whitespace(self):
         """Test cron_match with extra whitespace"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': ' * ', 'hour': ' * ', 'dayofmonth': ' * ',
-                    'month': ' * ', 'dayofweek': ' * '}
+        test_job = {
+            "minute": " * ",
+            "hour": " * ",
+            "dayofmonth": " * ",
+            "month": " * ",
+            "dayofweek": " * ",
+        }
         # Should fail since extra whitespace isn't allowed
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_future_dst_transition(self):
         """Test at_remain with future DST transition"""
         # This test may fail depending on the system's timezone and DST rules
         now = datetime.datetime.now()
         future_dst_time = now.replace(month=3, day=12, hour=2, minute=30)
-        test_job = {'time_stamp': future_dst_time}
+        test_job = {"time_stamp": future_dst_time}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (future_dst_time - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
 
     def test_get_path_expand_map_with_fragment(self):
         """Test path expansion with fragment"""
-        trigger_path = '/test/path/file.txt#fragment'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertEqual(expanded['+TRIGGERPATH+'],
-                         '/test/path/file.txt#fragment')
-        self.assertEqual(expanded['+TRIGGERFILENAME+'], 'file.txt#fragment')
-        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file')
-        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt#fragment')
+        trigger_path = "/test/path/file.txt#fragment"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(
+            expanded["+TRIGGERPATH+"], "/test/path/file.txt#fragment"
+        )
+        self.assertEqual(expanded["+TRIGGERFILENAME+"], "file.txt#fragment")
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt#fragment")
 
     def test_get_time_expand_map_with_century_year(self):
         """Test time expansion with century year"""
         timestamp = datetime.datetime(2100, 1, 1, 0, 0)  # Year 2100
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '01')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2100')
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2100")
 
     def test_run_cron_command_with_multiple_commands(self):
         """Test running cron command with multiple commands"""
-        target_path = 'test.txt'
-        command_list = ['touch', 'test1', '&&', 'touch', 'test2']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        target_path = "test.txt"
+        command_list = ["touch", "test1", "&&", "touch", "test2"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         try:
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_cron_command raised an exception: %s" % exc)
 
     def test_run_events_command_with_multiple_commands(self):
         """Test running events command with multiple commands"""
-        target_path = 'test.txt'
-        command_list = ['touch', 'test1', '&&', 'touch', 'test2']
-        rule = {'run_as': DUMMY_USER_DN}
+        target_path = "test.txt"
+        command_list = ["touch", "test1", "&&", "touch", "test2"]
+        rule = {"run_as": DUMMY_USER_DN}
         try:
-            run_events_command(command_list, target_path, rule,
-                               self.configuration)
+            run_events_command(
+                command_list, target_path, rule, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
             self.fail("run_events_command raised an exception: %s" % exc)
@@ -1442,117 +1741,147 @@ invalid line
         """Test parsing crontab with quotes"""
         crontab_content = '''* * * * * /bin/command1 "arg1 with spaces"'''
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', 'arg1 with spaces'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "arg1 with spaces"]
+        )
 
     def test_parse_atjobs_with_quotes(self):
         """Test parsing atjobs with quotes"""
-        atjobs_content = '''2042-01-01 12:34:56 /bin/command1 "arg1 with spaces"'''
+        atjobs_content = (
+            '''2042-01-01 12:34:56 /bin/command1 "arg1 with spaces"'''
+        )
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', 'arg1 with spaces'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "arg1 with spaces"]
+        )
 
     @unittest.skip("implement extra value check in function and enable next")
     def test_cron_match_with_invalid_field_count(self):
         """Test cron_match with invalid field count"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '*', 'hour': '*', 'dayofmonth': '*',
-                    'month': '*', 'dayofweek': '*',
-                    'extra_field': '*'}
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "month": "*",
+            "dayofweek": "*",
+            "extra_field": "*",
+        }
         # Should fail since field count is invalid, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_past_dst_transition(self):
         """Test at_remain with past DST transition"""
         # This test may fail depending on the system's timezone and DST rules
         now = datetime.datetime.now()
         past_dst_time = now.replace(month=11, day=5, hour=1, minute=30)
-        test_job = {'time_stamp': past_dst_time}
+        test_job = {"time_stamp": past_dst_time}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (past_dst_time - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
 
     def test_get_path_expand_map_with_encoded_chars(self):
         """Test path expansion with encoded characters"""
-        trigger_path = '/test/path/file%20with%20spaces.txt'
-        rule = {'vgrid_name': 'test', 'run_as': DUMMY_USER_DN}
-        expanded = get_path_expand_map(trigger_path, rule, 'modified')
-        self.assertEqual(expanded['+TRIGGERPATH+'],
-                         '/test/path/file%20with%20spaces.txt')
-        self.assertEqual(expanded['+TRIGGERFILENAME+'],
-                         'file%20with%20spaces.txt')
-        self.assertEqual(expanded['+TRIGGERPREFIX+'], 'file%20with%20spaces')
-        self.assertEqual(expanded['+TRIGGEREXTENSION+'], '.txt')
+        trigger_path = "/test/path/file%20with%20spaces.txt"
+        rule = {"vgrid_name": "test", "run_as": DUMMY_USER_DN}
+        expanded = get_path_expand_map(trigger_path, rule, "modified")
+        self.assertEqual(
+            expanded["+TRIGGERPATH+"], "/test/path/file%20with%20spaces.txt"
+        )
+        self.assertEqual(
+            expanded["+TRIGGERFILENAME+"], "file%20with%20spaces.txt"
+        )
+        self.assertEqual(expanded["+TRIGGERPREFIX+"], "file%20with%20spaces")
+        self.assertEqual(expanded["+TRIGGEREXTENSION+"], ".txt")
 
     def test_get_time_expand_map_with_millennium_year(self):
         """Test time expansion with millennium year"""
         timestamp = datetime.datetime(2000, 1, 1, 0, 0)  # Year 2000
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '01')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '2000')
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "2000")
 
     def test_run_cron_command_with_input_redirection(self):
         """Test running cron command with input redirection"""
-        target_path = 'test.txt'
-        command_list = ['chksum', 'md5', '<', 'input.txt']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        target_path = "test.txt"
+        command_list = ["chksum", "md5", "<", "input.txt"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         # NOTE: touch fails without log in input validation
         with self.assertRaises(Exception):
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
 
     def test_run_events_command_with_input_redirection(self):
         """Test running events command with input redirection"""
-        target_path = 'test.txt'
-        command_list = ['chksum', 'md5', '<', 'input.txt']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["chksum", "md5", "<", "input.txt"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('found invalid character' in msg
-                    for msg in log_capture.output))
+                any(
+                    "found invalid character" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_single_quotes(self):
         """Test parsing crontab with single quotes"""
         crontab_content = """* * * * * /bin/command1 'arg1 with spaces'"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', "arg1 with spaces"])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "arg1 with spaces"]
+        )
 
     def test_parse_atjobs_with_single_quotes(self):
         """Test parsing atjobs with single quotes"""
-        atjobs_content = """2042-01-01 12:34:56 /bin/command1 'arg1 with spaces'"""
+        atjobs_content = (
+            """2042-01-01 12:34:56 /bin/command1 'arg1 with spaces'"""
+        )
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', "arg1 with spaces"])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "arg1 with spaces"]
+        )
 
     def test_cron_match_with_missing_fields(self):
         """Test cron_match with missing fields"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '*', 'hour': '*', 'dayofmonth': '*',
-                    'dayofweek': '*'}
+        test_job = {
+            "minute": "*",
+            "hour": "*",
+            "dayofmonth": "*",
+            "dayofweek": "*",
+        }
         # NOTE: throws exception before log since values must be strings
         with self.assertRaises(Exception):
             result = cron_match(self.configuration, now, test_job)
@@ -1563,15 +1892,31 @@ invalid line
         """Test at_remain with future leap second"""
         # December 31, 2016, had a leap second to include time 23:59:60
         now = datetime.datetime.now(datetime.timezone.utc)
-        t_minus_sixty = now.replace(year=2016, month=12, day=31, hour=23,
-                                    minute=59, second=0, microsecond=0)
-        leap_second = t_minus_sixty + \
-            datetime.timedelta(seconds=60)
-        t_plus_sixty = now.replace(year=2017, month=1, day=1, hour=0,
-                                   minute=0, second=59, microsecond=0)
-        self.assertEqual((t_plus_sixty - t_minus_sixty).total_seconds(), 120,
-                         "Leap second does not appear supported")
-        test_job = {'time_stamp': leap_second}
+        t_minus_sixty = now.replace(
+            year=2016,
+            month=12,
+            day=31,
+            hour=23,
+            minute=59,
+            second=0,
+            microsecond=0,
+        )
+        leap_second = t_minus_sixty + datetime.timedelta(seconds=60)
+        t_plus_sixty = now.replace(
+            year=2017,
+            month=1,
+            day=1,
+            hour=0,
+            minute=0,
+            second=59,
+            microsecond=0,
+        )
+        self.assertEqual(
+            (t_plus_sixty - t_minus_sixty).total_seconds(),
+            120,
+            "Leap second does not appear supported",
+        )
+        test_job = {"time_stamp": leap_second}
         remaining = at_remain(self.configuration, t_minus_sixty, test_job)
         # print("DEBUG: remaining now %s vs %s vs %s : %s" %
         #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
@@ -1580,63 +1925,76 @@ invalid line
     def test_get_time_expand_map_with_year_zero(self):
         """Test time expansion with year zero"""
         timestamp = datetime.datetime(1, 1, 1, 0, 0)  # Year 1
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '01')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '1')
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "1")
 
     def test_run_cron_command_with_here_document(self):
         """Test running cron command with here document"""
-        target_path = 'test.txt'
-        command_list = ['cat', '<<EOF', 'test content', 'EOF']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["cat", "<<EOF", "test content", "EOF"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_run_events_command_with_here_document(self):
         """Test running events command with here document"""
-        target_path = 'test.txt'
-        command_list = ['cat', '<<EOF', 'test content', 'EOF']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["cat", "<<EOF", "test content", "EOF"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_backslash(self):
         """Test parsing crontab with backslash"""
         crontab_content = """* * * * * /bin/command1 arg1\\ arg2"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', 'arg1 arg2'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "arg1 arg2"])
 
     def test_parse_atjobs_with_backslash(self):
         """Test parsing atjobs with backslash"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 arg1\\ arg2"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', 'arg1 arg2'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "arg1 arg2"])
 
     def test_cron_match_with_non_string_values(self):
         """Test cron_match with non-string values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': 15, 'hour': 3, 'dayofmonth': 7,
-                    'month': 6, 'dayofweek': 1}
+        test_job = {
+            "minute": 15,
+            "hour": 3,
+            "dayofmonth": 7,
+            "month": 6,
+            "dayofweek": 1,
+        }
         # NOTE: throws exception before log since values must be strings
         with self.assertRaises(Exception):
             result = cron_match(self.configuration, now, test_job)
@@ -1647,16 +2005,34 @@ invalid line
         """Test at_remain with past leap second"""
         # December 31, 2016, had a leap second to include time 23:59:60
         now = datetime.datetime.now(datetime.timezone.utc)
-        t_minus_sixty = now.replace(year=2016, month=12, day=31, hour=23,
-                                    minute=59, second=0, microsecond=0)
+        t_minus_sixty = now.replace(
+            year=2016,
+            month=12,
+            day=31,
+            hour=23,
+            minute=59,
+            second=0,
+            microsecond=0,
+        )
         leap_second = t_minus_sixty + datetime.timedelta(seconds=60)
-        t_plus_sixty = now.replace(year=2017, month=1, day=1, hour=0,
-                                   minute=0, second=59, microsecond=0)
-        t_plus_sixtyone = now.replace(year=2017, month=1, day=1, hour=0,
-                                      minute=1, second=0, microsecond=0)
-        self.assertEqual((t_plus_sixty - t_minus_sixty).total_seconds(), 120,
-                         "Leap second does not appear supported")
-        test_job = {'time_stamp': leap_second}
+        t_plus_sixty = now.replace(
+            year=2017,
+            month=1,
+            day=1,
+            hour=0,
+            minute=0,
+            second=59,
+            microsecond=0,
+        )
+        t_plus_sixtyone = now.replace(
+            year=2017, month=1, day=1, hour=0, minute=1, second=0, microsecond=0
+        )
+        self.assertEqual(
+            (t_plus_sixty - t_minus_sixty).total_seconds(),
+            120,
+            "Leap second does not appear supported",
+        )
+        test_job = {"time_stamp": leap_second}
         remaining = at_remain(self.configuration, t_plus_sixty, test_job)
         # print("DEBUG: remaining now %s vs %s vs %s : %s" %
         #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
@@ -1669,63 +2045,80 @@ invalid line
     def test_get_time_expand_map_with_year_9999(self):
         """Test time expansion with year 9999"""
         timestamp = datetime.datetime(9999, 12, 31, 23, 59)
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '31')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '12')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '9999')
+        self.assertEqual(expanded["+SCHEDDAY+"], "31")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "9999")
 
     def test_run_cron_command_with_subshell(self):
         """Test running cron command with subshell"""
-        target_path = 'test.txt'
-        command_list = ['(touch', 'test1; touch', 'test2)']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["(touch", "test1; touch", "test2)"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_run_events_command_with_subshell(self):
         """Test running events command with subshell"""
-        target_path = 'test.txt'
-        command_list = ['(touch', 'test1; touch', 'test2)']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["(touch", "test1; touch", "test2)"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_double_backslash(self):
         """Test parsing crontab with double backslash"""
         crontab_content = """* * * * * /bin/command1 arg1\\\\ arg2"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', 'arg1\\', 'arg2'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "arg1\\", "arg2"]
+        )
 
     def test_parse_atjobs_with_double_backslash(self):
         """Test parsing atjobs with double backslash"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 arg1\\\\ arg2"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', 'arg1\\', 'arg2'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "arg1\\", "arg2"]
+        )
 
     def test_cron_match_with_boolean_values(self):
         """Test cron_match with boolean values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': True, 'hour': False, 'dayofmonth': True,
-                    'month': False, 'dayofweek': True}
+        test_job = {
+            "minute": True,
+            "hour": False,
+            "dayofmonth": True,
+            "month": False,
+            "dayofweek": True,
+        }
         # NOTE: throws exception before log since values must be strings
         with self.assertRaises(Exception):
             result = cron_match(self.configuration, now, test_job)
@@ -1733,9 +2126,10 @@ invalid line
     def test_at_remain_with_future_leap_year(self):
         """Test at_remain with future leap year"""
         now = datetime.datetime.now()
-        future_leap_year = now.replace(year=2096, month=2, day=29,
-                                       hour=12, minute=0)
-        test_job = {'time_stamp': future_leap_year}
+        future_leap_year = now.replace(
+            year=2096, month=2, day=29, hour=12, minute=0
+        )
+        test_job = {"time_stamp": future_leap_year}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (future_leap_year - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
@@ -1743,63 +2137,68 @@ invalid line
     def test_get_time_expand_map_with_year_0001(self):
         """Test time expansion with year 0001"""
         timestamp = datetime.datetime(1, 1, 1, 0, 0)  # Year 1
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '01')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '1')
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "1")
 
     def test_run_cron_command_with_command_substitution(self):
         """Test running cron command with command substitution"""
-        target_path = 'test.txt'
-        command_list = ['touch', '$(date)']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
+        target_path = "test.txt"
+        command_list = ["touch", "$(date)"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
         try:
-            run_cron_command(command_list, target_path, crontab_entry,
-                             self.configuration)
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
-            self.fail(
-                "run_cron_command raised an exception: %s" % exc)
+            self.fail("run_cron_command raised an exception: %s" % exc)
 
     def test_run_events_command_with_command_substitution(self):
         """Test running events command with command substitution"""
-        target_path = 'test.txt'
-        command_list = ['touch', '$(date)']
-        rule = {'run_as': DUMMY_USER_DN}
+        target_path = "test.txt"
+        command_list = ["touch", "$(date)"]
+        rule = {"run_as": DUMMY_USER_DN}
         try:
-            run_events_command(command_list, target_path, rule,
-                               self.configuration)
+            run_events_command(
+                command_list, target_path, rule, self.configuration
+            )
             self.assertTrue(True)  # If no exception, test passes
         except Exception as exc:
-            self.fail(
-                "run_events_command raised an exception: %s" % exc)
+            self.fail("run_events_command raised an exception: %s" % exc)
 
     def test_parse_crontab_with_caret(self):
         """Test parsing crontab with caret"""
         crontab_content = """* * * * * /bin/command1 ^arg1"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '^arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "^arg1"])
 
     def test_parse_atjobs_with_caret(self):
         """Test parsing atjobs with caret"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 ^arg1"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '^arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "^arg1"])
 
     def test_cron_match_with_none_values(self):
         """Test cron_match with none values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': None, 'hour': None, 'dayofmonth': None,
-                    'month': None, 'dayofweek': None}
+        test_job = {
+            "minute": None,
+            "hour": None,
+            "dayofmonth": None,
+            "month": None,
+            "dayofweek": None,
+        }
         # NOTE: throws exception before log since values must be strings
         with self.assertRaises(Exception):
             result = cron_match(self.configuration, now, test_job)
@@ -1807,9 +2206,10 @@ invalid line
     def test_at_remain_with_past_leap_year(self):
         """Test at_remain with past leap year"""
         now = datetime.datetime.now()
-        past_leap_year = now.replace(year=2000, month=2, day=29,
-                                     hour=12, minute=0)
-        test_job = {'time_stamp': past_leap_year}
+        past_leap_year = now.replace(
+            year=2000, month=2, day=29, hour=12, minute=0
+        )
+        test_job = {"time_stamp": past_leap_year}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (past_leap_year - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
@@ -1817,78 +2217,94 @@ invalid line
     def test_get_time_expand_map_with_year_9999_end(self):
         """Test time expansion with year 9999 end"""
         timestamp = datetime.datetime(9999, 12, 31, 23, 59)
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '31')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '12')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '9999')
+        self.assertEqual(expanded["+SCHEDDAY+"], "31")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "9999")
 
     def test_run_cron_command_with_true_command(self):
         """Test running cron command with true command"""
-        target_path = 'test.txt'
-        command_list = ['true']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["true"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_run_events_command_with_true_command(self):
         """Test running events command with true command"""
-        target_path = 'test.txt'
-        command_list = ['true']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["true"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_hash(self):
         """Test parsing crontab with hash"""
         crontab_content = """* * * * * /bin/command1 #arg1"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1"])
 
     def test_parse_atjobs_with_hash(self):
         """Test parsing atjobs with hash"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 #arg1"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1"])
 
     def test_cron_match_with_tab_values(self):
         """Test cron_match with tab values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '\t', 'hour': '\t', 'dayofmonth': '\t',
-                    'month': '\t', 'dayofweek': '\t'}
+        test_job = {
+            "minute": "\t",
+            "hour": "\t",
+            "dayofmonth": "\t",
+            "month": "\t",
+            "dayofweek": "\t",
+        }
         # Should fail since values are tabs, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_future_millennium(self):
         """Test at_remain with future millennium"""
         now = datetime.datetime.now()
-        future_millennium = now.replace(year=now.year + 1000, month=1, day=1,
-                                        hour=0, minute=0)
-        test_job = {'time_stamp': future_millennium}
+        future_millennium = now.replace(
+            year=now.year + 1000, month=1, day=1, hour=0, minute=0
+        )
+        test_job = {"time_stamp": future_millennium}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (future_millennium - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
@@ -1896,149 +2312,180 @@ invalid line
     def test_get_time_expand_map_with_year_0001_end(self):
         """Test time expansion with year 0001 end"""
         timestamp = datetime.datetime(1, 12, 31, 23, 59)  # Year 1
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '31')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '12')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '1')
+        self.assertEqual(expanded["+SCHEDDAY+"], "31")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "12")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "1")
 
     def test_run_cron_command_with_false_command(self):
         """Test running cron command with false command"""
-        target_path = 'test.txt'
-        command_list = ['false']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["false"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_run_events_command_with_false_command(self):
         """Test running events command with false command"""
-        target_path = 'test.txt'
-        command_list = ['false']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["false"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_dollar(self):
         """Test parsing crontab with dollar"""
         crontab_content = """* * * * * /bin/command1 $arg1"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '$arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "$arg1"])
 
     def test_parse_atjobs_with_dollar(self):
         """Test parsing atjobs with dollar"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 $arg1"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '$arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "$arg1"])
 
     def test_cron_match_with_newline_values(self):
         """Test cron_match with newline values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '\n', 'hour': '\n', 'dayofmonth': '\n',
-                    'month': '\n', 'dayofweek': '\n'}
+        test_job = {
+            "minute": "\n",
+            "hour": "\n",
+            "dayofmonth": "\n",
+            "month": "\n",
+            "dayofweek": "\n",
+        }
         # Should fail since values are newlines, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_past_millennium(self):
         """Test at_remain with past millennium"""
         now = datetime.datetime.now()
-        past_millennium = now.replace(year=now.year - 1000, month=1, day=1,
-                                      hour=0, minute=0)
-        test_job = {'time_stamp': past_millennium}
+        past_millennium = now.replace(
+            year=now.year - 1000, month=1, day=1, hour=0, minute=0
+        )
+        test_job = {"time_stamp": past_millennium}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (past_millennium - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
 
     def test_run_cron_command_with_null_command(self):
         """Test running cron command with null command"""
-        target_path = 'test.txt'
-        command_list = [':']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = [":"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_run_events_command_with_null_command(self):
         """Test running events command with null command"""
-        target_path = 'test.txt'
-        command_list = [':']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = [":"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_percent(self):
         """Test parsing crontab with percent"""
         crontab_content = """* * * * * /bin/command1 %arg1"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '%arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "%arg1"])
 
     def test_parse_atjobs_with_percent(self):
         """Test parsing atjobs with percent"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 %arg1"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '%arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "%arg1"])
 
     def test_cron_match_with_carriage_return_values(self):
         """Test cron_match with carriage return values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '\r', 'hour': '\r', 'dayofmonth': '\r',
-                    'month': '\r', 'dayofweek': '\r'}
+        test_job = {
+            "minute": "\r",
+            "hour": "\r",
+            "dayofmonth": "\r",
+            "month": "\r",
+            "dayofweek": "\r",
+        }
         # Should fail since values are carriage returns, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_future_millennium_end(self):
         """Test at_remain with future millennium end"""
         now = datetime.datetime.now()
-        future_millennium_end = now.replace(year=now.year + 1000,
-                                            month=12, day=31,
-                                            hour=23, minute=59)
-        test_job = {'time_stamp': future_millennium_end}
+        future_millennium_end = now.replace(
+            year=now.year + 1000, month=12, day=31, hour=23, minute=59
+        )
+        test_job = {"time_stamp": future_millennium_end}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (future_millennium_end - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
@@ -2046,79 +2493,94 @@ invalid line
     def test_get_time_expand_map_with_year_0001_start(self):
         """Test time expansion with year 0001 start"""
         timestamp = datetime.datetime(1, 1, 1, 0, 0)  # Year 1
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '01')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '1')
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "1")
 
     def test_run_cron_command_with_builtin_command(self):
         """Test running cron command with builtin command"""
-        target_path = 'test.txt'
-        command_list = ['builtin', 'command']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["builtin", "command"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_run_events_command_with_builtin_command(self):
         """Test running events command with builtin command"""
-        target_path = 'test.txt'
-        command_list = ['builtin', 'command']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["builtin", "command"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_ampersand(self):
         """Test parsing crontab with ampersand"""
         crontab_content = """* * * * * /bin/command1 &arg1"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '&arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "&arg1"])
 
     def test_parse_atjobs_with_ampersand(self):
         """Test parsing atjobs with ampersand"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 &arg1"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '&arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "&arg1"])
 
     def test_cron_match_with_vertical_tab_values(self):
         """Test cron_match with vertical tab values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '\v', 'hour': '\v', 'dayofmonth': '\v',
-                    'month': '\v', 'dayofweek': '\v'}
+        test_job = {
+            "minute": "\v",
+            "hour": "\v",
+            "dayofmonth": "\v",
+            "month": "\v",
+            "dayofweek": "\v",
+        }
         # Should fail since values are vertical tabs, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_past_millennium_end(self):
         """Test at_remain with past millennium end"""
         now = datetime.datetime.now()
-        past_millennium_end = now.replace(year=now.year - 1000,
-                                          month=12, day=31,
-                                          hour=23, minute=59)
-        test_job = {'time_stamp': past_millennium_end}
+        past_millennium_end = now.replace(
+            year=now.year - 1000, month=12, day=31, hour=23, minute=59
+        )
+        test_job = {"time_stamp": past_millennium_end}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (past_millennium_end - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
@@ -2126,341 +2588,413 @@ invalid line
     def test_get_time_expand_map_with_year_9999_start(self):
         """Test time expansion with year 9999 start"""
         timestamp = datetime.datetime(9999, 1, 1, 0, 0)  # Year 9999
-        rule = {'run_as': DUMMY_USER_DN}
+        rule = {"run_as": DUMMY_USER_DN}
         expanded = get_time_expand_map(timestamp, rule)
-        self.assertEqual(expanded['+SCHEDDAY+'], '01')
-        self.assertEqual(expanded['+SCHEDMONTH+'], '01')
-        self.assertEqual(expanded['+SCHEDYEAR+'], '9999')
+        self.assertEqual(expanded["+SCHEDDAY+"], "01")
+        self.assertEqual(expanded["+SCHEDMONTH+"], "01")
+        self.assertEqual(expanded["+SCHEDYEAR+"], "9999")
 
     def test_run_cron_command_with_alias_command(self):
         """Test running cron command with alias command"""
-        target_path = 'test.txt'
-        command_list = ['alias', 'command']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["alias", "command"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_run_events_command_with_alias_command(self):
         """Test running events command with alias command"""
-        target_path = 'test.txt'
-        command_list = ['alias', 'command']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["alias", "command"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_pipe(self):
         """Test parsing crontab with pipe"""
         crontab_content = """* * * * * /bin/command1 | /bin/command2"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '|', '/bin/command2'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "|", "/bin/command2"]
+        )
 
     def test_parse_atjobs_with_pipe(self):
         """Test parsing atjobs with pipe"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 | /bin/command2"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '|', '/bin/command2'])
+        self.assertEqual(
+            parsed[0]["command"], ["/bin/command1", "|", "/bin/command2"]
+        )
 
     def test_cron_match_with_form_feed_values(self):
         """Test cron_match with form feed values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '\f', 'hour': '\f', 'dayofmonth': '\f',
-                    'month': '\f', 'dayofweek': '\f'}
+        test_job = {
+            "minute": "\f",
+            "hour": "\f",
+            "dayofmonth": "\f",
+            "month": "\f",
+            "dayofweek": "\f",
+        }
         # Should fail since values are form feeds, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_future_century_end(self):
         """Test at_remain with future century end"""
         now = datetime.datetime.now()
-        future_century_end = now.replace(year=now.year + 100,
-                                         month=12, day=31,
-                                         hour=23, minute=59)
-        test_job = {'time_stamp': future_century_end}
+        future_century_end = now.replace(
+            year=now.year + 100, month=12, day=31, hour=23, minute=59
+        )
+        test_job = {"time_stamp": future_century_end}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (future_century_end - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
 
     def test_run_cron_command_with_function_command(self):
         """Test running cron command with function command"""
-        target_path = 'test.txt'
-        command_list = ['function', 'name() { command; }']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["function", "name() { command; }"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_run_events_command_with_function_command(self):
         """Test running events command with function command"""
-        target_path = 'test.txt'
-        command_list = ['function', 'name() { command; }']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["function", "name() { command; }"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_question_mark(self):
         """Test parsing crontab with question mark"""
         crontab_content = """* * * * * /bin/command1 ?arg1"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '?arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "?arg1"])
 
     def test_parse_atjobs_with_question_mark(self):
         """Test parsing atjobs with question mark"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 ?arg1"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '?arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "?arg1"])
 
     def test_cron_match_with_escape_values(self):
         """Test cron_match with escape values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '\\', 'hour': '\\', 'dayofmonth': '\\',
-                    'month': '\\', 'dayofweek': '\\'}
+        test_job = {
+            "minute": "\\",
+            "hour": "\\",
+            "dayofmonth": "\\",
+            "month": "\\",
+            "dayofweek": "\\",
+        }
         # Should fail since values are escapes, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_past_century_end(self):
         """Test at_remain with past century end"""
         now = datetime.datetime.now()
-        past_century_end = now.replace(year=now.year - 100,
-                                       month=12, day=31,
-                                       hour=23, minute=59)
-        test_job = {'time_stamp': past_century_end}
+        past_century_end = now.replace(
+            year=now.year - 100, month=12, day=31, hour=23, minute=59
+        )
+        test_job = {"time_stamp": past_century_end}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (past_century_end - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
 
     def test_run_cron_command_with_reserved_command(self):
         """Test running cron command with reserved command"""
-        target_path = 'test.txt'
-        command_list = ['reserved', 'command']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["reserved", "command"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_plus(self):
         """Test parsing crontab with plus"""
         crontab_content = """* * * * * /bin/command1 +arg1"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '+arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "+arg1"])
 
     def test_parse_atjobs_with_plus(self):
         """Test parsing atjobs with plus"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 +arg1"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '+arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "+arg1"])
 
     def test_cron_match_with_delete_values(self):
         """Test cron_match with delete values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': '\x7f', 'hour': '\x7f', 'dayofmonth': '\x7f',
-                    'month': '\x7f', 'dayofweek': '\x7f'}
+        test_job = {
+            "minute": "\x7f",
+            "hour": "\x7f",
+            "dayofmonth": "\x7f",
+            "month": "\x7f",
+            "dayofweek": "\x7f",
+        }
         # Should fail since values are deletes, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_future_century_start(self):
         """Test at_remain with future century start"""
         now = datetime.datetime.now()
-        future_century_start = now.replace(year=now.year + 100,
-                                           month=1, day=1,
-                                           hour=0, minute=0)
-        test_job = {'time_stamp': future_century_start}
+        future_century_start = now.replace(
+            year=now.year + 100, month=1, day=1, hour=0, minute=0
+        )
+        test_job = {"time_stamp": future_century_start}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (future_century_start - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
 
     def test_run_cron_command_with_dot_command(self):
         """Test running cron command with dot command"""
-        target_path = 'test.txt'
-        command_list = ['.', 'command']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = [".", "command"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_run_events_command_with_dot_command(self):
         """Test running events command with dot command"""
-        target_path = 'test.txt'
-        command_list = ['.', 'command']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = [".", "command"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_comma(self):
         """Test parsing crontab with comma"""
         crontab_content = """* * * * * /bin/command1,arg1"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1,arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1,arg1"])
 
     def test_parse_atjobs_with_comma(self):
         """Test parsing atjobs with comma"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1,arg1"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1,arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1,arg1"])
 
     def test_cron_match_with_space_values(self):
         """Test cron_match with space values"""
         now = datetime.datetime.now().replace(second=0, microsecond=0)
-        test_job = {'minute': ' ', 'hour': ' ', 'dayofmonth': ' ',
-                    'month': ' ', 'dayofweek': ' '}
+        test_job = {
+            "minute": " ",
+            "hour": " ",
+            "dayofmonth": " ",
+            "month": " ",
+            "dayofweek": " ",
+        }
         # Should fail since values are spaces, but shouldn't crash
         # NOTE: tweak cron_match use for missing debug log access in assertLogs
-        with self.assertLogs(level='WARNING') as log_capture:
-            result = cron_match(self.configuration, now, test_job,
-                                _warn_mismatch=True)
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = cron_match(
+                self.configuration, now, test_job, _warn_mismatch=True
+            )
             self.assertFalse(result)
-            self.assertTrue(any('no cron_match on' in msg
-                                for msg in log_capture.output))
+            self.assertTrue(
+                any("no cron_match on" in msg for msg in log_capture.output)
+            )
 
     def test_at_remain_with_past_century_start(self):
         """Test at_remain with past century start"""
         now = datetime.datetime.now()
-        past_century_start = now.replace(year=now.year - 100,
-                                         month=1, day=1,
-                                         hour=0, minute=0)
-        test_job = {'time_stamp': past_century_start}
+        past_century_start = now.replace(
+            year=now.year - 100, month=1, day=1, hour=0, minute=0
+        )
+        test_job = {"time_stamp": past_century_start}
         remaining = at_remain(self.configuration, now, test_job)
         expected_minutes = (past_century_start - now).total_seconds() // 60
         self.assertEqual(remaining, expected_minutes)
 
     def test_run_cron_command_with_colon_command(self):
         """Test running cron command with colon command"""
-        target_path = 'test.txt'
-        command_list = [':']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = [":"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_run_cron_command_with_bracket_command(self):
         """Test running cron command with bracket command"""
-        target_path = 'test.txt'
-        command_list = ['[', 'test', '-f', 'file', ']']
-        crontab_entry = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["[", "test", "-f", "file", "]"]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_cron_command(command_list, target_path, crontab_entry,
-                                 self.configuration)
+                run_cron_command(
+                    command_list, target_path, crontab_entry, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_run_events_command_with_bracket_command(self):
         """Test running events command with bracket command"""
-        target_path = 'test.txt'
-        command_list = ['[', 'test', '-f', 'file', ']']
-        rule = {'run_as': DUMMY_USER_DN}
-        with self.assertLogs(level='ERROR') as log_capture:
+        target_path = "test.txt"
+        command_list = ["[", "test", "-f", "file", "]"]
+        rule = {"run_as": DUMMY_USER_DN}
+        with self.assertLogs(level="ERROR") as log_capture:
             with self.assertRaises(Exception):
-                run_events_command(command_list, target_path, rule,
-                                   self.configuration)
+                run_events_command(
+                    command_list, target_path, rule, self.configuration
+                )
             self.assertTrue(
-                any('failed to run' in msg or 'failed to lookup' in msg
-                    for msg in log_capture.output))
+                any(
+                    "failed to run" in msg or "failed to lookup" in msg
+                    for msg in log_capture.output
+                )
+            )
 
     def test_parse_crontab_with_less_than(self):
         """Test parsing crontab with less than"""
         crontab_content = """* * * * * /bin/command1 <arg1"""
         crontab_lines = crontab_content.splitlines()
-        parsed = parse_crontab_contents(self.configuration, DUMMY_USER_DN,
-                                        crontab_lines)
+        parsed = parse_crontab_contents(
+            self.configuration, DUMMY_USER_DN, crontab_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '<arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "<arg1"])
 
     def test_parse_atjobs_with_less_than(self):
         """Test parsing atjobs with less than"""
         atjobs_content = """2042-01-01 12:34:56 /bin/command1 <arg1"""
         atjobs_lines = atjobs_content.splitlines()
-        parsed = parse_atjobs_contents(self.configuration, DUMMY_USER_DN,
-                                       atjobs_lines)
+        parsed = parse_atjobs_contents(
+            self.configuration, DUMMY_USER_DN, atjobs_lines
+        )
         self.assertEqual(len(parsed), 1)
-        self.assertEqual(parsed[0]['command'],
-                         ['/bin/command1', '<arg1'])
+        self.assertEqual(parsed[0]["command"], ["/bin/command1", "<arg1"])
 
 
 class MigLibEvents__legacy_main(MigTestCase):
@@ -2472,9 +3006,11 @@ class MigLibEvents__legacy_main(MigTestCase):
                 if raise_on_error_exit.last_print is not None:
                     identifying_message = raise_on_error_exit.last_print
                 else:
-                    identifying_message = 'unknown'
+                    identifying_message = "unknown"
                 raise AssertionError(
-                    'failure in unittest/testcore: %s' % (identifying_message,))
+                    "failure in unittest/testcore: %s" % (identifying_message,)
+                )
+
         raise_on_error_exit.last_print = None
 
         def record_last_print(value):
@@ -2483,5 +3019,5 @@ class MigLibEvents__legacy_main(MigTestCase):
         events_main(_exit=raise_on_error_exit, _print=record_last_print)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fundamentally migrate `mig/shared/events.py` to new FHSesque `mig/lib/` location with unit tests coverage.

Switch to shared stop signal handler and helpers from `mig/lib/daemon.py` in events and cron services.

Rename constant helpers from _lower_case to UPPER_CASE and move to `mig/lib/events.py` 

Rename `run_command` to `run_{cron,events}_command` and migrate them and their dependencies to `mig/lib/events.py` Adjust them slightly to init local logger from provided `configuration` rather than global `logger` var.

Minor style adjustments from autopoep8, etc. and pruned a few unused imports.

Sync the use of `importlib` to events service command runner to eliminate the old deprecated and unsafe `exec` method.

Adjust legacy self-tests slightly to allow calling them from unit tests.

Added explicit save and restore environment helpers as that turned out to be crucial in relation to e.g. avoid unit test cross-talk.

Adjust `cron_match` slightly to allow elevating mismatch log messages to warnings for unit tests to carefully inspect what failed.

Reformat everything in `mig/lib/events.py` and `tests/test_mig_lib_events.py` with `black` and `isort` for consistency.

There's a follow-up branch to migrate the remaining slightly more cumbersome bits to `mig/lib/` and `mig/sbin/` on top of this PR, but it requires some API changes especially in some helper functions and classes that currently rely on global configuration, logger, etc. availability, so it's probably better left for later.