### PR TITLE
Include unit tests and their support files in py code list for codegrep inclusion

### DIFF
--- a/mig/shared/projcode.py
+++ b/mig/shared/projcode.py
@@ -38,6 +38,8 @@ py_code_files = [
     "../%s" % PLAIN,
     "../bin/%s" % PLAIN,
     "../sbin/%s" % PLAIN,
+    "../tests/%s" % PLAIN,
+    "../tests/support/%s" % PLAIN,
     "%s" % PLAIN,
     "lib/%s" % PLAIN,
     "cgi-bin/%s" % PLAIN,


### PR DESCRIPTION
Trivial: include `tests/` and `tests/support/` files in `py_code_files` so that they can e.g. easily be searched with `codegrep.py`.