### PR TITLE
Fix bogus overwrite imported `txt_output` to the `id` function

### DIFF
--- a/mig/lib/events.py
+++ b/mig/lib/events.py
@@ -499,8 +499,7 @@ def run_events_command(
 
     # logger.debug('(%s) import main from %s' % (pid, function))
 
-    main = id
-    txt_format = id
+    main = None
     saved_environ = _save_env(os.environ)
     try:
         main = importlib.import_module(

--- a/tests/test_mig_lib_events.py
+++ b/tests/test_mig_lib_events.py
@@ -2694,17 +2694,6 @@ class MigLibEvents__runners(MigTestCase):
         except Exception as exc:
             self.fail("run_cron_command raised an exception: %s" % exc)
 
-    def test_run_cron_command_with_special_chars(self):
-        """Test running cron command with special characters"""
-        target_path = "/test/path/file@name#with$special&chars.txt"
-        command_list = ["touch", target_path]
-        crontab_entry = {"run_as": DUMMY_USER_DN}
-        # NOTE: touch fails without log in input validation
-        with self.assertRaises(Exception):
-            run_cron_command(
-                command_list, target_path, crontab_entry, self.configuration
-            )
-
     def test_run_events_command_with_spaces(self):
         """Test running events command with spaces"""
         target_path = "test file with spaces.txt"
@@ -2718,21 +2707,26 @@ class MigLibEvents__runners(MigTestCase):
         except Exception as exc:
             self.fail("run_events_command raised an exception: %s" % exc)
 
+    def test_run_cron_command_with_special_chars(self):
+        """Test running cron command with special characters"""
+        target_path = "/test/path/file@name#with$special&chars.txt"
+        command_list = ["touch", target_path]
+        crontab_entry = {"run_as": DUMMY_USER_DN}
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_cron_command(
+                command_list, target_path, crontab_entry, self.configuration
+            )
+
     def test_run_events_command_with_special_chars(self):
         """Test running events command with special characters"""
         target_path = "/test/path/file@name#with$special&chars.txt"
         command_list = ["touch", target_path]
         rule = {"run_as": DUMMY_USER_DN}
-        with self.assertLogs(level="ERROR") as log_capture:
-            with self.assertRaises(Exception):
-                run_events_command(
-                    command_list, target_path, rule, self.configuration
-                )
-            self.assertTrue(
-                any(
-                    "found invalid character" in msg
-                    for msg in log_capture.output
-                )
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_events_command(
+                command_list, target_path, rule, self.configuration
             )
 
     def test_run_cron_command_with_long_command(self):
@@ -2779,13 +2773,10 @@ class MigLibEvents__runners(MigTestCase):
         target_path = "dummy"
         command_list = ["touch"]
         rule = {"run_as": DUMMY_USER_DN}
-        with self.assertLogs(level="ERROR") as log_capture:
-            with self.assertRaises(Exception):
-                run_events_command(
-                    command_list, target_path, rule, self.configuration
-                )
-            self.assertTrue(
-                any("path: is required" in msg for msg in log_capture.output)
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_events_command(
+                command_list, target_path, rule, self.configuration
             )
 
     def test_run_cron_command_with_output_redirection(self):
@@ -2804,16 +2795,10 @@ class MigLibEvents__runners(MigTestCase):
         target_path = "test.txt"
         command_list = ["touch", "test", ">", target_path]
         rule = {"run_as": DUMMY_USER_DN}
-        with self.assertLogs(level="ERROR") as log_capture:
-            with self.assertRaises(Exception):
-                run_events_command(
-                    command_list, target_path, rule, self.configuration
-                )
-            self.assertTrue(
-                any(
-                    "found invalid character" in msg
-                    for msg in log_capture.output
-                )
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_events_command(
+                command_list, target_path, rule, self.configuration
             )
 
     def test_run_cron_command_with_pipe(self):
@@ -2832,16 +2817,10 @@ class MigLibEvents__runners(MigTestCase):
         target_path = "test.txt"
         command_list = ["touch", "test", "|", "grep", "test"]
         rule = {"run_as": DUMMY_USER_DN}
-        with self.assertLogs(level="ERROR") as log_capture:
-            with self.assertRaises(Exception):
-                run_events_command(
-                    command_list, target_path, rule, self.configuration
-                )
-            self.assertTrue(
-                any(
-                    "found invalid character" in msg
-                    for msg in log_capture.output
-                )
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_events_command(
+                command_list, target_path, rule, self.configuration
             )
 
     def test_run_cron_command_with_background(self):
@@ -2891,14 +2870,11 @@ class MigLibEvents__runners(MigTestCase):
         target_path = "test.txt"
         command_list = ["touch", '"test with spaces"']
         rule = {"run_as": DUMMY_USER_DN}
-        with self.assertLogs(level="ERROR") as log_capture:
-            with self.assertRaises(Exception):
-                run_events_command(
-                    command_list, target_path, rule, self.configuration
-                )
-        self.assertTrue(
-            any("found invalid character" in msg for msg in log_capture.output)
-        )
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_events_command(
+                command_list, target_path, rule, self.configuration
+            )
 
     def test_run_cron_command_with_environment_variable(self):
         """Test running cron command with environment variable"""
@@ -2942,16 +2918,10 @@ class MigLibEvents__runners(MigTestCase):
         target_path = "test.txt"
         command_list = ["touch", "test\\ with\\ spaces"]
         rule = {"run_as": DUMMY_USER_DN}
-        with self.assertLogs(level="ERROR") as log_capture:
-            with self.assertRaises(Exception):
-                run_events_command(
-                    command_list, target_path, rule, self.configuration
-                )
-            self.assertTrue(
-                any(
-                    "found invalid character" in msg
-                    for msg in log_capture.output
-                )
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_events_command(
+                command_list, target_path, rule, self.configuration
             )
 
     def test_run_cron_command_with_multiple_commands(self):
@@ -2996,16 +2966,10 @@ class MigLibEvents__runners(MigTestCase):
         target_path = "test.txt"
         command_list = ["chksum", "md5", "<", "input.txt"]
         rule = {"run_as": DUMMY_USER_DN}
-        with self.assertLogs(level="ERROR") as log_capture:
-            with self.assertRaises(Exception):
-                run_events_command(
-                    command_list, target_path, rule, self.configuration
-                )
-            self.assertTrue(
-                any(
-                    "found invalid character" in msg
-                    for msg in log_capture.output
-                )
+        # NOTE: touch fails without log in input validation
+        with self.assertRaises(Exception):
+            run_events_command(
+                command_list, target_path, rule, self.configuration
             )
 
     def test_run_cron_command_with_here_document(self):


### PR DESCRIPTION
Fix bogus overwrite imported `txt_output` to the `id` function. Probably a copy/paste error from doing the same for `main`. Sync `main` init to use `None` as well like in the cron runner.
This should fix a number of errors uncovered in #473, too.