### PR TITLE
Restrict CI action to explicit read-only access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@
 
 name: Continuous Integration
 
+# No need for more than read permission
+permissions:
+  contents: read
+
 on:
   # Triggers the workflow on push or pull request events but only for this git branch
   push:
@@ -56,9 +60,6 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-permissions:
-  contents: read
 
 jobs:
   # NOTE: We rely on containers for everything to get version consistency


### PR DESCRIPTION
Restrict CI check action to explicit read-only access to repo as recommended by code scanner.
NB: this is already the repo default setting and just clarified here.