### PR TITLE
Restrict c-ext sanity check action to explicit read-only access

### DIFF
--- a/.github/workflows/python-c-ext-sanity-check.yml
+++ b/.github/workflows/python-c-ext-sanity-check.yml
@@ -5,6 +5,9 @@
 
 name: Python C-Extension Sanity Checks
 
+permissions:
+  contents: read
+
 # Ignore the following paths
 # Format: PATH1|PATH2|PATH3
 env:

--- a/.github/workflows/python-c-ext-sanity-check.yml
+++ b/.github/workflows/python-c-ext-sanity-check.yml
@@ -5,6 +5,7 @@
 
 name: Python C-Extension Sanity Checks
 
+# No need for more than read permission
 permissions:
   contents: read
 
@@ -70,9 +71,6 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-permissions:
-  contents: read
 
 jobs:
   lint-c-ext-python3-latest:


### PR DESCRIPTION
Restrict c-ext sanity check action to explicit read-only access to repo as recommended by code scanner.
NB: this is already the repo default setting and just clarified here.