### PR TITLE
GDP: Added support for account tab and account renewal

### DIFF
--- a/mig/images/js/jquery.ajaxhelpers.js
+++ b/mig/images/js/jquery.ajaxhelpers.js
@@ -916,7 +916,7 @@ function ajax_gdp_project_info(callback, project_name) {
     console.debug("ajax_gdp_project_info: " + project_name);
     var result = { OK: [], WARNING: [], ERROR: [] };
     var target_op = "gdpman";
-    console.info("Lookup CSRF token for " + target_op);
+    console.debug("Lookup CSRF token for " + target_op);
 
     var jsonSettings = {
         base_vgrid_name: project_name,
@@ -925,9 +925,9 @@ function ajax_gdp_project_info(callback, project_name) {
     };
     if (csrf_map[target_op] !== undefined) {
         jsonSettings[csrf_field] = csrf_map[target_op];
-        console.info("Found CSRF token " + jsonSettings["_csrf"]);
+        console.debug("Found CSRF token " + jsonSettings["_csrf"]);
     } else {
-        console.info("No CSRF token for " + target_op);
+        console.error("No CSRF token for " + target_op);
     }
 
     $.ajax({
@@ -1131,7 +1131,7 @@ function ajax_renew_account_access(callback) {
     console.debug("ajax_renew_account_access");
     var result = { OK: [], WARNING: [], ERROR: [] };
     var target_op = "accountaction";
-    console.info("Lookup CSRF token for " + target_op);
+    console.debug("Lookup CSRF token for " + target_op);
 
     var jsonSettings = {
         output_format: "json",
@@ -1139,9 +1139,9 @@ function ajax_renew_account_access(callback) {
     };
     if (csrf_map[target_op] !== undefined) {
         jsonSettings[csrf_field] = csrf_map[target_op];
-        console.info("Found CSRF token " + jsonSettings["_csrf"]);
+        console.debug("Found CSRF token " + jsonSettings["_csrf"]);
     } else {
-        console.info("No CSRF token for " + target_op);
+        console.error("No CSRF token for " + target_op);
     }
 
     $.ajax({
@@ -1163,7 +1163,7 @@ function ajax_renew_account_access(callback) {
                     );
                     result.WARNING.push(jsonRes[i].text);
                 } else if (jsonRes[i]["object_type"] === "error_text") {
-                    console.error("ajax_gdp_project_info: " + jsonRes[i].text);
+                    console.error("ajax_renew_account_access: " + jsonRes[i].text);
                     result.ERROR.push(jsonRes[i].text);
                 }
             }

--- a/mig/images/js/jquery.ajaxhelpers.js
+++ b/mig/images/js/jquery.ajaxhelpers.js
@@ -4,7 +4,7 @@
   # --- BEGIN_HEADER ---
   #
   # jquery.ajaxhelpers - jquery based ajax helpers for managers
-  # Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
+  # Copyright (C) 2003-2026  The MiG Project lead by the Science HPC Center at UCPH
   #
   # This file is part of MiG.
   #
@@ -1122,6 +1122,63 @@ function prepare_seafile_settings(reg_url, username, integration,
             $("#"+status_prefix+"status").addClass("error iconleftpad");
             $("#"+status_prefix+"msg").addClass("status_offline");
             select_seafile_section(save_prefix);
+        }
+    });
+}
+
+/* User account access renew helper */
+function ajax_renew_account_access(callback) {
+    console.debug("ajax_renew_account_access");
+    var result = { OK: [], WARNING: [], ERROR: [] };
+    var target_op = "accountaction";
+    console.info("Lookup CSRF token for " + target_op);
+
+    var jsonSettings = {
+        output_format: "json",
+        action: "RENEW_ACCESS"
+    };
+    if (csrf_map[target_op] !== undefined) {
+        jsonSettings[csrf_field] = csrf_map[target_op];
+        console.info("Found CSRF token " + jsonSettings["_csrf"]);
+    } else {
+        console.info("No CSRF token for " + target_op);
+    }
+
+    $.ajax({
+        url: target_op + ".py",
+        data: jsonSettings,
+        type: "POST",
+        dataType: "json",
+        cache: false,
+        success: function(jsonRes) {
+            for (var i = 0; i < jsonRes.length; i++) {
+                console.debug("jsonRes: " + JSON.stringify(jsonRes[i]));
+                if (jsonRes[i].object_type === "text") {
+                    console.debug("ajax_renew_account_access: " +
+                      JSON.stringify(jsonRes[i].text));
+                    result.OK.push(jsonRes[i].text);
+                } else if (jsonRes[i]["object_type"] === "warning") {
+                    console.warning(
+                        "ajax_renew_account_access: " + jsonRes[i].text
+                    );
+                    result.WARNING.push(jsonRes[i].text);
+                } else if (jsonRes[i]["object_type"] === "error_text") {
+                    console.error("ajax_gdp_project_info: " + jsonRes[i].text);
+                    result.ERROR.push(jsonRes[i].text);
+                }
+            }
+            callback(result);
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+            console.error(
+                "ajax_renew_account_access: " +
+                    "status: " +
+                    textStatus +
+                    "error: " +
+                    errorThrown
+            );
+            result.ERROR.push(textStatus);
+            result.ERROR.push(errorThrown);
         }
     });
 }

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # accountreq - helpers for certificate/OpenID account requests
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -45,7 +45,8 @@ except ImportError:
 from mig.shared.accountstate import default_account_expire
 from mig.shared.base import auth_type_description, canonical_user, \
     client_id_dir, distinguished_name_to_user, fill_distinguished_name, \
-    fill_user, force_utf8, force_native_str_rec, get_user_id, mask_creds
+    fill_user, force_utf8, force_native_str_rec, get_user_id, mask_creds, \
+    requested_backend
 from mig.shared.defaults import peers_fields, peers_filename, \
     pending_peers_filename, keyword_auto, user_db_filename, \
     gdp_distinguished_field
@@ -660,7 +661,10 @@ and select which authentication method you want to change password for.
     return html
 
 
-def renew_account_access_template(configuration, default_values={}):
+def renew_account_access_template(configuration,
+                                  valid_peers,
+                                  environ,
+                                  default_values={}):
     """A general form template used for renewing account access."""
 
     html = """
@@ -668,6 +672,8 @@ def renew_account_access_template(configuration, default_values={}):
 """
 
     _logger = configuration.logger
+    script = requested_backend(environ)
+    # Create auth type filter
     auth_map = auth_type_description(configuration)
     show_auth_types = [(key, auth_map[key]) for key in
                        default_values.get('show', auth_map.keys())]
@@ -681,6 +687,24 @@ No matching local authentication methods enabled on this site, so no account
 access to renew here.
 </p>
 """
+    elif not valid_peers:
+        html += """
+<p>
+Account renewal request is needed.
+%(peer_acceptance_notice)s
+</p>
+"""
+        if script == "gdpman":
+            html += """
+<a class='ui-button' id='request_account_button' href='#' onclick='submitform(\"request_account\"); return false;'>Request Account Access</a>
+"""
+        else:
+            html += """
+<!-- use post here to avoid field contents in URL -->
+<form target='_blank' method='%(form_method)s' action='%(target_op)s.py'>
+    <input id='submit_button' type=submit value='Request Account Access'/>
+</form>
+"""
     else:
         html += """
 <p>
@@ -688,11 +712,18 @@ Account access automatically expires after a while and needs to be actively
 renewed.
 %(peer_acceptance_notice)s
 </p>
+"""
+        if script == "gdpman":
+            html += """
+<a class='ui-button' id='renew_account_button' href='#' onclick='submitform(\"renew_account_access\"); return false;'>Renew Account Access</a>
+"""
+        else:
+            html += """
 <!-- use post here to avoid field contents in URL -->
 <form method='%(form_method)s' action='%(target_op)s.py'>
     <input type='hidden' name='%(csrf_field)s' value='%(csrf_token)s' />
     <input type='hidden' name='action' value='%(account_action)s'/>
-    <input id='submit_button' type=submit value='Renew %(auth_label)s Account Access'/>
+    <input id='submit_button' type=submit value='Renew Account Access'/>
 </form>
 """
 
@@ -1302,7 +1333,7 @@ def save_account_request(configuration, req_dict):
     """Save req_dict account request as pickle in configured user_pending
     location.
     Returns a tuple of save status and output, where the latter is the request
-    path on success or the error message otherwise. 
+    path on success or the error message otherwise.
     """
     req_path = None
     try:

--- a/mig/shared/accountreq.py
+++ b/mig/shared/accountreq.py
@@ -687,7 +687,7 @@ No matching local authentication methods enabled on this site, so no account
 access to renew here.
 </p>
 """
-    elif not valid_peers:
+    elif configuration.site_peers_mandatory and not valid_peers:
         html += """
 <p>
 Account renewal request is needed.

--- a/mig/shared/defaults.py
+++ b/mig/shared/defaults.py
@@ -538,7 +538,8 @@ valid_gdp_auth_scripts = [
     'settingsaction.py',
     'twofactor.py',
     'uploadchunked.py',
-    'rmvgridowner.py'
+    'rmvgridowner.py',
+    'accountaction.py',
 ]
 # NOTE: these are cgi-sid scripts to always allow
 valid_gdp_anon_scripts = [

--- a/mig/shared/functionality/account.py
+++ b/mig/shared/functionality/account.py
@@ -195,9 +195,6 @@ at a time depending on site policies)"""
     (auth_type, auth_label) = find_auth_type_and_label(
         configuration, auth_type_name, auth_flavor
     )
-    show_local = [
-        i for i in configuration.site_login_methods if i.startswith("mig")
-    ]
     fill_helpers.update(
         {
             "auth_type": auth_type,
@@ -206,34 +203,42 @@ at a time depending on site policies)"""
             "auth_label": auth_label,
         }
     )
-    html += (
-        """
-        <div id="manage-container" class="row">
-            <div class="manage-page__header col-12">
-                <h2>Manage Account</h2>
-                <p class="sub-title">Depending on your %(short_title)s account
-                type you have access to one or more account management actions
-                below.
-                </p>
-            </div>
-            """
-        % fill_helpers
-    )
-    form_method = "post"
-    csrf_limit = get_csrf_limit(configuration)
-    target_op = "accountaction"
-    csrf_token = make_csrf_token(
-        configuration, form_method, target_op, client_id, csrf_limit
-    )
-    fill_helpers.update(
-        {
-            "target_op": target_op,
-            "form_method": form_method,
-            "csrf_field": csrf_field,
-            "csrf_token": csrf_token,
-        }
-    )
+    show_local = [
+        i for i in configuration.site_login_methods if i.startswith("mig")
+    ]
+    # TODO: Let extoid(c) users renew for configuration.X_valid_days ?
+    # show_remote = [
+    #    i for i in configuration.site_login_methods if i.startswith("ext")
+    # ]
     if auth_type in show_local:
+        html += (
+            """
+            <div id="manage-container" class="row">
+                <div class="manage-page__header col-12">
+                    <h2>Manage Account</h2>
+                    <p class="sub-title">Depending on your %(short_title)s account
+                    type you have access to one or more account management actions
+                    below.
+                    </p>
+                </div>
+                """
+            % fill_helpers
+        )
+        form_method = "post"
+        csrf_limit = get_csrf_limit(configuration)
+        target_op = "accountaction"
+        csrf_token = make_csrf_token(
+            configuration, form_method, target_op, client_id, csrf_limit
+        )
+        fill_helpers.update(
+            {
+                "target_op": target_op,
+                "form_method": form_method,
+                "csrf_field": csrf_field,
+                "csrf_token": csrf_token,
+            }
+        )
+        show_peers = ""
         fill_helpers["account_action"] = "RENEW_ACCESS"
         fill_helpers["peer_acceptance_notice"] = ""
         if configuration.site_peers_mandatory:
@@ -277,43 +282,44 @@ at a time depending on site policies)"""
                         if peer not in valid_peers_list
                     ]
                 )
-            show_peers = ""
             for peer in valid_peers_list:
                 show_peers += "%s &lt;%s&gt;" % (
                     extract_field(peer, "full_name"),
                     extract_field(peer, "email"),
                 )
-            if show_peers:
-                fill_helpers["peer_acceptance_notice"] = (
-                    """
-Apparently %s accepted you as a peer
-and if that peer appointment has not yet ended you can renew your access here
-without further operator or peer contact involvement. Otherwise you may need to
-obtain or await explicit extension or peer assignment from someone else before
-your access renewal can proceed.
+        if show_peers:
+            fill_helpers["peer_acceptance_notice"] = (
                 """
-                    % show_peers
+%s accepted you as a peer and you can now renew your access here.
+            """
+                % show_peers
+            )
+        elif not configuration.site_peers_mandatory:
+            fill_helpers["peer_acceptance_notice"] = (
+                """
+You can renew your access here.
+            """
+            )
+        else:
+            bin_url = requested_page(os.environ).replace("-sid", "-bin")
+            if fill_helpers.get("auth_flavor", "") == AUTH_MIG_OID:
+                fill_helpers["target_op"] = os.path.join(
+                    os.path.dirname(bin_url), "reqoid"
                 )
-            else:
-                bin_url = requested_page(os.environ).replace("-sid", "-bin")
-                if fill_helpers.get("auth_flavor", "") == AUTH_MIG_OID:
-                    fill_helpers["target_op"] = os.path.join(
-                        os.path.dirname(bin_url), "reqoid"
-                    )
-                elif fill_helpers.get("auth_flavor", "") == AUTH_MIG_OIDC:
-                    fill_helpers["target_op"] = os.path.join(
-                        os.path.dirname(bin_url), "reqoidc"
-                    )
-                elif auth_flavor == AUTH_MIG_CERT:
-                    fill_helpers["target_op"] = os.path.join(
-                        os.path.dirname(bin_url), "migcert"
-                    )
-                fill_helpers[
-                    "peer_acceptance_notice"
-                ] = """
+            elif fill_helpers.get("auth_flavor", "") == AUTH_MIG_OIDC:
+                fill_helpers["target_op"] = os.path.join(
+                    os.path.dirname(bin_url), "reqoidc"
+                )
+            elif auth_flavor == AUTH_MIG_CERT:
+                fill_helpers["target_op"] = os.path.join(
+                    os.path.dirname(bin_url), "migcert"
+                )
+            fill_helpers[
+                "peer_acceptance_notice"
+            ] = """
 It looks like you may need someone with authority to appoint you as their peer
 before your access renewal can be accepted.
-                """
+            """
         fill_helpers["renew_helper"] = (
             renew_account_access_template(
                 configuration,
@@ -333,10 +339,10 @@ before your access renewal can be accepted.
             % fill_helpers
         )
 
-    html += """
-            <div class="col-lg-12 vertical-spacer"></div>
-        </div>
-    """
+        html += """
+                <div class="col-lg-12 vertical-spacer"></div>
+            </div>
+        """
 
     # Show storage accounting information if enabled
 

--- a/mig/shared/functionality/account.py
+++ b/mig/shared/functionality/account.py
@@ -33,18 +33,24 @@ from __future__ import absolute_import
 
 import datetime
 import os
+import copy
+import time
 
 from mig.lib.accounting import get_usage
 from mig.shared import returnvalues
 from mig.shared.accountreq import renew_account_access_template
 from mig.shared.accountstate import account_expire_info
-from mig.shared.defaults import csrf_field, user_home_label
+from mig.shared.base import extract_field, requested_page
+from mig.shared.defaults import csrf_field, user_home_label, AUTH_MIG_OID, \
+    AUTH_MIG_OIDC, AUTH_MIG_CERT
 from mig.shared.functional import validate_input_and_cert
 from mig.shared.handlers import get_csrf_limit, make_csrf_token
 from mig.shared.htmlgen import html_user_messages, man_base_js
 from mig.shared.httpsclient import detect_client_auth, find_auth_type_and_label
 from mig.shared.init import find_entry, initialize_main_variables
-from mig.shared.useradm import get_full_user_map
+from mig.shared.useradm import get_full_user_map, default_search, search_users, \
+    verify_user_peers
+from mig.shared.userdb import default_db_path
 
 _account_field_order = [('full_name', 'Full Name'),
                         ('organization', 'Organization'),
@@ -68,7 +74,7 @@ def html_tmpl(configuration, client_id, environ, title_entry):
         user_msg = html_user_messages(configuration, client_id)
         show_user_msg = ''
     user_map = get_full_user_map(configuration)
-    user_dict = user_map.get(client_id, None)
+    user_dict = user_map.get(client_id, {})
     user_account = ''
     if user_dict:
         # NOTE: set min days high enough to always return renew and extend_days
@@ -81,15 +87,18 @@ def html_tmpl(configuration, client_id, environ, title_entry):
         registered:
         </p>
         '''
+        show_account = {}
         for (field, label) in _account_field_order:
             field_hint = ''
             if not user_dict.get(field, False):
                 continue
+            show_account[field] = copy.deepcopy(user_dict[field])
             if field == 'expire':
                 # NOTE: translate epoch to proper datetime string
-                expire_dt = datetime.datetime.fromtimestamp(user_dict[field])
+                expire_dt = datetime.datetime.fromtimestamp(
+                    show_account[field])
                 # strip usec for user-friendly time stamp
-                user_dict[field] = expire_dt.replace(microsecond=0)
+                show_account[field] = expire_dt.replace(microsecond=0)
                 if extend_days > 0:
                     field_hint = """(web login auto-extends access for %d days,
 and sign up for %d days at a time)""" % (extend_days, renew_days)
@@ -97,7 +106,7 @@ and sign up for %d days at a time)""" % (extend_days, renew_days)
                     field_hint = """(renewal may extend it for up to %d days
 at a time depending on site policies)""" % renew_days
             user_account += '''%s: %s %s<br/>
-            ''' % (label, user_dict[field], field_hint)
+            ''' % (label, show_account[field], field_hint)
     # NOTE: ID token is only available for openid connect
     claim_dump, user_token = '', ''
     for (key, val) in os.environ.items():
@@ -111,8 +120,10 @@ at a time depending on site policies)""" % renew_days
         </p>'''
         user_token += claim_dump
     fill_helpers = {'short_title': configuration.short_title,
-                    'user_msg': user_msg, 'show_user_msg': show_user_msg,
-                    'home_label': user_home_label, 'user_account': user_account,
+                    'user_msg': user_msg,
+                    'show_user_msg': show_user_msg,
+                    'home_label': user_home_label,
+                    'user_account': user_account,
                     'user_token': user_token}
 
     html = '''
@@ -178,20 +189,48 @@ at a time depending on site policies)""" % renew_days
     fill_helpers.update({'target_op': target_op, 'form_method':
                          form_method, 'csrf_field': csrf_field,
                          'csrf_token': csrf_token})
-    # TODO: extend renew to active ext accounts?
-    if auth_type in show_local and user_dict.get('status', 'active') == 'temporal':
+    if auth_type in show_local:
         fill_helpers['account_action'] = "RENEW_ACCESS"
         fill_helpers['peer_acceptance_notice'] = ""
         if configuration.site_peers_mandatory:
-            peers_full_name = user_dict.get("peers_full_name", "")
             peers_email = user_dict.get("peers_email", "")
             peers_list = user_dict.get("peers", [])
-            if peers_full_name and peers_email:
-                show_peers = "%s &lt;%s&gt;" % (peers_full_name, peers_email)
-            elif peers_list:
-                show_peers = ', '.join(peers_list)
-            else:
-                show_peers = ''
+            search_filter = default_search()
+            search_filter['email'] = peers_email
+            configuration.logger.info("peers_email: %r" % peers_email)
+            (_, hits) = search_users(search_filter,
+                                     configuration,
+                                     default_db_path(configuration),
+                                     regex_match=['email'])
+            possible_peers = [ent[0] for ent in hits]
+            possible_peers.extend(peers_list)
+            configuration.logger.info("possible_peers: %r" % possible_peers)
+            valid_peers_list = []
+            for verify_peer in possible_peers:
+                configuration.logger.info("verify_peer: %r" % verify_peer)
+                try:
+                    (verified_peer_list, _) \
+                        = verify_user_peers(configuration,
+                                            default_db_path(configuration),
+                                            client_id,
+                                            user_dict,
+                                            time.time(),
+                                            verify_peer,
+                                            0,
+                                            False,
+                                            False)
+                except Exception as err:
+                    logger.warning("Failed to verify user peers: %s" % err)
+                    continue
+                logger.info("verified_peer_list: %r"
+                            % verified_peer_list)
+                valid_peers_list.extend([peer for peer in verified_peer_list
+                                         if peer not in valid_peers_list])
+            show_peers = ''
+            for peer in valid_peers_list:
+                show_peers += "%s &lt;%s&gt;" \
+                    % (extract_field(peer, 'full_name'),
+                        extract_field(peer, 'email'))
             if show_peers:
                 fill_helpers['peer_acceptance_notice'] = """
 Apparently %s accepted you as a peer
@@ -201,12 +240,28 @@ obtain or await explicit extension or peer assignment from someone else before
 your access renewal can proceed.
                 """ % show_peers
             else:
+                bin_url = requested_page(os.environ).replace('-sid', '-bin')
+                if fill_helpers.get('auth_flavor', '') == AUTH_MIG_OID:
+                    fill_helpers['target_op'] \
+                        = os.path.join(os.path.dirname(bin_url),
+                                       'reqoid')
+                elif fill_helpers.get('auth_flavor', '') == AUTH_MIG_OIDC:
+                    fill_helpers['target_op'] \
+                        = os.path.join(os.path.dirname(bin_url),
+                                       'reqoidc')
+                elif auth_flavor == AUTH_MIG_CERT:
+                    fill_helpers['target_op'] \
+                        = os.path.join(os.path.dirname(bin_url),
+                                       'migcert')
                 fill_helpers['peer_acceptance_notice'] = """
 It looks like you may need someone with authority to appoint you as their peer
 before your access renewal can be accepted.
                 """
         fill_helpers['renew_helper'] = renew_account_access_template(
-            configuration, default_values=fill_helpers) % fill_helpers
+            configuration,
+            valid_peers_list,
+            environ,
+            default_values=fill_helpers) % fill_helpers
         html += '''
             <div class="renew-account-access__header col-12">
                 <h3>Renew Account Access</h3>
@@ -224,8 +279,8 @@ before your access renewal can be accepted.
     if configuration.site_enable_accounting:
         account_usage = get_usage(configuration, client_id)
         if account_usage is None:
-            logger.error("Failed to load acount usage for user: %r" \
-                    % client_id)
+            logger.error("Failed to load acount usage for user: %r"
+                         % client_id)
             account_usage = {}
         accounting = account_usage.get('accounting', {})
         accounting_dt = datetime.datetime.fromtimestamp(

--- a/mig/shared/functionality/account.py
+++ b/mig/shared/functionality/account.py
@@ -41,27 +41,37 @@ from mig.shared import returnvalues
 from mig.shared.accountreq import renew_account_access_template
 from mig.shared.accountstate import account_expire_info
 from mig.shared.base import extract_field, requested_page
-from mig.shared.defaults import csrf_field, user_home_label, AUTH_MIG_OID, \
-    AUTH_MIG_OIDC, AUTH_MIG_CERT
+from mig.shared.defaults import (
+    csrf_field,
+    user_home_label,
+    AUTH_MIG_OID,
+    AUTH_MIG_OIDC,
+    AUTH_MIG_CERT,
+)
 from mig.shared.functional import validate_input_and_cert
 from mig.shared.handlers import get_csrf_limit, make_csrf_token
 from mig.shared.htmlgen import html_user_messages, man_base_js
 from mig.shared.httpsclient import detect_client_auth, find_auth_type_and_label
 from mig.shared.init import find_entry, initialize_main_variables
-from mig.shared.useradm import get_full_user_map, default_search, search_users, \
-    verify_user_peers
+from mig.shared.useradm import (
+    get_full_user_map,
+    default_search,
+    search_users,
+    verify_user_peers,
+)
 from mig.shared.userdb import default_db_path
 
-_account_field_order = [('full_name', 'Full Name'),
-                        ('organization', 'Organization'),
-                        ('email', 'Email Address'),
-                        ('country', 'Country'),
-                        ('role', 'Role'),
-                        ('status', 'Account Status'),
-                        ('expire', 'Expire'),
-                        ('peers_full_name', 'Peer Full Name(s)'),
-                        ('peers_email', 'Peer Email Address(es)'),
-                        ]
+_account_field_order = [
+    ("full_name", "Full Name"),
+    ("organization", "Organization"),
+    ("email", "Email Address"),
+    ("country", "Country"),
+    ("role", "Role"),
+    ("status", "Account Status"),
+    ("expire", "Expire"),
+    ("peers_full_name", "Peer Full Name(s)"),
+    ("peers_email", "Peer Email Address(es)"),
+]
 
 
 def html_tmpl(configuration, client_id, environ, title_entry):
@@ -69,69 +79,84 @@ def html_tmpl(configuration, client_id, environ, title_entry):
     and environ.
     """
     logger = configuration.logger
-    user_msg, show_user_msg = '', 'hidden'
+    user_msg, show_user_msg = "", "hidden"
     if configuration.site_enable_user_messages:
         user_msg = html_user_messages(configuration, client_id)
-        show_user_msg = ''
+        show_user_msg = ""
     user_map = get_full_user_map(configuration)
     user_dict = user_map.get(client_id, {})
-    user_account = ''
+    user_account = ""
     if user_dict:
         # NOTE: set min days high enough to always return renew and extend_days
-        (_, _, renew_days, extend_days) = account_expire_info(configuration,
-                                                              client_id,
-                                                              environ, 999999)
-        user_account += '''
+        (_, _, renew_days, extend_days) = account_expire_info(
+            configuration, client_id, environ, 999999
+        )
+        user_account += """
         <h3>Account Details</h3>
         <p class="sub-title">Your account has the following information
         registered:
         </p>
-        '''
+        """
         show_account = {}
-        for (field, label) in _account_field_order:
-            field_hint = ''
+        for field, label in _account_field_order:
+            field_hint = ""
             if not user_dict.get(field, False):
                 continue
             show_account[field] = copy.deepcopy(user_dict[field])
-            if field == 'expire':
+            if field == "expire":
                 # NOTE: translate epoch to proper datetime string
-                expire_dt = datetime.datetime.fromtimestamp(
-                    show_account[field])
+                expire_dt = datetime.datetime.fromtimestamp(show_account[field])
                 # strip usec for user-friendly time stamp
                 show_account[field] = expire_dt.replace(microsecond=0)
                 if extend_days > 0:
                     field_hint = """(web login auto-extends access for %d days,
-and sign up for %d days at a time)""" % (extend_days, renew_days)
+and sign up for %d days at a time)""" % (
+                        extend_days,
+                        renew_days,
+                    )
                 elif renew_days > 0:
-                    field_hint = """(renewal may extend it for up to %d days
-at a time depending on site policies)""" % renew_days
-            user_account += '''%s: %s %s<br/>
-            ''' % (label, show_account[field], field_hint)
+                    field_hint = (
+                        """(renewal may extend it for up to %d days
+at a time depending on site policies)"""
+                        % renew_days
+                    )
+            user_account += """%s: %s %s<br/>
+            """ % (
+                label,
+                show_account[field],
+                field_hint,
+            )
     # NOTE: ID token is only available for openid connect
-    claim_dump, user_token = '', ''
-    for (key, val) in os.environ.items():
-        if key.startswith('OIDC_CLAIM_'):
+    claim_dump, user_token = "", ""
+    for key, val in os.environ.items():
+        if key.startswith("OIDC_CLAIM_"):
             claim_dump += "%s: %s<br/>" % (key, val)
     if claim_dump:
-        user_token = '''
+        user_token = """
         <h3>ID Token</h3>
         <p class="sub-title">Your current login session provides the following
         additional information:
-        </p>'''
+        </p>"""
         user_token += claim_dump
-    fill_helpers = {'short_title': configuration.short_title,
-                    'user_msg': user_msg,
-                    'show_user_msg': show_user_msg,
-                    'home_label': user_home_label,
-                    'user_account': user_account,
-                    'user_token': user_token}
+    fill_helpers = {
+        "short_title": configuration.short_title,
+        "user_msg": user_msg,
+        "show_user_msg": show_user_msg,
+        "home_label": user_home_label,
+        "user_account": user_account,
+        "user_token": user_token,
+    }
 
-    html = '''
+    html = (
+        """
     <!-- CONTENT -->
     <div class="container">
         <div id="account-container" class="row">
-            ''' % fill_helpers
-    html += '''
+            """
+        % fill_helpers
+    )
+    html += (
+        """
             <div id="user-account-container" class="col-12 invert-theme">
                 <div id="user-account-content" class="user-account-placeholder">
                     %(user_account)s
@@ -146,32 +171,43 @@ at a time depending on site policies)""" % renew_days
                 </p>
                 </div>
             </div>
-            ''' % fill_helpers
-    html += '''
+            """
+        % fill_helpers
+    )
+    html += (
+        """
             <div id="user-msg-container" class="col-12 invert-theme %(show_user_msg)s">
                 <div id="user-msg-content" class="user-msg-placeholder">
                     %(user_msg)s
                 </div>
             </div>
-            ''' % fill_helpers
-    html += '''
+            """
+        % fill_helpers
+    )
+    html += """
             <div class="col-lg-12 vertical-spacer"></div>
         </div>
-    '''
+    """
 
     # Account management like renew account access for local users
     # TODO: add change password and delete account support for all accounts?
     (auth_type_name, auth_flavor) = detect_client_auth(configuration, environ)
-    (auth_type, auth_label) = find_auth_type_and_label(configuration,
-                                                       auth_type_name,
-                                                       auth_flavor)
-    show_local = [i for i in configuration.site_login_methods
-                  if i.startswith('mig')]
-    fill_helpers.update({'auth_type': auth_type,
-                         'auth_type_name': auth_type_name,
-                         'auth_flavor': auth_flavor,
-                         'auth_label': auth_label})
-    html += '''
+    (auth_type, auth_label) = find_auth_type_and_label(
+        configuration, auth_type_name, auth_flavor
+    )
+    show_local = [
+        i for i in configuration.site_login_methods if i.startswith("mig")
+    ]
+    fill_helpers.update(
+        {
+            "auth_type": auth_type,
+            "auth_type_name": auth_type_name,
+            "auth_flavor": auth_flavor,
+            "auth_label": auth_label,
+        }
+    )
+    html += (
+        """
         <div id="manage-container" class="row">
             <div class="manage-page__header col-12">
                 <h2>Manage Account</h2>
@@ -180,28 +216,38 @@ at a time depending on site policies)""" % renew_days
                 below.
                 </p>
             </div>
-            ''' % fill_helpers
-    form_method = 'post'
+            """
+        % fill_helpers
+    )
+    form_method = "post"
     csrf_limit = get_csrf_limit(configuration)
-    target_op = 'accountaction'
-    csrf_token = make_csrf_token(configuration, form_method, target_op,
-                                 client_id, csrf_limit)
-    fill_helpers.update({'target_op': target_op, 'form_method':
-                         form_method, 'csrf_field': csrf_field,
-                         'csrf_token': csrf_token})
+    target_op = "accountaction"
+    csrf_token = make_csrf_token(
+        configuration, form_method, target_op, client_id, csrf_limit
+    )
+    fill_helpers.update(
+        {
+            "target_op": target_op,
+            "form_method": form_method,
+            "csrf_field": csrf_field,
+            "csrf_token": csrf_token,
+        }
+    )
     if auth_type in show_local:
-        fill_helpers['account_action'] = "RENEW_ACCESS"
-        fill_helpers['peer_acceptance_notice'] = ""
+        fill_helpers["account_action"] = "RENEW_ACCESS"
+        fill_helpers["peer_acceptance_notice"] = ""
         if configuration.site_peers_mandatory:
             peers_email = user_dict.get("peers_email", "")
             peers_list = user_dict.get("peers", [])
             search_filter = default_search()
-            search_filter['email'] = peers_email
+            search_filter["email"] = peers_email
             logger.debug("peers_email: %r" % peers_email)
-            (_, hits) = search_users(search_filter,
-                                     configuration,
-                                     default_db_path(configuration),
-                                     regex_match=['email'])
+            (_, hits) = search_users(
+                search_filter,
+                configuration,
+                default_db_path(configuration),
+                regex_match=["email"],
+            )
             possible_peers = [ent[0] for ent in hits]
             possible_peers.extend(peers_list)
             logger.debug("possible_peers: %r" % possible_peers)
@@ -209,145 +255,169 @@ at a time depending on site policies)""" % renew_days
             for verify_peer in possible_peers:
                 logger.debug("verify_peer: %r" % verify_peer)
                 try:
-                    (verified_peer_list, _) \
-                        = verify_user_peers(configuration,
-                                            default_db_path(configuration),
-                                            client_id,
-                                            user_dict,
-                                            time.time(),
-                                            verify_peer,
-                                            0,
-                                            False,
-                                            False)
+                    (verified_peer_list, _) = verify_user_peers(
+                        configuration,
+                        default_db_path(configuration),
+                        client_id,
+                        user_dict,
+                        time.time(),
+                        verify_peer,
+                        0,
+                        False,
+                        False,
+                    )
                 except Exception as err:
                     logger.warning("Failed to verify user peers: %s" % err)
                     continue
                 logger.debug("verified_peer_list: %r" % verified_peer_list)
-                valid_peers_list.extend([peer for peer in verified_peer_list
-                                         if peer not in valid_peers_list])
-            show_peers = ''
+                valid_peers_list.extend(
+                    [
+                        peer
+                        for peer in verified_peer_list
+                        if peer not in valid_peers_list
+                    ]
+                )
+            show_peers = ""
             for peer in valid_peers_list:
-                show_peers += "%s &lt;%s&gt;" \
-                    % (extract_field(peer, 'full_name'),
-                        extract_field(peer, 'email'))
+                show_peers += "%s &lt;%s&gt;" % (
+                    extract_field(peer, "full_name"),
+                    extract_field(peer, "email"),
+                )
             if show_peers:
-                fill_helpers['peer_acceptance_notice'] = """
+                fill_helpers["peer_acceptance_notice"] = (
+                    """
 Apparently %s accepted you as a peer
 and if that peer appointment has not yet ended you can renew your access here
 without further operator or peer contact involvement. Otherwise you may need to
 obtain or await explicit extension or peer assignment from someone else before
 your access renewal can proceed.
-                """ % show_peers
+                """
+                    % show_peers
+                )
             else:
-                bin_url = requested_page(os.environ).replace('-sid', '-bin')
-                if fill_helpers.get('auth_flavor', '') == AUTH_MIG_OID:
-                    fill_helpers['target_op'] \
-                        = os.path.join(os.path.dirname(bin_url),
-                                       'reqoid')
-                elif fill_helpers.get('auth_flavor', '') == AUTH_MIG_OIDC:
-                    fill_helpers['target_op'] \
-                        = os.path.join(os.path.dirname(bin_url),
-                                       'reqoidc')
+                bin_url = requested_page(os.environ).replace("-sid", "-bin")
+                if fill_helpers.get("auth_flavor", "") == AUTH_MIG_OID:
+                    fill_helpers["target_op"] = os.path.join(
+                        os.path.dirname(bin_url), "reqoid"
+                    )
+                elif fill_helpers.get("auth_flavor", "") == AUTH_MIG_OIDC:
+                    fill_helpers["target_op"] = os.path.join(
+                        os.path.dirname(bin_url), "reqoidc"
+                    )
                 elif auth_flavor == AUTH_MIG_CERT:
-                    fill_helpers['target_op'] \
-                        = os.path.join(os.path.dirname(bin_url),
-                                       'migcert')
-                fill_helpers['peer_acceptance_notice'] = """
+                    fill_helpers["target_op"] = os.path.join(
+                        os.path.dirname(bin_url), "migcert"
+                    )
+                fill_helpers[
+                    "peer_acceptance_notice"
+                ] = """
 It looks like you may need someone with authority to appoint you as their peer
 before your access renewal can be accepted.
                 """
-        fill_helpers['renew_helper'] = renew_account_access_template(
-            configuration,
-            valid_peers_list,
-            environ,
-            default_values=fill_helpers) % fill_helpers
-        html += '''
+        fill_helpers["renew_helper"] = (
+            renew_account_access_template(
+                configuration,
+                valid_peers_list,
+                environ,
+                default_values=fill_helpers,
+            )
+            % fill_helpers
+        )
+        html += (
+            """
             <div class="renew-account-access__header col-12">
                 <h3>Renew Account Access</h3>
                 %(renew_helper)s
             </div>
-        ''' % fill_helpers
+        """
+            % fill_helpers
+        )
 
-    html += '''
+    html += """
             <div class="col-lg-12 vertical-spacer"></div>
         </div>
-    '''
+    """
 
     # Show storage accounting information if enabled
 
     if configuration.site_enable_accounting:
         account_usage = get_usage(configuration, client_id)
         if account_usage is None:
-            logger.error("Failed to load acount usage for user: %r"
-                         % client_id)
+            logger.error("Failed to load acount usage for user: %r" % client_id)
             account_usage = {}
-        accounting = account_usage.get('accounting', {})
+        accounting = account_usage.get("accounting", {})
         accounting_dt = datetime.datetime.fromtimestamp(
-            account_usage.get('timestamp', 0))
-        quota = account_usage.get('quota', {})
-        fill_helpers['usage_helper'] = "<p>Updated: %s</p>" % accounting_dt
-        fill_helpers['usage_helper'] += "<p>Quota updated:<br/>"
+            account_usage.get("timestamp", 0)
+        )
+        quota = account_usage.get("quota", {})
+        fill_helpers["usage_helper"] = "<p>Updated: %s</p>" % accounting_dt
+        fill_helpers["usage_helper"] += "<p>Quota updated:<br/>"
         for backend, values in quota.items():
-            quota_dt = datetime.datetime.fromtimestamp(values.get('mtime', 0))
-            fill_helpers['usage_helper'] \
-                += "%s&nbsp;&nbsp;&nbsp;&nbsp;%s<br/>" % (quota_dt, backend)
-        fill_helpers['usage_helper'] += "</p><p>"
+            quota_dt = datetime.datetime.fromtimestamp(values.get("mtime", 0))
+            fill_helpers[
+                "usage_helper"
+            ] += "%s&nbsp;&nbsp;&nbsp;&nbsp;%s<br/>" % (quota_dt, backend)
+        fill_helpers["usage_helper"] += "</p><p>"
         accounting_report = accounting.get(client_id, {})
         if configuration.site_enable_gdp:
             # NOTE: Only show vgrid usage when in GDP mode
             #       as no data is stored in user home
-            vgrid_report = accounting_report.get('vgrid_report', '')
+            vgrid_report = accounting_report.get("vgrid_report", "")
             if vgrid_report:
-                fill_helpers['usage_helper'] \
-                    += vgrid_report.replace('\n', '<br/>')
+                fill_helpers["usage_helper"] += vgrid_report.replace(
+                    "\n", "<br/>"
+                )
         else:
-            total_report = accounting_report.get('total_report', '')
-            home_report = accounting_report.get('home_report', '')
-            freeze_report = accounting_report.get('freeze_report', '')
-            vgrid_report = accounting_report.get('vgrid_report', '')
-            ext_users_report = accounting_report.get('ext_users_report', '')
-            peers_report = accounting_report.get('peers_report', '')
+            total_report = accounting_report.get("total_report", "")
+            home_report = accounting_report.get("home_report", "")
+            freeze_report = accounting_report.get("freeze_report", "")
+            vgrid_report = accounting_report.get("vgrid_report", "")
+            ext_users_report = accounting_report.get("ext_users_report", "")
+            peers_report = accounting_report.get("peers_report", "")
             if total_report:
-                fill_helpers['usage_helper'] \
-                    += total_report.replace('\n', '<br/>') \
-                    + "<br/>"
+                fill_helpers["usage_helper"] += (
+                    total_report.replace("\n", "<br/>") + "<br/>"
+                )
             if home_report:
-                fill_helpers['usage_helper'] \
-                    += home_report.replace('\n', '<br/>') \
-                    + "<br/>"
+                fill_helpers["usage_helper"] += (
+                    home_report.replace("\n", "<br/>") + "<br/>"
+                )
             if freeze_report:
-                fill_helpers['usage_helper'] \
-                    += freeze_report.replace('\n', '<br/>') \
-                    + "<br/>"
+                fill_helpers["usage_helper"] += (
+                    freeze_report.replace("\n", "<br/>") + "<br/>"
+                )
             if vgrid_report:
-                fill_helpers['usage_helper'] \
-                    += vgrid_report.replace('\n', '<br/>') \
-                    + "<br/>"
+                fill_helpers["usage_helper"] += (
+                    vgrid_report.replace("\n", "<br/>") + "<br/>"
+                )
             if ext_users_report:
-                fill_helpers['usage_helper'] \
-                    += ext_users_report.replace('\n', '<br/>') \
-                    + "<br/>"
+                fill_helpers["usage_helper"] += (
+                    ext_users_report.replace("\n", "<br/>") + "<br/>"
+                )
             if peers_report:
-                fill_helpers['usage_helper'] \
-                    += peers_report.replace('\n', '<br/>') \
-                    + "<br/>"
-        fill_helpers['usage_helper'] += "</p>"
+                fill_helpers["usage_helper"] += (
+                    peers_report.replace("\n", "<br/>") + "<br/>"
+                )
+        fill_helpers["usage_helper"] += "</p>"
 
-        html += '''
+        html += """
         <div id="usage-container" class="row">
             <div class="usage-page__header col-12">
                 <h2>Account Usage</h2>
-       '''
-        html += '''
+       """
+        html += (
+            """
                 %(usage_helper)s
             </div>
             <div class="col-lg-12 vertical-spacer"></div>
-            ''' % fill_helpers
+            """
+            % fill_helpers
+        )
 
-    html += '''
+    html += """
         </div>
     </div>
-    '''
+    """
 
     return html
 
@@ -356,7 +426,7 @@ def signature():
     """Signature of the main function"""
 
     defaults = {}
-    return ['text', defaults]
+    return ["text", defaults]
 
 
 def main(client_id, user_arguments_dict, environ=None):
@@ -365,9 +435,9 @@ def main(client_id, user_arguments_dict, environ=None):
     if environ is None:
         environ = os.environ
 
-    (configuration, logger, output_objects, op_name) = \
-        initialize_main_variables(client_id, op_header=False,
-                                  op_menu=client_id)
+    (configuration, logger, output_objects, op_name) = (
+        initialize_main_variables(client_id, op_header=False, op_menu=client_id)
+    )
     defaults = signature()[1]
     (validate_status, accepted) = validate_input_and_cert(
         user_arguments_dict,
@@ -381,22 +451,22 @@ def main(client_id, user_arguments_dict, environ=None):
         return (accepted, returnvalues.CLIENT_ERROR)
 
     # Generate and insert the page HTML
-    title_entry = find_entry(output_objects, 'title')
-    title_entry['text'] = '%s Profile' % configuration.short_title
+    title_entry = find_entry(output_objects, "title")
+    title_entry["text"] = "%s Profile" % configuration.short_title
 
     # jquery support for AJAX saving
 
     (add_import, add_init, add_ready) = man_base_js(configuration, [])
-    add_init += '''
-    '''
-    add_ready += '''
+    add_init += """
+    """
+    add_ready += """
                 init_user_msg();
-    '''
-    title_entry['script']['advanced'] += add_import
-    title_entry['script']['init'] += add_init
-    title_entry['script']['ready'] += add_ready
+    """
+    title_entry["script"]["advanced"] += add_import
+    title_entry["script"]["init"] += add_init
+    title_entry["script"]["ready"] += add_ready
 
     html = html_tmpl(configuration, client_id, environ, title_entry)
-    output_objects.append({'object_type': 'html_form', 'text': html})
+    output_objects.append({"object_type": "html_form", "text": html})
 
     return (output_objects, returnvalues.OK)

--- a/mig/shared/functionality/account.py
+++ b/mig/shared/functionality/account.py
@@ -238,6 +238,7 @@ at a time depending on site policies)"""
                 "csrf_token": csrf_token,
             }
         )
+        valid_peers_list = []
         show_peers = ""
         fill_helpers["account_action"] = "RENEW_ACCESS"
         fill_helpers["peer_acceptance_notice"] = ""
@@ -256,7 +257,6 @@ at a time depending on site policies)"""
             possible_peers = [ent[0] for ent in hits]
             possible_peers.extend(peers_list)
             logger.debug("possible_peers: %r" % possible_peers)
-            valid_peers_list = []
             for verify_peer in possible_peers:
                 logger.debug("verify_peer: %r" % verify_peer)
                 try:

--- a/mig/shared/functionality/account.py
+++ b/mig/shared/functionality/account.py
@@ -197,17 +197,17 @@ at a time depending on site policies)""" % renew_days
             peers_list = user_dict.get("peers", [])
             search_filter = default_search()
             search_filter['email'] = peers_email
-            configuration.logger.info("peers_email: %r" % peers_email)
+            logger.debug("peers_email: %r" % peers_email)
             (_, hits) = search_users(search_filter,
                                      configuration,
                                      default_db_path(configuration),
                                      regex_match=['email'])
             possible_peers = [ent[0] for ent in hits]
             possible_peers.extend(peers_list)
-            configuration.logger.info("possible_peers: %r" % possible_peers)
+            logger.debug("possible_peers: %r" % possible_peers)
             valid_peers_list = []
             for verify_peer in possible_peers:
-                configuration.logger.info("verify_peer: %r" % verify_peer)
+                logger.debug("verify_peer: %r" % verify_peer)
                 try:
                     (verified_peer_list, _) \
                         = verify_user_peers(configuration,
@@ -222,8 +222,7 @@ at a time depending on site policies)""" % renew_days
                 except Exception as err:
                     logger.warning("Failed to verify user peers: %s" % err)
                     continue
-                logger.info("verified_peer_list: %r"
-                            % verified_peer_list)
+                logger.debug("verified_peer_list: %r" % verified_peer_list)
                 valid_peers_list.extend([peer for peer in verified_peer_list
                                          if peer not in valid_peers_list])
             show_peers = ''

--- a/mig/shared/functionality/accountaction.py
+++ b/mig/shared/functionality/accountaction.py
@@ -158,8 +158,8 @@ Renewed account:
                                        _logger,
                                        configuration)
             if not notify_status:
-                _logger.error("Failed to send account renew notification to %s"
-                              % recipient)
+                _logger.error("Failed to send account renew notification" \
+                              + " to peer %s" % recipient)
     return (renew_status, renew_err)
 
 

--- a/mig/shared/functionality/accountaction.py
+++ b/mig/shared/functionality/accountaction.py
@@ -110,25 +110,31 @@ def renew_access(configuration, client_id, user_dict, auth_flavor):
     # Notify user and peer(s) that account was renewed
 
     if renew_status:
-        new_expire_dt \
-            = datetime.datetime.fromtimestamp(user_dict.get('expire', 0))
-        email_subject = '%s account renewed for %s' \
-            % (configuration.short_title, user_dict.get('full_name', ''))
-        email_msg_template = "Renewed account:\n" \
-            + " * Full Name: %s\n" \
-            % user_dict.get('full_name', '') \
-            + " * Organization: %s\n" \
-            % user_dict.get('organization', '') \
-            + " * State: %s\n" \
-            % user_dict.get('state', '') \
-            + " * Country: %s\n" \
-            % user_dict.get('country', '') \
-            + " * Email: %s\n" \
-            % user_dict.get('email', '') \
-            + " * New Expire: %s\n" \
-            % new_expire_dt
-        email_header = "Your %s user account was renewed\n\n" \
-            % configuration.short_title
+        expire_dt = datetime.datetime.fromtimestamp(user_dict.get('expire', 0))
+        email_fill_helper = {'title': configuration.short_title,
+                          'full_name': '',
+                          'organization': '',
+                          'state': '',
+                          'country': '',
+                          'email': '',
+                          'expire_dt': expire_dt,
+                          }
+        for key in ['full_name', 'organization', 'state', 'country', 'email']:
+            if key in user_dict:
+                email_fill_helper[key] = user_dict[key]
+        email_subject = "%(title)s account renewed for %(full_name)s" \
+            % email_fill_helper
+        email_msg_template = '''
+Renewed account:
+ * Full Name: %(full_name)s
+ * Organization: %(organization)s
+ * State: %(state)s
+ * Country: %(country)s
+ * Email: %(email)s
+ * New Expire: %(expire_dt)s
+ ''' % email_fill_helper
+        email_header = "Your %(title)s user account was renewed\n" \
+            % email_fill_helper
         email_msg = email_header + email_msg_template
         recipient = user_dict.get('email', '')
         # Notify user

--- a/mig/shared/functionality/accountaction.py
+++ b/mig/shared/functionality/accountaction.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # accountaction - handle account actions like change pw and renew access
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -31,9 +31,10 @@ from __future__ import absolute_import
 
 import os
 import time
+import datetime
 
 from mig.shared import returnvalues
-from mig.shared.base import is_gdp_user
+from mig.shared.base import extract_field, is_gdp_user
 from mig.shared.defaults import keyword_auto, AUTH_MIG_CERT, AUTH_MIG_OID, \
     AUTH_MIG_OIDC
 from mig.shared.functional import validate_input, REJECT_UNSET
@@ -45,6 +46,7 @@ from mig.shared.handlers import safe_handler, get_csrf_limit
 from mig.shared.htmlgen import themed_styles, themed_scripts
 from mig.shared.httpsclient import detect_client_auth, find_auth_type_and_label
 from mig.shared.init import initialize_main_variables
+from mig.shared.notification import send_email
 from mig.shared.userdb import default_db_path
 from mig.shared.useradm import default_search, search_users, create_user
 
@@ -105,7 +107,53 @@ def renew_access(configuration, client_id, user_dict, auth_flavor):
     except Exception as exc:
         _logger.warning("Error renewing user %r: %s" % (client_id, exc))
 
-    # TODO: send email on renew?
+    # Notify user and peer(s) that account was renewed
+
+    if renew_status:
+        new_expire_dt \
+            = datetime.datetime.fromtimestamp(user_dict.get('expire', 0))
+        email_subject = '%s account renewed for %s' \
+            % (configuration.short_title, user_dict.get('full_name', ''))
+        email_msg_template = "Renewed account:\n" \
+            + " * Full Name: %s\n" \
+            % user_dict.get('full_name', '') \
+            + " * Organization: %s\n" \
+            % user_dict.get('organization', '') \
+            + " * State: %s\n" \
+            % user_dict.get('state', '') \
+            + " * Country: %s\n" \
+            % user_dict.get('country', '') \
+            + " * Email: %s\n" \
+            % user_dict.get('email', '') \
+            + " * New Expire: %s\n" \
+            % new_expire_dt
+        email_header = "Your %s user account was renewed\n\n" \
+            % configuration.short_title
+        email_msg = email_header + email_msg_template
+        recipient = user_dict.get('email', '')
+        # Notify user
+        notify_status = send_email(recipient,
+                                   email_subject,
+                                   email_msg,
+                                   _logger,
+                                   configuration)
+        if not notify_status:
+            _logger.error("Failed to send account renew notification to %s"
+                          % recipient)
+        # Notify peers
+        for peer in user_dict.get('peers', []):
+            recipient = extract_field(peer, 'email')
+            email_header = "Your %s external peer made an account renewal\n\n" \
+                % configuration.short_title
+            email_msg = email_header + email_msg_template
+            notify_status = send_email(recipient,
+                                       email_subject,
+                                       email_msg,
+                                       _logger,
+                                       configuration)
+            if not notify_status:
+                _logger.error("Failed to send account renew notification to %s"
+                              % recipient)
     return (renew_status, renew_err)
 
 
@@ -245,7 +293,7 @@ CSRF-filtered POST requests to prevent unintended updates'''
 <div class="vertical-spacer"></div>
 <div class="error leftpad errortext">
 '''})
-        output_objects.append({'object_type': 'text', 'text': """
+        output_objects.append({'object_type': 'error_text', 'text': """
 Invalid input or rate limit exceeded - please wait %d seconds before retrying.
 """ % delay_retry
                                })

--- a/mig/shared/functionality/accountaction.py
+++ b/mig/shared/functionality/accountaction.py
@@ -71,7 +71,10 @@ def renew_access(configuration, client_id, user_dict, auth_flavor):
     """Helper to actually renew access for the RENEW_ACCESS requests."""
     _logger = configuration.logger
     renew_status, renew_err = False, 'Not fully implemented yet'
-    peer_pattern = keyword_auto
+    if configuration.site_peers_mandatory:
+        peer_pattern = keyword_auto
+    else:
+        peer_pattern = None
     db_path = default_db_path(configuration)
     old_expire = user_dict.get('expire', -1)
     if auth_flavor == AUTH_MIG_CERT:

--- a/mig/shared/functionality/gdpman.py
+++ b/mig/shared/functionality/gdpman.py
@@ -35,9 +35,11 @@ import os
 from mig.shared import returnvalues
 from mig.shared.auth import get_twofactor_secrets
 from mig.shared.base import get_xgi_bin, requested_page
-from mig.shared.defaults import csrf_field
+from mig.shared.defaults import csrf_field, AUTH_MIG_OID, AUTH_MIG_OIDC, \
+    AUTH_MIG_CERT
 from mig.shared.fileio import write_named_tempfile
 from mig.shared.functional import validate_input_and_cert
+from mig.shared.functionality.account import html_tmpl as account_html_tmpl
 from mig.shared.gdp.all import ensure_gdp_user, get_projects, get_users, \
     get_active_project_client_id, get_short_id_from_user_id, \
     project_accept_user, project_create, project_remove, \
@@ -53,6 +55,7 @@ from mig.shared.settings import load_twofactor, parse_and_save_twofactor
 from mig.shared.twofactorkeywords import get_keywords_dict as twofactor_keywords
 from mig.shared.useradm import get_full_user_map
 from mig.shared.vgrid import vgrid_create_allowed, vgrid_manage_allowed
+from mig.shared.httpsclient import detect_client_auth
 
 
 def signature():
@@ -139,7 +142,8 @@ def html_tmpl(
         action,
         client_id,
         csrf_token,
-        status_msg):
+        status_msg,
+        environ):
     """HTML main template for GDP manager"""
 
     fill_entries = {'csrf_field': csrf_field,
@@ -286,6 +290,8 @@ def html_tmpl(
             preselected_tab = tab_count
         tab_count += 1
     if twofactor_enabled:
+        html += """<li><a href='#account_tab'>Account</a></li>"""
+        tab_count += 1
         html += """<li><a href='#logout_tab'>Logout</a></li>"""
         tab_count += 1
 
@@ -971,6 +977,9 @@ def html_tmpl(
     setOTPProgress(['otp_intro', 'otp_install', 'otp_import', 'otp_verify',
                     'otp_ready']);
 </script>
+    <div id='account_tab'>
+        %(account_helper)s
+    </div>
     <div id='logout_tab'>
     <table class='gm_projects_table' style='border-spacing=0;'>
     <thead>
@@ -1004,6 +1013,10 @@ def html_tmpl(
 """
     fill_helpers.update({
         'client_id': client_id,
+        'account_helper': account_html_tmpl(configuration,
+                                            client_id,
+                                            environ,
+                                            {}),
     })
 
     fill_entries.update(fill_helpers)
@@ -1012,15 +1025,29 @@ def html_tmpl(
     return html
 
 
-def js_tmpl_parts(configuration, csrf_token):
+def js_tmpl_parts(configuration, csrf_tokens, environ):
     """Javascript parts to include in the page header"""
-
     (tfa_import, tfa_init, tfa_ready) = twofactor_wizard_js(configuration)
-    fill_entries = {'csrf_field': csrf_field,
-                    'csrf_token': csrf_token,
-                    'tfa_init': tfa_init,
-                    'tfa_ready': tfa_ready,
-                    }
+    # Resolve account request url based on auth flavor
+    (_, auth_flavor) = detect_client_auth(configuration, environ)
+    bin_url = requested_page(os.environ).replace('-sid', '-bin')
+    if auth_flavor == AUTH_MIG_OID:
+        request_account_url = os.path.join(os.path.dirname(bin_url),
+                                           'reqoid.py')
+    elif auth_flavor == AUTH_MIG_OIDC:
+        request_account_url = os.path.join(os.path.dirname(bin_url),
+                                           'reqoidc.py')
+    elif auth_flavor == AUTH_MIG_CERT:
+        request_account_url = os.path.join(os.path.dirname(bin_url),
+                                           'migcert.py')
+    fill_entries = {
+        'csrf_field': csrf_field,
+        'csrf_token_gdpman': csrf_tokens.get('gdpman', ''),
+        'csrf_token_accountaction': csrf_tokens.get('accountaction', ''),
+        'tfa_init': tfa_init,
+        'tfa_ready': tfa_ready,
+        'request_account_url': request_account_url,
+    }
     js_import = ''
     js_import += '<script type="text/javascript" src="/images/js/jquery.prettyprint.js"></script>'
     js_import += '<script type="text/javascript" src="/images/js/jquery.ajaxhelpers.js"></script>'
@@ -1028,7 +1055,9 @@ def js_tmpl_parts(configuration, csrf_token):
     # TODO: move this code to stand-alone js file
     js_init = """
     var csrf_field = '%(csrf_field)s';
-    var csrf_map = {'gdpman': '%(csrf_token)s'};
+    var csrf_map = {'gdpman': '%(csrf_token_gdpman)s',
+                    'accountaction': '%(csrf_token_accountaction)s'};
+    var request_account_url = '%(request_account_url)s';
     var preselected_tab = 0;
     var category_map = {};
 
@@ -1338,6 +1367,13 @@ def js_tmpl_parts(configuration, csrf_token):
             if (!handleStaticFields(project_action, '', '', '')) return false;
             $('#gm_project_submit_form').submit();
         }
+        else if (project_action == 'request_account') {
+            window.open(request_account_url, '_blank');
+        }
+        else if (project_action == 'renew_account_access') {
+            if (!handleStaticFields(project_action, '', '', '')) return false;
+            ajax_renew_account_access(showRenewAccountAccessDialog);
+        }
     }
     function showProjectInfoDialog(project_name, project_info) {
         var html = '';
@@ -1432,7 +1468,6 @@ def js_tmpl_parts(configuration, csrf_token):
         $('#info_dialog').html('<p>'+html+'</p>');
         $('#info_dialog').dialog('open');
     }
-
     function showRemoveDialog(project_action) {
         var project_name = extractProject(project_action);
         var title = 'Remove Project ' + project_name;
@@ -1444,7 +1479,30 @@ def js_tmpl_parts(configuration, csrf_token):
         $('#remove_dialog').html('<p>'+html+'</p>');
         $('#remove_dialog').dialog('open');
     }
-
+    function showRenewAccountAccessDialog(result) {
+        var html = '';
+        var body = '';
+        if (result.OK.length > 0) {
+            for (var i=0; i<result.OK.length; i++) {
+                html += '<p>'+result.OK[i]+'</p>';
+            }
+        }
+        if (result.ERROR.length > 0) {
+            for (var i=0; i<result.ERROR.length; i++) {
+                html += '<p class=\"errortext\">' +
+                        'Error: '+result.ERROR[i]+'</p>';
+            }
+        }
+        if (result.WARNING.length > 0) {
+            for (var i=0; i<result.WARNING.length; i++) {
+                html += '<p class=\"warningtext\">' +
+                        'Warning: '+ result.WARNING[i]+'</p>';
+            }
+        }
+        $('#info_dialog').dialog('option', 'title', 'Renew Account Access');
+        $('#info_dialog').html('<p>'+html+'</p>');
+        $('#info_dialog').dialog('open');
+    }
     function showProjectInfo() {
         var project_name = extractProject('project_info');
         if (project_name === null) {
@@ -1514,8 +1572,13 @@ def main(client_id, user_arguments_dict, environ=None):
     client_addr = environ.get('REMOTE_ADDR', None)
     req_url = environ.get('SCRIPT_URI', None)
     csrf_limit = get_csrf_limit(configuration)
-    csrf_token = make_csrf_token(configuration, 'post', op_name,
-                                 client_id, csrf_limit)
+    csrf_tokens = {}
+    for operation in [op_name, 'accountaction']:
+        csrf_tokens[operation] = make_csrf_token(configuration,
+                                                 'post',
+                                                 operation,
+                                                 client_id,
+                                                 csrf_limit)
     defaults = signature()[1]
     (validate_status, accepted) = validate_input_and_cert(
         user_arguments_dict,
@@ -1553,7 +1616,8 @@ def main(client_id, user_arguments_dict, environ=None):
         title_entry = find_entry(output_objects, 'title')
         title_entry['text'] = title_text
         add_import, add_init, add_ready = js_tmpl_parts(configuration,
-                                                        csrf_token)
+                                                        csrf_tokens,
+                                                        environ)
         title_entry['script']['advanced'] = add_import
         title_entry['script']['init'] = add_init
         title_entry['script']['ready'] = add_ready
@@ -1655,7 +1719,7 @@ Please contact the site admins %s if you think it should be enabled.
                                client_id,
                                autologout=True)
             return_url = req_url.replace(environ.get('SCRIPT_URL', ''),
-                                     configuration.site_autolaunch_page)
+                                         configuration.site_autolaunch_page)
             redirect_url = build_autologout_url(configuration,
                                                 environ,
                                                 client_id,
@@ -2037,8 +2101,12 @@ Please contact the site admins %s if you think it should be enabled.
             action_msg = validate_msg
 
         if output_format != 'json':
-            html = html_tmpl(configuration, action, client_id, csrf_token,
-                             action_msg)
+            html = html_tmpl(configuration,
+                             action,
+                             client_id,
+                             csrf_tokens.get(op_name, ''),
+                             action_msg,
+                             environ)
             output_objects.append({'object_type': 'html_form',
                                    'text': html})
 

--- a/mig/shared/functionality/gdpman.py
+++ b/mig/shared/functionality/gdpman.py
@@ -1040,7 +1040,7 @@ def js_tmpl_parts(configuration, csrf_tokens, environ):
                                            'reqoidc.py')
     elif auth_flavor == AUTH_MIG_CERT:
         request_account_url = os.path.join(os.path.dirname(bin_url),
-                                           'migcert.py')
+                                           'reqcert.py')
     fill_entries = {
         'csrf_field': csrf_field,
         'csrf_token_gdpman': csrf_tokens.get('gdpman', ''),

--- a/mig/shared/functionality/gdpman.py
+++ b/mig/shared/functionality/gdpman.py
@@ -1029,6 +1029,7 @@ def js_tmpl_parts(configuration, csrf_tokens, environ):
     """Javascript parts to include in the page header"""
     (tfa_import, tfa_init, tfa_ready) = twofactor_wizard_js(configuration)
     # Resolve account request url based on auth flavor
+    request_account_url = ""
     (_, auth_flavor) = detect_client_auth(configuration, environ)
     bin_url = requested_page(os.environ).replace('-sid', '-bin')
     if auth_flavor == AUTH_MIG_OID:

--- a/mig/shared/functionality/gdpman.py
+++ b/mig/shared/functionality/gdpman.py
@@ -1031,7 +1031,7 @@ def js_tmpl_parts(configuration, csrf_tokens, environ):
     # Resolve account request url based on auth flavor
     request_account_url = ""
     (_, auth_flavor) = detect_client_auth(configuration, environ)
-    bin_url = requested_page(os.environ).replace('-sid', '-bin')
+    bin_url = requested_page(environ).replace('-sid', '-bin')
     if auth_flavor == AUTH_MIG_OID:
         request_account_url = os.path.join(os.path.dirname(bin_url),
                                            'reqoid.py')

--- a/mig/shared/functionality/gdpman.py
+++ b/mig/shared/functionality/gdpman.py
@@ -1041,10 +1041,13 @@ def js_tmpl_parts(configuration, csrf_tokens, environ):
     elif auth_flavor == AUTH_MIG_CERT:
         request_account_url = os.path.join(os.path.dirname(bin_url),
                                            'reqcert.py')
+    csrf_map = "{"
+    for key, value in csrf_tokens.items():
+        csrf_map += "\n'%s': '%s'," % (key, value)
+    csrf_map += "}"
     fill_entries = {
         'csrf_field': csrf_field,
-        'csrf_token_gdpman': csrf_tokens.get('gdpman', ''),
-        'csrf_token_accountaction': csrf_tokens.get('accountaction', ''),
+        'csrf_map': csrf_map,
         'tfa_init': tfa_init,
         'tfa_ready': tfa_ready,
         'request_account_url': request_account_url,
@@ -1056,8 +1059,7 @@ def js_tmpl_parts(configuration, csrf_tokens, environ):
     # TODO: move this code to stand-alone js file
     js_init = """
     var csrf_field = '%(csrf_field)s';
-    var csrf_map = {'gdpman': '%(csrf_token_gdpman)s',
-                    'accountaction': '%(csrf_token_accountaction)s'};
+    var csrf_map = %(csrf_map)s;
     var request_account_url = '%(request_account_url)s';
     var preselected_tab = 0;
     var category_map = {};

--- a/mig/shared/gdp/base.py
+++ b/mig/shared/gdp/base.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # base - gdp base helper functions related to GDP actions
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #

--- a/mig/shared/gdp/base.py
+++ b/mig/shared/gdp/base.py
@@ -93,6 +93,7 @@ skip_client_id_rewrite = [
     'vgridman.py',
     'viewvgrid.py',
     'rmvgridowner.py',
+    'accountaction.py',
 ]
 
 valid_log_actions = [


### PR DESCRIPTION
1) The `account` page is modified to check for valid peers. If valid peers are found then `Renew Account Access` is offered. Otherwise `Request Account Access` (prefilled signup page for the used auth flavor) is offered. This eliminates `account renewal` attempts which are bound to fail.

2) Users and peers are now notified by email upon successful account renewal.

3) Addresses issue #241 by:
* Adding support for `Account` page/tab on the GDP front page
* Adding support for account renewal / account request when in GDP mode
