### PR TITLE
Follow-up to PR505 for the recently added cmdapi unit tests in PR514

### DIFF
--- a/mig/shared/cmdapi.py
+++ b/mig/shared/cmdapi.py
@@ -182,9 +182,7 @@ def parse_command_args(configuration, command_list):
     return (function, user_arguments_dict)
 
 
-def legacy_main(_exit=sys.exit, _print=print):
-    from mig.shared.conf import get_configuration_object
-    conf = get_configuration_object()
+def legacy_main(conf, print=print, _exit=sys.exit):
     for cmd_list in [['cp', 'srcfile', 'dstfile'],
                      ['cp', 'srcfile', 'srcfile2', 'dstdir'],
                      ['cp', '-r', 'srcdir', 'dstdir'],
@@ -200,4 +198,6 @@ def legacy_main(_exit=sys.exit, _print=print):
 
 
 if __name__ == '__main__':
-    legacy_main()
+    from mig.shared.conf import get_configuration_object
+    conf = get_configuration_object()
+    legacy_main(conf)

--- a/tests/test_mig_shared_cmdapi.py
+++ b/tests/test_mig_shared_cmdapi.py
@@ -294,7 +294,10 @@ class TestMigSharedCmdapi(MigTestCase):
 
 
 class TestMigSharedCmdapi__legacy_main(MigTestCase):
-    """Unit tests for legacy cmdapi self-checks"""
+    """Unit tests for corresponding module legacy self-checks"""
+
+    def _provide_configuration(self):
+        return 'testconfig'
 
     def test_existing_main(self):
         """Run the legacy self-tests directly in module"""
@@ -315,7 +318,8 @@ class TestMigSharedCmdapi__legacy_main(MigTestCase):
             """Keep track of printed output"""
             raise_on_error_exit.last_print = value
 
-        legacy_main(_exit=raise_on_error_exit, _print=record_last_print)
+        legacy_main(self.configuration, print=record_last_print,
+                    _exit=raise_on_error_exit)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Follow-up to #505 for the recently added `cmdapi` unit tests in #514 to similarly reduce legacy self-test noise.