### PR TITLE
Bind interactive job vncsession to specific service interface

### DIFF
--- a/mig/shared/functionality/vncsession.py
+++ b/mig/shared/functionality/vncsession.py
@@ -3,7 +3,7 @@
 #
 # --- BEGIN_HEADER ---
 #
-# vncsession - Start a new VNC session
+# vncsession - Start a new VNC session for interactive jobs
 # Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
@@ -25,7 +25,7 @@
 # -- END_HEADER ---
 #
 
-"""Start a new vnc session"""
+"""Start a new vnc session for interactive jobs"""
 
 from __future__ import absolute_import
 
@@ -78,6 +78,11 @@ def main(client_id, user_arguments_dict):
     height = accepted['height'][-1]
     depth = accepted['depth'][-1]
     desktopname = accepted['desktopname'][-1]
+
+    if not configuration.site_enable_jobs:
+        output_objects.append({'object_type': 'error_text', 'text':
+                               '''Job execution is not enabled on this system'''})
+        return (output_objects, returnvalues.SYSTEM_ERROR)
 
     # Please note that base_dir must end in slash to avoid access to other
     # user dirs when own name is a prefix of another user name

--- a/mig/shared/functionality/vncsession.py
+++ b/mig/shared/functionality/vncsession.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # vncsession - Start a new VNC session
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -172,15 +172,15 @@ def main(client_id, user_arguments_dict):
         for i in range(start_display, VNC_port_count + start_display):
             free_display_found = False
             try:
-                S = socket.socket()
-                S.bind(('', baseVNCport + i))
+                vnc_sock = socket.socket()
+                vnc_sock.bind((configuration.server_fqdn, baseVNCport + i))
                 display_number = i
                 vnc_port = baseVNCport + display_number
                 free_display_found = True
             except Exception as exc:
                 error = exc
-            S.close()
-            S = None
+            vnc_sock.close()
+            vnc_sock = None
 
             if free_display_found:
 


### PR DESCRIPTION
Bind vncservice to the specific service socket where user is pointed to in order to avoid wild-card network binds.
