### PR TITLE
Address a bug in the leading zero removal of cron_match as identified after PR464 merge

### DIFF
--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -316,9 +316,14 @@ def cron_match(configuration, cron_time, entry, _warn_mismatch=False):
     }
     # TODO: extend to support e.g. */5, 8-16 and the likes?
     for name, val in time_vals.items():
-        # Strip any leading zeros before integer match but never last one
-        entry_val = entry[name][:-1].lstrip("0") + entry[name][-1]
-        if not fnmatch.fnmatch("%s" % val, entry_val):
+        # Allow leading zeros in integer match for plain or wildcard patterns
+        # Namely, we want to allow 5, 05 to match 5 and 0* to match [0-9]
+        # while preserving that a single * matches any value.
+        entry_val = entry[name]
+        cmp_pattern = "%d"
+        if len(entry_val) > 1:
+            cmp_pattern = "%%.%dd" % len(entry_val)
+        if not fnmatch.fnmatch(cmp_pattern % val, entry_val):
             msg = "no cron_match on %s: %s vs %s" % (name, val, entry[name])
             if _warn_mismatch:
                 _logger.warning(msg)

--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -316,8 +316,9 @@ def cron_match(configuration, cron_time, entry, _warn_mismatch=False):
     }
     # TODO: extend to support e.g. */5, 8-16 and the likes?
     for name, val in time_vals.items():
-        # Strip any leading zeros before integer match
-        if not fnmatch.fnmatch("%s" % val, entry[name].lstrip("0")):
+        # Strip any leading zeros before integer match but never last one
+        entry_val = entry[name][:-1].lstrip("0") + entry[name][-1]
+        if not fnmatch.fnmatch("%s" % val, entry_val):
             msg = "no cron_match on %s: %s vs %s" % (name, val, entry[name])
             if _warn_mismatch:
                 _logger.warning(msg)

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -417,6 +417,46 @@ class MigLibEvents__timers(MigTestCase):
             ),
             (
                 {
+                    "minute": "*5",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(minute=5),
+            ),
+            (
+                {
+                    "minute": "0*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(minute=5),
+            ),
+            (
+                {
+                    "minute": "*2",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(minute=42),
+            ),
+            (
+                {
+                    "minute": "4*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(minute=42),
+            ),
+            (
+                {
                     "minute": "*",
                     "hour": "0",
                     "dayofmonth": "*",

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -348,9 +348,9 @@ class MigLibEvents__timers(MigTestCase):
                     "hour": "*",
                     "dayofmonth": "*",
                     "month": "*",
-                    "dayofweek": "0",
+                    "dayofweek": "1",
                 },
-                now.weekday() == 0,
+                now.weekday() == 1,
             ),
         ]
         for job, expected in test_cases:
@@ -370,6 +370,278 @@ class MigLibEvents__timers(MigTestCase):
             "dayofweek": "*",
         }
         self.assertFalse(cron_match(self.configuration, now, test_job))
+
+    def test_cron_match_with_leading_zero_match(self):
+        """Test cron_match with various leading zero match combinations"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_cases = [
+            (
+                {
+                    "minute": "0",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(minute=0),
+            ),
+            (
+                {
+                    "minute": "00",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(minute=0),
+            ),
+            (
+                {
+                    "minute": "000",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(minute=0),
+            ),
+            (
+                {
+                    "minute": "05",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(minute=5),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "0",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(hour=0),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "03",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(hour=3),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "04",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(day=4),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "06",
+                    "dayofweek": "*",
+                },
+                now.replace(month=6),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "0",
+                },
+                # Get first Monday of current month
+                now.replace(day=7).replace(
+                    day=now.replace(day=7).day - now.replace(day=7).weekday()),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "04",
+                },
+                # Get first Friday of current month
+                now.replace(day=7).replace(
+                    day=4 + now.replace(day=7).day - now.replace(day=7).weekday()),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "000",
+                },
+                # Get first Monday of current month
+                now.replace(day=7).replace(
+                    day=now.replace(day=7).day - now.replace(day=7).weekday()),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "004",
+                },
+                # Get first Friday of current month
+                now.replace(day=7).replace(
+                    day=4 + now.replace(day=7).day - now.replace(day=7).weekday()),
+            ),
+        ]
+        for job, now in test_cases:
+            self.assertTrue(cron_match(self.configuration, now, job))
+
+    def test_cron_match_with_leading_zero_mismatch(self):
+        """Test cron_match with various leading zero mismatch combinations"""
+        now = datetime.datetime.now().replace(second=0, microsecond=0)
+        test_cases = [
+            (
+                {
+                    "minute": "0",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(minute=1),
+            ),
+            (
+                {
+                    "minute": "00",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(minute=1),
+            ),
+            (
+                {
+                    "minute": "000",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(minute=1),
+            ),
+            (
+                {
+                    "minute": "05",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(minute=6),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "0",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(hour=1),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "03",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(hour=1),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "04",
+                    "month": "*",
+                    "dayofweek": "*",
+                },
+                now.replace(day=1),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "06",
+                    "dayofweek": "*",
+                },
+                now.replace(month=1),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "0",
+                },
+                # Get first Friday of current month
+                now.replace(day=7).replace(
+                    day=4 + now.replace(day=7).day - now.replace(day=7).weekday()),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "04",
+                },
+                # Get first Monday of current month
+                now.replace(day=7).replace(
+                    day=now.replace(day=7).day - now.replace(day=7).weekday()),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "000",
+                },
+                # Get first Friday of current month
+                now.replace(day=7).replace(
+                    day=4 + now.replace(day=7).day - now.replace(day=7).weekday()),
+            ),
+            (
+                {
+                    "minute": "*",
+                    "hour": "*",
+                    "dayofmonth": "*",
+                    "month": "*",
+                    "dayofweek": "004",
+                },
+                # Get first Monday of current month
+                now.replace(day=7).replace(
+                    day=now.replace(day=7).day - now.replace(day=7).weekday()),
+            ),
+        ]
+        for job, now in test_cases:
+            self.assertFalse(cron_match(self.configuration, now, job))
 
     @unittest.skip("enable next if ever relevant - fails with TypeError")
     def test_at_remain_with_timezones(self):
@@ -529,8 +801,6 @@ class MigLibEvents__timers(MigTestCase):
         )
         test_job = {"time_stamp": t_plus_sixty}
         remaining = at_remain(self.configuration, leap_second, test_job)
-        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
-        #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
         self.assertEqual(remaining, 1)
 
     def test_cron_match_with_invalid_chars(self):
@@ -676,12 +946,8 @@ class MigLibEvents__timers(MigTestCase):
         )
         test_job = {"time_stamp": leap_second}
         remaining = at_remain(self.configuration, t_plus_sixty, test_job)
-        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
-        #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
         self.assertEqual(remaining, -1)
         remaining = at_remain(self.configuration, t_plus_sixtyone, test_job)
-        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
-        #      (t_minus_sixty, leap_second, t_plus_sixtyone, remaining))
         self.assertEqual(remaining, -2)
 
     def test_cron_match_with_non_string_values(self):
@@ -730,8 +996,6 @@ class MigLibEvents__timers(MigTestCase):
         )
         test_job = {"time_stamp": leap_second}
         remaining = at_remain(self.configuration, t_minus_sixty, test_job)
-        # print("DEBUG: remaining now %s vs %s vs %s : %s" %
-        #      (t_minus_sixty, leap_second, t_plus_sixty, remaining))
         self.assertEqual(remaining, 1)
 
     def test_cron_match_with_boolean_values(self):


### PR DESCRIPTION
Address a bug in the leading zero removal of cron_match as identified after PR464 merge but coincidentally apparently not triggered in prior unit tests there, because they happened to run on a Monday where the dynamic `datetime` actually disabled the otherwise failing test :-/
Fixed the underlying issue in `cron_match` and added two additional fixed date test methods to make sure we avoid that situation and test more thoroughly as regression tests.