### PR TITLE
Adjust `mig/shared/base.py` functions with `environ=None` arg to honor empty dict

### DIFF
--- a/mig/shared/base.py
+++ b/mig/shared/base.py
@@ -399,7 +399,7 @@ def requested_backend(environ=None, fallback='UNKNOWN', strip_ext=True):
     too, so use it whenever the actual (potentially unsafe) URL is not a strict
     requirement.
     """
-    if not environ:
+    if environ is None:
         environ = os.environ
     # NOTE: RPC wrappers inject name of actual backend as BACKEND_NAME
     # NOTE: wsgi sets SCRIPT_X to wsgi-bin but PATH_TRANSLATED contains backend
@@ -426,7 +426,7 @@ def requested_page(environ=None, fallback='home.py', name_only=False,
     environment values without proper filtering and then MUST be used very
     carefully, because printing may otherwise result in XSS vulnerabilities.
     """
-    if not environ:
+    if environ is None:
         environ = os.environ
     if name_only:
         return requested_backend(environ, fallback, strip_ext)
@@ -456,7 +456,7 @@ def requested_url_base(environ=None, include_unsafe=False, uri_field='SCRIPT_URI
     values without proper filtering and thus MUST be used very carefully,
     because printing may otherwise result in XSS vulnerabilities.
     """
-    if not environ:
+    if environ is None:
         environ = os.environ
     full_url = environ.get(uri_field, None)
     parts = full_url.split('/', 3)

--- a/tests/test_mig_shared_base.py
+++ b/tests/test_mig_shared_base.py
@@ -883,6 +883,15 @@ just use the one that looks most familiar or try them in turn)"""
         result = requested_page(fake_env, fallback=fallback)
         self.assertEqual(result, fallback)
 
+    def test_requested_page_fallback_despite_os_environ_value(self):
+        """Test fallback to default"""
+        fake_env = {}
+        fallback = 'special.py'
+        os.environ['BACKEND_NAME'] = 'BOGUS'
+        result = requested_page(fake_env, fallback=fallback)
+        del os.environ['BACKEND_NAME']
+        self.assertEqual(result, fallback)
+
     def test_requested_url_base_normal(self):
         """Test requested_url_base with basic complete URL"""
         fake_env = {'SCRIPT_URI': 'https://example.com/path/to/script.py'}


### PR DESCRIPTION
Adjust `mig/shared/base.py` functions with `environ=None` arg to honor empty dict and only fall back to `os.environ` if `environ` arg is in fact `None` rather than boolean `False`. Otherwise we get hammered by various env changes in unit tests when passing an empty dict for `environ`.

We might want to look into always resetting `os.environ` after temporary changes there, but that is left as a follow-up. Please refer to #464 for details and a fix for the specific unit test failure there.