### PR TITLE
Further tighten tlsserver context setup to fit modern ssl

### DIFF
--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -10,3 +10,5 @@ isort
 paramiko;python_version >= "3.7"
 paramiko<3;python_version < "3.7"
 werkzeug
+# We need pyOpenSSL for the FTPS service and related tlsserver unit tests
+pyOpenSSL

--- a/mig/shared/tlsserver.py
+++ b/mig/shared/tlsserver.py
@@ -57,16 +57,19 @@ def hardened_ssl_context(configuration, keyfile, certfile, dhparamsfile=None,
     #       https://wiki.mozilla.org/Security/Server_Side_TLS
     ssl_options |= getattr(ssl, 'OP_NO_SSLv2', 0x1000000)
     ssl_options |= getattr(ssl, 'OP_NO_SSLv3', 0x2000000)
+    ssl_options |= getattr(ssl, 'OP_NO_TLSv1', 0x4000000)
+    ssl_ctx.minimum_version = ssl.TLSVersion.TLSv1_1
     # NOTE: refuse weak TLS protocols unless allow_pre_tlsv12
     if not allow_pre_tlsv12:
-        ssl_options |= getattr(ssl, 'OP_NO_TLSv1', 0x4000000)
         ssl_options |= getattr(ssl, 'OP_NO_TLSv1_1', 0x10000000)
+        ssl_ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     # NOTE: refuse slightly dated TLS 1.2 protocol unless allow_pre_tlsv13
     if not allow_pre_tlsv13:
         if getattr(ssl, 'HAS_TLSv1_3', False):
             ssl_options |= getattr(ssl, 'OP_NO_TLSv1_2', 0x8000000)
         else:
             _logger.warning("won't disable TLS 1.2 without TLS 1.3 support")
+        ssl_ctx.minimum_version = ssl.TLSVersion.TLSv1_3
     # NOTE: refuse client TLS renegotiation unless allow_renegotiation
     if not allow_renegotiation:
         ssl_options |= getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000)

--- a/mig/shared/tlsserver.py
+++ b/mig/shared/tlsserver.py
@@ -80,7 +80,7 @@ def hardened_ssl_context(configuration, keyfile, certfile, dhparamsfile=None,
     ssl_options |= getattr(ssl, 'OP_SINGLE_DH_USE', 0x100000)
     # Useful for debugging
     # ssl_options |= getattr(ssl, 'OP_NO_TICKET',  0x0004000)
-    # ssl_options |= getattr(ssl, 'OP_NO_TLSv1_1', 0x1000000)
+    # ssl_options |= getattr(ssl, 'OP_NO_TLSv1_1', 0x10000000)
     # ssl_options |= getattr(ssl, 'OP_NO_TLSv1_2', 0x8000000)
     if sys.version_info[:2] >= (2, 7) and ssl_ctx:
         _logger.info("enforcing strong SSL/TLS options")
@@ -156,14 +156,17 @@ def hardened_openssl_context(configuration, OpenSSL, keyfile, certfile,
     #       https://wiki.mozilla.org/Security/Server_Side_TLS
     ssl_options |= getattr(SSL, 'OP_NO_SSLv2', 0x1000000)
     ssl_options |= getattr(SSL, 'OP_NO_SSLv3', 0x2000000)
+    ssl_options |= getattr(SSL, 'OP_NO_TLSv1', 0x4000000)
+    ssl_ctx.set_min_proto_version(SSL.TLS1_1_VERSION)
     # NOTE: refuse weak TLS protocols unless allow_pre_tlsv12
     if not allow_pre_tlsv12:
-        ssl_options |= getattr(SSL, 'OP_NO_TLSv1', 0x4000000)
         ssl_options |= getattr(SSL, 'OP_NO_TLSv1_1', 0x10000000)
+        ssl_ctx.set_min_proto_version(SSL.TLS1_2_VERSION)
     # NOTE: refuse slightly dated TLS 1.2 protocol unless allow_pre_tlsv13
     if not allow_pre_tlsv13:
         if getattr(SSL, 'HAS_TLSv1_3', False):
             ssl_options |= getattr(SSL, 'OP_NO_TLSv1_2', 0x8000000)
+            ssl_ctx.set_min_proto_version(SSL.TLS1_3_VERSION)
         else:
             _logger.warning("won't disable TLS 1.2 without TLS 1.3 support")
     # NOTE: refuse client TLS renegotiation unless allow_renegotiation

--- a/mig/shared/tlsserver.py
+++ b/mig/shared/tlsserver.py
@@ -67,9 +67,9 @@ def hardened_ssl_context(configuration, keyfile, certfile, dhparamsfile=None,
     if not allow_pre_tlsv13:
         if getattr(ssl, 'HAS_TLSv1_3', False):
             ssl_options |= getattr(ssl, 'OP_NO_TLSv1_2', 0x8000000)
+            ssl_ctx.minimum_version = ssl.TLSVersion.TLSv1_3
         else:
             _logger.warning("won't disable TLS 1.2 without TLS 1.3 support")
-        ssl_ctx.minimum_version = ssl.TLSVersion.TLSv1_3
     # NOTE: refuse client TLS renegotiation unless allow_renegotiation
     if not allow_renegotiation:
         ssl_options |= getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000)

--- a/mig/shared/tlsserver.py
+++ b/mig/shared/tlsserver.py
@@ -158,15 +158,24 @@ def hardened_openssl_context(configuration, OpenSSL, keyfile, certfile,
     ssl_options |= getattr(SSL, 'OP_NO_SSLv3', 0x2000000)
     ssl_options |= getattr(SSL, 'OP_NO_TLSv1', 0x4000000)
     ssl_ctx.set_min_proto_version(SSL.TLS1_1_VERSION)
+    # Mimic native ssl exposure of options
+    ssl_ctx._minimum_version = SSL.TLS1_1_VERSION
     # NOTE: refuse weak TLS protocols unless allow_pre_tlsv12
     if not allow_pre_tlsv12:
         ssl_options |= getattr(SSL, 'OP_NO_TLSv1_1', 0x10000000)
         ssl_ctx.set_min_proto_version(SSL.TLS1_2_VERSION)
+        # Mimic native ssl exposure of options
+        ssl_ctx._minimum_version = SSL.TLS1_2_VERSION
     # NOTE: refuse slightly dated TLS 1.2 protocol unless allow_pre_tlsv13
     if not allow_pre_tlsv13:
-        if getattr(SSL, 'HAS_TLSv1_3', False):
+        # IMPORTANT: OpenSSL doesn't have TLSv1.3 support marker at the moment,
+        #            so fall back to checking if native ssl does.
+        if getattr(SSL, 'HAS_TLSv1_3', False) or \
+                getattr(ssl, 'HAS_TLSv1_3', False):
             ssl_options |= getattr(SSL, 'OP_NO_TLSv1_2', 0x8000000)
             ssl_ctx.set_min_proto_version(SSL.TLS1_3_VERSION)
+            # Mimic native ssl exposure of options
+            ssl_ctx._minimum_version = SSL.TLS1_3_VERSION
         else:
             _logger.warning("won't disable TLS 1.2 without TLS 1.3 support")
     # NOTE: refuse client TLS renegotiation unless allow_renegotiation
@@ -181,9 +190,13 @@ def hardened_openssl_context(configuration, OpenSSL, keyfile, certfile,
         _logger.info("enforcing strong SSL/TLS options")
         _logger.debug("SSL/TLS options: %s" % ssl_options)
         ssl_ctx.set_options(ssl_options)
+        # Mimic native ssl exposure of options
+        ssl_ctx._options = ssl_options
     else:
         _logger.info("can't enforce strong SSL/TLS options")
         _logger.warning("Upgrade to python 2.7.9+ for maximum security")
+        # Mimic native ssl exposure of options
+        ssl_ctx._options = None
 
     pfs_available = False
     if dhparamsfile:
@@ -225,4 +238,9 @@ curves to take advantage of this optional improved security feature""")
 dhparams nor elliptic curves available.""")
 
     ssl_ctx.set_cipher_list(ciphers)
+
+    # Mimic dumbed down version of native ssl get_ciphers method yielding specs
+    ssl_ctx._ciphers = ':'.join([i for i in ciphers.split(':')
+                                 if not i.startswith('!')])
+
     return ssl_ctx

--- a/tests/test_mig_shared_tlsserver.py
+++ b/tests/test_mig_shared_tlsserver.py
@@ -183,9 +183,11 @@ class MigSharedTlsServer(MigTestCase):
 
         # Verify the options were OR'd into the context
         self.assertEqual(context.options & expected_options, expected_options)
+        # Verify that the minimum TLS version is enforced
+        self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_2)
 
-    def test_hardened_ssl_context_options_tls1_1_only(self):
-        """Test SSL context options are set correctly with TLS 1.1 only"""
+    def test_hardened_ssl_context_options_tls1_1(self):
+        """Test SSL context options are set correctly with TLS 1.1 enabled"""
         config = self.configuration
         config.logger = self.logger
 
@@ -197,7 +199,7 @@ class MigSharedTlsServer(MigTestCase):
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
             True,
-            False,
+            True,
             False
         )
 
@@ -205,7 +207,7 @@ class MigSharedTlsServer(MigTestCase):
         expected_options = (
             getattr(ssl, 'OP_NO_SSLv2', 0x1000000) |
             getattr(ssl, 'OP_NO_SSLv3', 0x2000000) |
-            getattr(ssl, 'OP_NO_TLSv1_2', 0x8000000) |
+            getattr(ssl, 'OP_NO_TLSv1', 0x4000000) |
             getattr(ssl, 'OP_NO_COMPRESSION', 0x20000) |
             getattr(ssl, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
             getattr(ssl, 'OP_SINGLE_ECDH_USE', 0x80000) |
@@ -216,6 +218,8 @@ class MigSharedTlsServer(MigTestCase):
 
         # Verify the options were OR'd into the context
         self.assertEqual(context.options & expected_options, expected_options)
+        # Verify that the minimum TLS version is enforced
+        self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_1)
 
     def test_hardened_ssl_context_options_tls1_3_only(self):
         """Test SSL context options are set correctly with TLS 1.3 only"""
@@ -251,6 +255,8 @@ class MigSharedTlsServer(MigTestCase):
 
         # Verify the options were OR'd into the context
         self.assertEqual(context.options & expected_options, expected_options)
+        # Verify that the minimum TLS version is enforced
+        self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_3)
 
     def test_hardened_ssl_context_options_fail_reneg(self):
         """Test SSL context options fail when different"""

--- a/tests/test_mig_shared_tlsserver.py
+++ b/tests/test_mig_shared_tlsserver.py
@@ -207,9 +207,11 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertEqual(context.options & expected_options, expected_options)
+        options = context.options
+        self.assertEqual(options & expected_options, expected_options)
         # Verify that the minimum TLS version is enforced
-        self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_2)
+        minimum_version = context.minimum_version
+        self.assertEqual(minimum_version, ssl.TLSVersion.TLSv1_2)
 
     def test_hardened_ssl_context_options_default(self):
         """Test SSL context options are set correctly"""
@@ -242,9 +244,11 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertEqual(context.options & expected_options, expected_options)
+        options = context.options
+        self.assertEqual(options & expected_options, expected_options)
         # Verify that the minimum TLS version is enforced
-        self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_2)
+        minimum_version = context.minimum_version
+        self.assertEqual(minimum_version, ssl.TLSVersion.TLSv1_2)
 
     def test_hardened_ssl_context_options_tls1_1(self):
         """Test SSL context options are set correctly with TLS 1.1 enabled"""
@@ -276,9 +280,11 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertEqual(context.options & expected_options, expected_options)
+        options = context.options
+        self.assertEqual(options & expected_options, expected_options)
         # Verify that the minimum TLS version is enforced
-        self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_1)
+        minimum_version = context.minimum_version
+        self.assertEqual(minimum_version, ssl.TLSVersion.TLSv1_1)
 
     def test_hardened_ssl_context_options_tls1_3_only(self):
         """Test SSL context options are set correctly with TLS 1.3 only"""
@@ -312,9 +318,11 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertEqual(context.options & expected_options, expected_options)
+        options = context.options
+        self.assertEqual(options & expected_options, expected_options)
         # Verify that the minimum TLS version is enforced
-        self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_3)
+        minimum_version = context.minimum_version
+        self.assertEqual(minimum_version, ssl.TLSVersion.TLSv1_3)
 
     def test_hardened_ssl_context_options_fail_reneg(self):
         """Test SSL context options fail when different"""
@@ -437,9 +445,9 @@ class MigSharedTlsServer(MigTestCase):
         # NOTE: this may be too platform specific
         expected_start = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:"
         expected_end = ":DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
-        result = ':'.join([spec['name'] for spec in context.get_ciphers()])
-        self.assertTrue(result.startswith(expected_start))
-        self.assertTrue(result.endswith(expected_end))
+        ciphers = ':'.join([spec['name'] for spec in context.get_ciphers()])
+        self.assertTrue(ciphers.startswith(expected_start))
+        self.assertTrue(ciphers.endswith(expected_end))
 
     def test_hardened_ssl_context_legacy_ciphers(self):
         """Test SSL context legacy ciphers are set correctly"""
@@ -460,9 +468,9 @@ class MigSharedTlsServer(MigTestCase):
         # NOTE: this may be too platform specific
         expected_start = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:"
         expected_end = ":CAMELLIA256-SHA256:CAMELLIA128-SHA256"
-        result = ':'.join([spec['name'] for spec in context.get_ciphers()])
-        self.assertTrue(result.startswith(expected_start))
-        self.assertTrue(result.endswith(expected_end))
+        ciphers = ':'.join([spec['name'] for spec in context.get_ciphers()])
+        self.assertTrue(ciphers.startswith(expected_start))
+        self.assertTrue(ciphers.endswith(expected_end))
 
     @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
     def test_hardened_openssl_context_options_default_without_dhparams(self):
@@ -499,9 +507,11 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertEqual(context._options & expected_options, expected_options)
+        options = getattr(context, '_options', None)
+        self.assertEqual(options & expected_options, expected_options)
         # Verify that the minimum TLS version is enforced
-        self.assertEqual(context._minimum_version, SSL.TLS1_2_VERSION)
+        minimum_version = getattr(context, '_minimum_version', None)
+        self.assertEqual(minimum_version, SSL.TLS1_2_VERSION)
 
     @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
     def test_hardened_openssl_context_options_default(self):
@@ -538,9 +548,11 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertEqual(context._options & expected_options, expected_options)
+        options = getattr(context, '_options', None)
+        self.assertEqual(options & expected_options, expected_options)
         # Verify that the minimum TLS version is enforced
-        self.assertEqual(context._minimum_version, SSL.TLS1_2_VERSION)
+        minimum_version = getattr(context, '_minimum_version', None)
+        self.assertEqual(minimum_version, SSL.TLS1_2_VERSION)
 
     @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
     def test_hardened_openssl_context_options_tls1_1(self):
@@ -576,9 +588,11 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertEqual(context._options & expected_options, expected_options)
+        options = getattr(context, '_options', None)
+        self.assertEqual(options & expected_options, expected_options)
         # Verify that the minimum TLS version is enforced
-        self.assertEqual(context._minimum_version, SSL.TLS1_1_VERSION)
+        minimum_version = getattr(context, '_minimum_version', None)
+        self.assertEqual(minimum_version, SSL.TLS1_1_VERSION)
 
     @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
     def test_hardened_openssl_context_options_tls1_3_only(self):
@@ -616,9 +630,11 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertEqual(context._options & expected_options, expected_options)
+        options = getattr(context, '_options', None)
+        self.assertEqual(options & expected_options, expected_options)
         # Verify that the minimum TLS version is enforced
-        self.assertEqual(context._minimum_version, SSL.TLS1_3_VERSION)
+        minimum_version = getattr(context, '_minimum_version', None)
+        self.assertEqual(minimum_version, SSL.TLS1_3_VERSION)
 
     @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
     def test_hardened_openssl_context_options_fail_reneg(self):
@@ -655,8 +671,8 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertNotEqual(
-            context._options & expected_options, expected_options)
+        options = getattr(context, '_options', None)
+        self.assertNotEqual(options & expected_options, expected_options)
 
     @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
     def test_hardened_openssl_context_options_fail_tls1_1(self):
@@ -693,8 +709,8 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertNotEqual(
-            context._options & expected_options, expected_options)
+        options = getattr(context, '_options', None)
+        self.assertNotEqual(options & expected_options, expected_options)
 
     @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
     def test_hardened_openssl_context_options_fail_tls1_2(self):
@@ -731,8 +747,8 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertNotEqual(
-            context._options & expected_options, expected_options)
+        options = getattr(context, '_options', None)
+        self.assertNotEqual(options & expected_options, expected_options)
 
     @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
     def test_hardened_openssl_context_ciphers(self):
@@ -757,9 +773,9 @@ class MigSharedTlsServer(MigTestCase):
         # NOTE: this may be too platform specific
         expected_start = "ECDHE-ECDSA-AES128-GCM-SHA256:"
         expected_end = ":DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
-        result = context._ciphers
-        self.assertTrue(result.startswith(expected_start))
-        self.assertTrue(result.endswith(expected_end))
+        ciphers = getattr(context, '_ciphers', None)
+        self.assertTrue(ciphers.startswith(expected_start))
+        self.assertTrue(ciphers.endswith(expected_end))
 
     @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
     def test_hardened_openssl_context_legacy_ciphers(self):
@@ -784,6 +800,6 @@ class MigSharedTlsServer(MigTestCase):
         # NOTE: this may be too platform specific
         expected_start = "ECDHE-RSA-AES128-GCM-SHA256:"
         expected_end = ":DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES:CAMELLIA"
-        result = context._ciphers
-        self.assertTrue(result.startswith(expected_start))
-        self.assertTrue(result.endswith(expected_end))
+        ciphers = getattr(context, '_ciphers', None)
+        self.assertTrue(ciphers.startswith(expected_start))
+        self.assertTrue(ciphers.endswith(expected_end))

--- a/tests/test_mig_shared_tlsserver.py
+++ b/tests/test_mig_shared_tlsserver.py
@@ -30,8 +30,14 @@
 import os
 import unittest
 
+try:
+    import OpenSSL
+except ImportError:
+    OpenSSL = None
+
 # Imports of the code under test
-from mig.shared.tlsserver import hardened_ssl_context, ssl
+from mig.shared.tlsserver import hardened_openssl_context, \
+    hardened_ssl_context, ssl
 # Imports required for the unit test wrapping
 from mig.shared.defaults import STRONG_TLS_CIPHERS, STRONG_TLS_LEGACY_CIPHERS, \
     STRONG_TLS_CURVES
@@ -40,7 +46,8 @@ from tests.support import MigTestCase
 
 TEST_KEY_FILE = "testkey.pem"
 TEST_CERT_FILE = "testcert.pem"
-TEST_CACERT_FILE = "testcacert.pem"
+# TEST_CACERT_FILE = "testcacert.pem"
+TEST_CACERT_FILE = None
 TEST_DHPARAMS_FILE = "testdhparams.pem"
 # IMPORTANT: this is a BOGUS key + self-signed cert, ONLY ever use for testing!
 TEST_HOST_KEY = """-----BEGIN PRIVATE KEY-----
@@ -129,6 +136,22 @@ UPrFPCy8BqR4ZvZTvjtxMF81ahq2t+fmj8QeG1o0mSnH/Q3lP7vn7xSjZTu5+ldc
 haiaED1TUyXIyHyn/L+NJmbdcbfPebvrv7KYdtxTC9j47kwWdkSuWMEW1pMTPM9W
 EthFXgjAdlUayA5VqbcWIdm/P4d5Wc5lgj2XlbcwREcktT4=
 -----END CERTIFICATE-----"""
+# Public DH PARAMS from https://ssl-config.mozilla.org/ffdhe4096.txt
+TEST_DHPARAMS = """
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEA//////////+t+FRYortKmq/cViAnPTzx2LnFg84tNpWp4TZBFGQz
++8yTnc4kmz75fS/jY2MMddj2gbICrsRhetPfHtXV/WVhJDP1H18GbtCFY2VVPe0a
+87VXE15/V8k1mE8McODmi3fipona8+/och3xWKE2rec1MKzKT0g6eXq8CrGCsyT7
+YdEIqUuyyOP7uWrat2DX9GgdT0Kj3jlN9K5W7edjcrsZCwenyO4KbXCeAvzhzffi
+7MA0BM0oNC9hkXL+nOmFg/+OTxIy7vKBg8P+OxtMb61zO7X8vC7CIAXFjvGDfRaD
+ssbzSibBsu/6iGtCOGEfz9zeNVs7ZRkDW7w09N75nAI4YbRvydbmyQd62R0mkff3
+7lmMsPrBhtkcrv4TCYUTknC0EwyTvEN5RPT9RFLi103TZPLiHnH1S/9croKrnJ32
+nuhtK8UiNjoNq8Uhl5sN6todv5pC1cRITgq80Gv6U93vPBsg7j/VnXwl5B0rZp4e
+8W5vUsMWTfT7eTDp5OWIV7asfV9C1p9tGHdjzx1VA0AEh/VbpX4xzHpxNciG77Qx
+iu1qHgEtnmgyqQdgCpGBMMRtx3j5ca0AOAkpmaMzy4t6Gh25PXFAADwqTs6p+Y0K
+zAqCkc3OyX3Pjsm1Wn+IpGtNtahR9EGC4caKAH5eZV9q//////////8CAQI=
+-----END DH PARAMETERS-----
+"""
 
 
 class MigSharedTlsServer(MigTestCase):
@@ -139,19 +162,22 @@ class MigSharedTlsServer(MigTestCase):
         return 'testconfig'
 
     # TODO: move the key+cert e.g. to data/X with helper function to load them?
-    def _prepare_key_cert(self, key_path, cert_path):
+    def _prepare_key_cert(self, key_path, cert_path, dhparams_path):
         """Save key and cert file for use in real ssl tests"""
         with open(key_path, 'w') as key_fd:
             key_fd.write(TEST_HOST_KEY)
         with open(cert_path, 'w') as cert_fd:
             cert_fd.write(TEST_HOST_CERT)
+        with open(dhparams_path, 'w') as dhparams_fd:
+            dhparams_fd.write(TEST_DHPARAMS)
 
     def before_each(self):
         """Set up test configuration and reset state before each test"""
-        self._prepare_key_cert(TEST_KEY_FILE, TEST_CERT_FILE)
+        self._prepare_key_cert(TEST_KEY_FILE, TEST_CERT_FILE,
+                               TEST_DHPARAMS_FILE)
 
-    def test_hardened_ssl_context_options_default(self):
-        """Test SSL context options are set correctly"""
+    def test_hardened_ssl_context_options_default_without_dhparams(self):
+        """Test SSL context options are set correctly without DH params"""
         config = self.configuration
         config.logger = self.logger
 
@@ -177,8 +203,42 @@ class MigSharedTlsServer(MigTestCase):
             getattr(ssl, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
             getattr(ssl, 'OP_SINGLE_ECDH_USE', 0x80000) |
             getattr(ssl, 'OP_SINGLE_DH_USE', 0x100000) |
-            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000) |
-            getattr(ssl, 'OP_RENEGOTIATION', 0x40000000)
+            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000)
+        )
+
+        # Verify the options were OR'd into the context
+        self.assertEqual(context.options & expected_options, expected_options)
+        # Verify that the minimum TLS version is enforced
+        self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_2)
+
+    def test_hardened_ssl_context_options_default(self):
+        """Test SSL context options are set correctly"""
+        config = self.configuration
+        config.logger = self.logger
+
+        context = hardened_ssl_context(
+            config,
+            TEST_KEY_FILE,
+            TEST_CERT_FILE,
+            TEST_DHPARAMS_FILE,
+            STRONG_TLS_CIPHERS,
+            STRONG_TLS_CURVES,
+            False,
+            True,
+            False
+        )
+
+        # Verify options are set
+        expected_options = (
+            getattr(ssl, 'OP_NO_SSLv2', 0x1000000) |
+            getattr(ssl, 'OP_NO_SSLv3', 0x2000000) |
+            getattr(ssl, 'OP_NO_TLSv1', 0x4000000) |
+            getattr(ssl, 'OP_NO_TLSv1_1', 0x10000000) |
+            getattr(ssl, 'OP_NO_COMPRESSION', 0x20000) |
+            getattr(ssl, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
+            getattr(ssl, 'OP_SINGLE_ECDH_USE', 0x80000) |
+            getattr(ssl, 'OP_SINGLE_DH_USE', 0x100000) |
+            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000)
         )
 
         # Verify the options were OR'd into the context
@@ -195,7 +255,7 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            None,
+            TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
             True,
@@ -212,8 +272,7 @@ class MigSharedTlsServer(MigTestCase):
             getattr(ssl, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
             getattr(ssl, 'OP_SINGLE_ECDH_USE', 0x80000) |
             getattr(ssl, 'OP_SINGLE_DH_USE', 0x100000) |
-            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000) |
-            getattr(ssl, 'OP_RENEGOTIATION', 0x40000000)
+            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000)
         )
 
         # Verify the options were OR'd into the context
@@ -230,7 +289,7 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            None,
+            TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
             False,
@@ -249,8 +308,7 @@ class MigSharedTlsServer(MigTestCase):
             getattr(ssl, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
             getattr(ssl, 'OP_SINGLE_ECDH_USE', 0x80000) |
             getattr(ssl, 'OP_SINGLE_DH_USE', 0x100000) |
-            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000) |
-            getattr(ssl, 'OP_RENEGOTIATION', 0x40000000)
+            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000)
         )
 
         # Verify the options were OR'd into the context
@@ -267,7 +325,7 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            None,
+            TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
             False,
@@ -285,8 +343,7 @@ class MigSharedTlsServer(MigTestCase):
             getattr(ssl, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
             getattr(ssl, 'OP_SINGLE_ECDH_USE', 0x80000) |
             getattr(ssl, 'OP_SINGLE_DH_USE', 0x100000) |
-            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000) |
-            getattr(ssl, 'OP_RENEGOTIATION', 0x40000000)
+            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000)
         )
 
         # Verify the options were OR'd into the context
@@ -302,7 +359,7 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            None,
+            TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
             True,
@@ -320,8 +377,7 @@ class MigSharedTlsServer(MigTestCase):
             getattr(ssl, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
             getattr(ssl, 'OP_SINGLE_ECDH_USE', 0x80000) |
             getattr(ssl, 'OP_SINGLE_DH_USE', 0x100000) |
-            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000) |
-            getattr(ssl, 'OP_RENEGOTIATION', 0x40000000)
+            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000)
         )
 
         # Verify the options were OR'd into the context
@@ -337,7 +393,7 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            None,
+            TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
             True,
@@ -355,8 +411,7 @@ class MigSharedTlsServer(MigTestCase):
             getattr(ssl, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
             getattr(ssl, 'OP_SINGLE_ECDH_USE', 0x80000) |
             getattr(ssl, 'OP_SINGLE_DH_USE', 0x100000) |
-            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000) |
-            getattr(ssl, 'OP_RENEGOTIATION', 0x40000000)
+            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000)
         )
 
         # Verify the options were OR'd into the context
@@ -372,7 +427,7 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            None,
+            TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
             False,
@@ -395,7 +450,7 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            None,
+            TEST_DHPARAMS_FILE,
             STRONG_TLS_LEGACY_CIPHERS,
             STRONG_TLS_CURVES,
             False,
@@ -406,5 +461,329 @@ class MigSharedTlsServer(MigTestCase):
         expected_start = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:"
         expected_end = ":CAMELLIA256-SHA256:CAMELLIA128-SHA256"
         result = ':'.join([spec['name'] for spec in context.get_ciphers()])
+        self.assertTrue(result.startswith(expected_start))
+        self.assertTrue(result.endswith(expected_end))
+
+    @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
+    def test_hardened_openssl_context_options_default_without_dhparams(self):
+        """Test OpenSSL context options are set correctly without DH params"""
+        config = self.configuration
+        config.logger = self.logger
+        SSL = OpenSSL.SSL
+
+        context = hardened_openssl_context(
+            config,
+            OpenSSL,
+            TEST_KEY_FILE,
+            TEST_CERT_FILE,
+            TEST_CACERT_FILE,
+            None,
+            STRONG_TLS_CIPHERS,
+            STRONG_TLS_CURVES,
+            False,
+            True,
+            False
+        )
+
+        # Verify options are set
+        expected_options = (
+            getattr(SSL, 'OP_NO_SSLv2', 0x1000000) |
+            getattr(SSL, 'OP_NO_SSLv3', 0x2000000) |
+            getattr(SSL, 'OP_NO_TLSv1', 0x4000000) |
+            getattr(SSL, 'OP_NO_TLSv1_1', 0x10000000) |
+            getattr(SSL, 'OP_NO_COMPRESSION', 0x20000) |
+            getattr(SSL, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
+            getattr(SSL, 'OP_SINGLE_ECDH_USE', 0x80000) |
+            getattr(SSL, 'OP_SINGLE_DH_USE', 0x100000) |
+            getattr(SSL, 'OP_NO_RENEGOTIATION', 0x40000000)
+        )
+
+        # Verify the options were OR'd into the context
+        self.assertEqual(context._options & expected_options, expected_options)
+        # Verify that the minimum TLS version is enforced
+        self.assertEqual(context._minimum_version, SSL.TLS1_2_VERSION)
+
+    @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
+    def test_hardened_openssl_context_options_default(self):
+        """Test OpenSSL context options are set correctly"""
+        config = self.configuration
+        config.logger = self.logger
+        SSL = OpenSSL.SSL
+
+        context = hardened_openssl_context(
+            config,
+            OpenSSL,
+            TEST_KEY_FILE,
+            TEST_CERT_FILE,
+            TEST_CACERT_FILE,
+            TEST_DHPARAMS_FILE,
+            STRONG_TLS_CIPHERS,
+            STRONG_TLS_CURVES,
+            False,
+            True,
+            False
+        )
+
+        # Verify options are set
+        expected_options = (
+            getattr(SSL, 'OP_NO_SSLv2', 0x1000000) |
+            getattr(SSL, 'OP_NO_SSLv3', 0x2000000) |
+            getattr(SSL, 'OP_NO_TLSv1', 0x4000000) |
+            getattr(SSL, 'OP_NO_TLSv1_1', 0x10000000) |
+            getattr(SSL, 'OP_NO_COMPRESSION', 0x20000) |
+            getattr(SSL, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
+            getattr(SSL, 'OP_SINGLE_ECDH_USE', 0x80000) |
+            getattr(SSL, 'OP_SINGLE_DH_USE', 0x100000) |
+            getattr(SSL, 'OP_NO_RENEGOTIATION', 0x40000000)
+        )
+
+        # Verify the options were OR'd into the context
+        self.assertEqual(context._options & expected_options, expected_options)
+        # Verify that the minimum TLS version is enforced
+        self.assertEqual(context._minimum_version, SSL.TLS1_2_VERSION)
+
+    @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
+    def test_hardened_openssl_context_options_tls1_1(self):
+        """Test OpenSSL context options are set correctly with TLS 1.1 enabled"""
+        config = self.configuration
+        config.logger = self.logger
+        SSL = OpenSSL.SSL
+
+        context = hardened_openssl_context(
+            config,
+            OpenSSL,
+            TEST_KEY_FILE,
+            TEST_CERT_FILE,
+            TEST_CACERT_FILE,
+            TEST_DHPARAMS_FILE,
+            STRONG_TLS_CIPHERS,
+            STRONG_TLS_CURVES,
+            True,
+            True,
+            False
+        )
+
+        # Verify options are set
+        expected_options = (
+            getattr(SSL, 'OP_NO_SSLv2', 0x1000000) |
+            getattr(SSL, 'OP_NO_SSLv3', 0x2000000) |
+            getattr(SSL, 'OP_NO_TLSv1', 0x4000000) |
+            getattr(SSL, 'OP_NO_COMPRESSION', 0x20000) |
+            getattr(SSL, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
+            getattr(SSL, 'OP_SINGLE_ECDH_USE', 0x80000) |
+            getattr(SSL, 'OP_SINGLE_DH_USE', 0x100000) |
+            getattr(SSL, 'OP_NO_RENEGOTIATION', 0x40000000)
+        )
+
+        # Verify the options were OR'd into the context
+        self.assertEqual(context._options & expected_options, expected_options)
+        # Verify that the minimum TLS version is enforced
+        self.assertEqual(context._minimum_version, SSL.TLS1_1_VERSION)
+
+    @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
+    def test_hardened_openssl_context_options_tls1_3_only(self):
+        """Test OpenSSL context options are set correctly with TLS 1.3 only"""
+        config = self.configuration
+        config.logger = self.logger
+        SSL = OpenSSL.SSL
+
+        context = hardened_openssl_context(
+            config,
+            OpenSSL,
+            TEST_KEY_FILE,
+            TEST_CERT_FILE,
+            TEST_CACERT_FILE,
+            TEST_DHPARAMS_FILE,
+            STRONG_TLS_CIPHERS,
+            STRONG_TLS_CURVES,
+            False,
+            False,
+            False
+        )
+
+        # Verify options are set
+        expected_options = (
+            getattr(SSL, 'OP_NO_SSLv2', 0x1000000) |
+            getattr(SSL, 'OP_NO_SSLv3', 0x2000000) |
+            getattr(SSL, 'OP_NO_TLSv1', 0x4000000) |
+            getattr(SSL, 'OP_NO_TLSv1_1', 0x10000000) |
+            getattr(SSL, 'OP_NO_TLSv1_2', 0x8000000) |
+            getattr(SSL, 'OP_NO_COMPRESSION', 0x20000) |
+            getattr(SSL, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
+            getattr(SSL, 'OP_SINGLE_ECDH_USE', 0x80000) |
+            getattr(SSL, 'OP_SINGLE_DH_USE', 0x100000) |
+            getattr(SSL, 'OP_NO_RENEGOTIATION', 0x40000000)
+        )
+
+        # Verify the options were OR'd into the context
+        self.assertEqual(context._options & expected_options, expected_options)
+        # Verify that the minimum TLS version is enforced
+        self.assertEqual(context._minimum_version, SSL.TLS1_3_VERSION)
+
+    @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
+    def test_hardened_openssl_context_options_fail_reneg(self):
+        """Test OpenSSL context options fail when different"""
+        config = self.configuration
+        config.logger = self.logger
+        SSL = OpenSSL.SSL
+
+        context = hardened_openssl_context(
+            config,
+            OpenSSL,
+            TEST_KEY_FILE,
+            TEST_CERT_FILE,
+            TEST_CACERT_FILE,
+            TEST_DHPARAMS_FILE,
+            STRONG_TLS_CIPHERS,
+            STRONG_TLS_CURVES,
+            False,
+            True,
+            True
+        )
+
+        # Verify options are set
+        expected_options = (
+            getattr(SSL, 'OP_NO_SSLv2', 0x1000000) |
+            getattr(SSL, 'OP_NO_SSLv3', 0x2000000) |
+            getattr(SSL, 'OP_NO_TLSv1', 0x4000000) |
+            getattr(SSL, 'OP_NO_TLSv1_1', 0x10000000) |
+            getattr(SSL, 'OP_NO_COMPRESSION', 0x20000) |
+            getattr(SSL, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
+            getattr(SSL, 'OP_SINGLE_ECDH_USE', 0x80000) |
+            getattr(SSL, 'OP_SINGLE_DH_USE', 0x100000) |
+            getattr(SSL, 'OP_NO_RENEGOTIATION', 0x40000000)
+        )
+
+        # Verify the options were OR'd into the context
+        self.assertNotEqual(
+            context._options & expected_options, expected_options)
+
+    @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
+    def test_hardened_openssl_context_options_fail_tls1_1(self):
+        """Test OpenSSL context options fail when different"""
+        config = self.configuration
+        config.logger = self.logger
+        SSL = OpenSSL.SSL
+
+        context = hardened_openssl_context(
+            config,
+            OpenSSL,
+            TEST_KEY_FILE,
+            TEST_CERT_FILE,
+            TEST_CACERT_FILE,
+            TEST_DHPARAMS_FILE,
+            STRONG_TLS_CIPHERS,
+            STRONG_TLS_CURVES,
+            True,
+            True,
+            False
+        )
+
+        # Verify options are set
+        expected_options = (
+            getattr(SSL, 'OP_NO_SSLv2', 0x1000000) |
+            getattr(SSL, 'OP_NO_SSLv3', 0x2000000) |
+            getattr(SSL, 'OP_NO_TLSv1', 0x4000000) |
+            getattr(SSL, 'OP_NO_TLSv1_1', 0x10000000) |
+            getattr(SSL, 'OP_NO_COMPRESSION', 0x20000) |
+            getattr(SSL, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
+            getattr(SSL, 'OP_SINGLE_ECDH_USE', 0x80000) |
+            getattr(SSL, 'OP_SINGLE_DH_USE', 0x100000) |
+            getattr(SSL, 'OP_NO_RENEGOTIATION', 0x40000000)
+        )
+
+        # Verify the options were OR'd into the context
+        self.assertNotEqual(
+            context._options & expected_options, expected_options)
+
+    @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
+    def test_hardened_openssl_context_options_fail_tls1_2(self):
+        """Test OpenSSL context options fail when different"""
+        config = self.configuration
+        config.logger = self.logger
+        SSL = OpenSSL.SSL
+
+        context = hardened_openssl_context(
+            config,
+            OpenSSL,
+            TEST_KEY_FILE,
+            TEST_CERT_FILE,
+            TEST_CACERT_FILE,
+            TEST_DHPARAMS_FILE,
+            STRONG_TLS_CIPHERS,
+            STRONG_TLS_CURVES,
+            True,
+            False,
+            False
+        )
+
+        # Verify options are set
+        expected_options = (
+            getattr(SSL, 'OP_NO_SSLv2', 0x1000000) |
+            getattr(SSL, 'OP_NO_SSLv3', 0x2000000) |
+            getattr(SSL, 'OP_NO_TLSv1', 0x4000000) |
+            getattr(SSL, 'OP_NO_TLSv1_1', 0x10000000) |
+            getattr(SSL, 'OP_NO_COMPRESSION', 0x20000) |
+            getattr(SSL, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
+            getattr(SSL, 'OP_SINGLE_ECDH_USE', 0x80000) |
+            getattr(SSL, 'OP_SINGLE_DH_USE', 0x100000) |
+            getattr(SSL, 'OP_NO_RENEGOTIATION', 0x40000000)
+        )
+
+        # Verify the options were OR'd into the context
+        self.assertNotEqual(
+            context._options & expected_options, expected_options)
+
+    @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
+    def test_hardened_openssl_context_ciphers(self):
+        """Test OpenSSL context ciphers are set correctly"""
+        config = self.configuration
+        config.logger = self.logger
+        SSL = OpenSSL.SSL
+
+        context = hardened_openssl_context(
+            config,
+            OpenSSL,
+            TEST_KEY_FILE,
+            TEST_CERT_FILE,
+            TEST_CACERT_FILE,
+            TEST_DHPARAMS_FILE,
+            STRONG_TLS_CIPHERS,
+            STRONG_TLS_CURVES,
+            False,
+            True,
+            False
+        )
+        # NOTE: this may be too platform specific
+        expected_start = "ECDHE-ECDSA-AES128-GCM-SHA256:"
+        expected_end = ":DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
+        result = context._ciphers
+        self.assertTrue(result.startswith(expected_start))
+        self.assertTrue(result.endswith(expected_end))
+
+    @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
+    def test_hardened_openssl_context_legacy_ciphers(self):
+        """Test OpenSSL context legacy ciphers are set correctly"""
+        config = self.configuration
+        config.logger = self.logger
+        SSL = OpenSSL.SSL
+
+        context = hardened_openssl_context(
+            config,
+            OpenSSL,
+            TEST_KEY_FILE,
+            TEST_CERT_FILE,
+            TEST_CACERT_FILE,
+            TEST_DHPARAMS_FILE,
+            STRONG_TLS_LEGACY_CIPHERS,
+            STRONG_TLS_CURVES,
+            False,
+            True,
+            False
+        )
+        # NOTE: this may be too platform specific
+        expected_start = "ECDHE-RSA-AES128-GCM-SHA256:"
+        expected_end = ":DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES:CAMELLIA"
+        result = context._ciphers
         self.assertTrue(result.startswith(expected_start))
         self.assertTrue(result.endswith(expected_end))


### PR DESCRIPTION
Follow-up to tighten the default `ssl` context with unit tests for the `tlsserver` module in place (#491). ~Includes that PR and it should be rebased after merge.~
Enforces `minimum_version` and now prevents anything below TLSv1_1 even if the `allow_pre_tlsv12` is explicitly requested. The same is implemented for the pyOpenSSL version  and the unit tests were adjusted to fit those changes.

NOTE: the code was tested for each of the openid, webdavs, ftps and sftp services in actual deployment. None of them regressed security-wise for the unchanged defaults allowing TLSv1.2+. It also works when toggling off the `allow_pre_tls13` to drop TLSv1.2 and require at least TLSv1.3. Of course that limits support for old and outdated client platforms but we will probably want to do that sooner or later.