### PR TITLE
Restrict python stylecheck action to explicit read-only access to repo

### DIFF
--- a/.github/workflows/python-stylecheck.yml
+++ b/.github/workflows/python-stylecheck.yml
@@ -3,6 +3,7 @@
 
 name: Python Style Checks
 
+# No need for more than read permission
 permissions:
   contents: read
 

--- a/.github/workflows/python-stylecheck.yml
+++ b/.github/workflows/python-stylecheck.yml
@@ -3,6 +3,9 @@
 
 name: Python Style Checks
 
+permissions:
+  contents: read
+
 on:
   # Triggers the workflow on push or pull request events but only for this git branch
   push:


### PR DESCRIPTION
Restrict python stylecheck action to explicit read-only access to repo as recommended by code scanner.
NB: this is already the repo default setting.