### PR TITLE
Enable TracTags module.

### DIFF
--- a/mig/server/trac-py3.ini
+++ b/mig/server/trac-py3.ini
@@ -77,6 +77,9 @@ tracfullblog.* = enabled
 #tracdiscussion.spamfilter.DiscussionSpamFilter = disabled # Optional, disable if you don't have SpamFilterPlugin.
 #tracdiscussion.tags.DiscussionTagProvider = disabled
 #tracdiscussion.tags.DiscussionTags = disabled
+# Please refer to https://trac-hacks.org/wiki/TracPlugins for install requirements
+# pip install svn+https://trac-hacks.org/svn/tagsplugin/trunk
+tractags.* = enabled
 
 # Mercurial plugin settings
 #[hg]


### PR DESCRIPTION
Just the conf side of things to enable the `TracTags` plugin in the optional vgrid `Trac` component integration. Requires the plugin to be installed along with `Trac` itself. 
Please note that Trac-1.6 currently requires an unreleased repo version of the plugin as stated on
https://trac-hacks.org/wiki/TagsPlugin

For docker-migrid deployments the plugin integration is included in https://github.com/ucphhpc/docker-migrid/pull/145

Existing vgridtrackers will need a refresh with something like
`trac-admin /home/mig/state/vgrid_files_writable/VGRIDNAME/.vgridtracker/var/ upgrade`
 and likely also
`trac-admin /home/mig/state/vgrid_files_{writable,home}/VGRIDNAME/.vgridtracker/var/  wiki upgrade`
as the former upgrade will suggest.