### PR TITLE
Restrict python sanity check action to explicit read-only access

### DIFF
--- a/.github/workflows/python-sanity-check.yml
+++ b/.github/workflows/python-sanity-check.yml
@@ -5,6 +5,9 @@
 
 name: Python Sanity Checks
 
+permissions:
+  contents: read
+
 on:
   # Triggers the workflow on push or pull request events but only for this git branch
   push:

--- a/.github/workflows/python-sanity-check.yml
+++ b/.github/workflows/python-sanity-check.yml
@@ -5,6 +5,7 @@
 
 name: Python Sanity Checks
 
+# No need for more than read permission
 permissions:
   contents: read
 
@@ -61,9 +62,6 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-permissions:
-  contents: read
 
 jobs:
   lint-python3-latest:


### PR DESCRIPTION
Restrict python sanity check action to explicit read-only access to repo as recommended by code scanner.
NB: this is already the repo default setting and just clarified here.