### PR TITLE
Drop unused TLSv1.1 support completely in tlsserver module

### DIFF
--- a/mig/install/MiGserver-template.conf
+++ b/mig/install/MiGserver-template.conf
@@ -586,24 +586,15 @@ enable_sftp_subsys = __ENABLE_SFTP_SUBSYS__
 # Pure Python WsgiDAV-based webdav(s) daemon
 enable_davs = __ENABLE_DAVS__
 # Allow sub-optimal but still relatively strong legacy TLS support in WebDAVS
-# NOTE: Python-2.7.x ssl supports TLSv1.2+ with strong ciphers and all popular
+# NOTE: Python-2.7+ ssl supports TLSv1.2+ with strong ciphers and all popular
 #       clients (including Windows 10+ native WebDAVS) also work with those.
-# NOTE: Apparently Win 7 (+8.1?) native WebDAVS only works with semi-strong
-#       legacy ciphers and TLSv1.0+v1.1 unless updated and enabled 
-# NOTE: Win 7 went EoL in January 2020 and should no longer be needed
 #enable_davs_legacy_tls = False
 # Pure Python pyftpdlib-based ftp(s) daemon
 enable_ftps = __ENABLE_FTPS__
 # Allow sub-optimal but still relatively strong legacy TLS supports in FTPS
-# NOTE: Recent PyOpenSSL supports TLSv1.2+ with strong ciphers and all popular
+# NOTE: Modern PyOpenSSL supports TLSv1.2+ with strong ciphers and all popular
 #       clients also work with those.
-# NOTE: CentOS 7 native pyOpenSSL 0.13 does NOT support elliptic curve ciphers
-#       and FileZilla fails on listdir with remaining strong DHE ciphers.
-#       Installing a recent pyopenssl e.g. from the centos-openstack-X repo
-#       allows disabling legacy tls support without breaking FileZilla support.
-# TODO: disable as soon as a recent pyopenssl version is available - the one
-#       from pip breaks paramiko so do NOT go there.
-enable_ftps_legacy_tls = True
+#enable_ftps_legacy_tls = False
 # Enable WSGI served web pages (faster than CGI) - requires apache wsgi module
 enable_wsgi = __ENABLE_WSGI__
 # Enable system notify helper used e.g. to warn about failed user logins
@@ -638,6 +629,10 @@ peers_explicit_fields = __PEERS_EXPLICIT_FIELDS__
 peers_contact_hint = __PEERS_CONTACT_HINT__
 # Enable OpenID daemon for web access with user/pw from local user DB
 enable_openid = __ENABLE_OPENID__
+# Allow sub-optimal but still relatively strong legacy TLS support in OpenID 2.0
+# NOTE: Python-2.7+ ssl supports TLSv1.2+ with strong ciphers and all popular
+#       clients also work with those.
+#enable_openid_legacy_tls = False
 # Enable share links for easy external exchange of data with anyone
 enable_sharelinks = __ENABLE_SHARELINKS__
 # Enable storage quota

--- a/mig/server/grid_ftps.py
+++ b/mig/server/grid_ftps.py
@@ -96,6 +96,7 @@ except ImportError:
 from mig.shared.accountstate import check_account_accessible
 from mig.shared.base import invisible_path, force_utf8, force_native_str
 from mig.shared.conf import get_configuration_object
+from mig.shared.defaults import STRONG_TLS_CIPHERS, STRONG_TLS_LEGACY_CIPHERS
 from mig.shared.fileio import user_chroot_exceptions
 from mig.shared.griddaemons.ftps import default_max_user_hits, \
     default_user_abuse_hits, default_proto_abuse_hits, \
@@ -493,14 +494,22 @@ def start_service(conf):
         handler.tls_data_required = True
         keyfile = certfile = conf.user_ftps_key
         handler.certfile = certfile
+        # Mimic cipher setup from other daemons
+        ciphers = daemon_conf['ssl_ciphers'] = None
         # Harden TLS/SSL if possible, requires recent pyftpdlib
         if hasattr(handler, 'ssl_context'):
-            dhparamsfile = configuration.user_shared_dhparams
+            dhparams_path = configuration.user_shared_dhparams
             legacy_tls = configuration.site_enable_ftps_legacy_tls
+            if ciphers is not None:
+                use_ciphers = ciphers
+            elif legacy_tls:
+                use_ciphers = STRONG_TLS_LEGACY_CIPHERS
+            else:
+                use_ciphers = STRONG_TLS_CIPHERS
             ssl_ctx = hardened_openssl_context(conf, OpenSSL, keyfile,
                                                certfile,
-                                               dhparamsfile=dhparamsfile,
-                                               allow_pre_tlsv12=legacy_tls)
+                                               dhparamsfile=dhparams_path,
+                                               ciphers=use_ciphers)
             handler.ssl_context = ssl_ctx
         else:
             logger.warning("Unable to enforce explicit strong TLS connections")

--- a/mig/server/grid_ftps.py
+++ b/mig/server/grid_ftps.py
@@ -494,8 +494,7 @@ def start_service(conf):
         handler.tls_data_required = True
         keyfile = certfile = conf.user_ftps_key
         handler.certfile = certfile
-        # Mimic cipher setup from other daemons
-        ciphers = daemon_conf['ssl_ciphers'] = None
+        ciphers = None
         # Harden TLS/SSL if possible, requires recent pyftpdlib
         if hasattr(handler, 'ssl_context'):
             dhparams_path = configuration.user_shared_dhparams

--- a/mig/server/grid_openid.py
+++ b/mig/server/grid_openid.py
@@ -102,6 +102,8 @@ try:
     from mig.shared.base import client_id_dir, cert_field_map, force_utf8, \
         force_native_str
     from mig.shared.conf import get_configuration_object
+    from mig.shared.defaults import STRONG_TLS_CIPHERS, \
+        STRONG_TLS_LEGACY_CIPHERS
     from mig.shared.griddaemons.openid import default_max_user_hits, \
         default_user_abuse_hits, default_proto_abuse_hits, \
         default_username_validator, refresh_user_creds, update_login_map, \
@@ -1654,6 +1656,8 @@ def start_service(configuration):
     data_path = configuration.openid_store
     daemon_conf = configuration.daemon_conf
     nossl = daemon_conf['nossl']
+    # Mimic cipher setup from other daemons
+    ciphers = daemon_conf['ssl_ciphers'] = None
     addr = (host, port)
     # TODO: is this threaded version robust enough (thread safety)?
     # OpenIDServer = OpenIDHTTPServer
@@ -1675,12 +1679,20 @@ def start_service(configuration):
         # Use best possible SSL/TLS args for this python version
         key_path = cert_path = configuration.user_openid_key
         dhparams_path = configuration.user_shared_dhparams
+        legacy_tls = configuration.site_enable_openid_legacy_tls
+        if ciphers is not None:
+            use_ciphers = ciphers
+        elif legacy_tls:
+            use_ciphers = STRONG_TLS_LEGACY_CIPHERS
+        else:
+            use_ciphers = STRONG_TLS_CIPHERS
         if not os.path.isfile(cert_path):
             logger.error('No such server key: %s' % cert_path)
             sys.exit(1)
         logger.info('Wrapping connections in SSL')
         ssl_ctx = hardened_ssl_context(configuration, key_path, cert_path,
-                                       dhparams_path)
+                                       dhparamsfile=dhparams_path,
+                                       ciphers=use_ciphers)
         httpserver.socket = ssl_ctx.wrap_socket(httpserver.socket,
                                                 server_side=True)
         # Override default SSLSocket accept function to inject timeout support

--- a/mig/server/grid_openid.py
+++ b/mig/server/grid_openid.py
@@ -1656,8 +1656,7 @@ def start_service(configuration):
     data_path = configuration.openid_store
     daemon_conf = configuration.daemon_conf
     nossl = daemon_conf['nossl']
-    # Mimic cipher setup from other daemons
-    ciphers = daemon_conf['ssl_ciphers'] = None
+    ciphers = None
     addr = (host, port)
     # TODO: is this threaded version robust enough (thread safety)?
     # OpenIDServer = OpenIDHTTPServer

--- a/mig/server/grid_webdavs.py
+++ b/mig/server/grid_webdavs.py
@@ -335,8 +335,7 @@ class HardenedSSLAdapter(BuiltinSSLAdapter):
         context to use in all future connections in the wrap method.
 
         If the optional legacy_tls arg is set the STRONG_TLS_LEGACY_CIPHERS
-        are used instead of the STRONG_TLS_CIPHERS, and the limitation to
-        TLSv1.2+ is left out to allow legacy TLSv1.0 and TLSv1.1 connections.
+        are used instead of the STRONG_TLS_CIPHERS.
         This is required to support e.g. native Windows 7 WebDAVS access with
         the weak ECDHE-RSA-AES128-SHA cipher.
         """
@@ -345,7 +344,7 @@ class HardenedSSLAdapter(BuiltinSSLAdapter):
                                                  certificate_chain, ciphers)
         # logger.debug("proceed with hardening of ssl contetx")
         # Set up hardened SSL context once and for all
-        dhparams = configuration.user_shared_dhparams
+        dhparams_path = configuration.user_shared_dhparams
         if ciphers is not None:
             use_ciphers = ciphers
         elif legacy_tls:
@@ -353,9 +352,9 @@ class HardenedSSLAdapter(BuiltinSSLAdapter):
         else:
             use_ciphers = STRONG_TLS_CIPHERS
         self.context = hardened_ssl_context(configuration, self.private_key,
-                                            self.certificate, dhparams,
-                                            ciphers=use_ciphers,
-                                            allow_pre_tlsv12=legacy_tls)
+                                            self.certificate,
+                                            dhparamsfile=dhparams_path,
+                                            ciphers=use_ciphers)
         # logger.debug("established hardened ssl contetx")
 
     def __force_close(self, socket_list):

--- a/mig/server/grid_webdavs.py
+++ b/mig/server/grid_webdavs.py
@@ -1950,7 +1950,7 @@ def run(configuration):
         cert = config['ssl_certificate'] = configuration.user_davs_key
         key = config['ssl_private_key'] = configuration.user_davs_key
         chain = config['ssl_certificate_chain'] = ''
-        ciphers = config['ssl_ciphers'] = None
+        ciphers = None
 
     # NOTE: Briefly insert dummy user to avoid bogus warning about anon access
     #       We dynamically add users as they connect so it isn't empty.

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -1603,6 +1603,11 @@ location.""" % self.config_file)
                 'SITE', 'enable_openid')
         else:
             self.site_enable_openid = False
+        if config.has_option('SITE', 'enable_openid_legacy_tls'):
+            self.site_enable_openid_legacy_tls = config.getboolean(
+                'SITE', 'enable_openid_legacy_tls')
+        else:
+            self.site_enable_openid_legacy_tls = False
         if config.has_option('GLOBAL', 'user_openid_address'):
             self.user_openid_address = config.get('GLOBAL',
                                                   'user_openid_address')

--- a/mig/shared/tlsserver.py
+++ b/mig/shared/tlsserver.py
@@ -48,7 +48,7 @@ def hardened_ssl_context(configuration, keyfile, certfile, dhparamsfile=None,
     _logger = configuration.logger
     _logger.info("enforcing strong SSL/TLS connections")
     _logger.debug("using SSL/TLS ciphers: %s" % ciphers)
-    ssl_ctx = ssl.create_default_context()
+    ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ssl_ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ssl_ctx.load_cert_chain(certfile, keyfile)
     ssl_options = 0

--- a/mig/shared/tlsserver.py
+++ b/mig/shared/tlsserver.py
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -40,7 +41,6 @@ from mig.shared.defaults import STRONG_TLS_CIPHERS, STRONG_TLS_CURVES
 def hardened_ssl_context(configuration, keyfile, certfile, dhparamsfile=None,
                          ciphers=STRONG_TLS_CIPHERS,
                          curve_priority=STRONG_TLS_CURVES,
-                         allow_pre_tlsv12=False,
                          allow_pre_tlsv13=True,
                          allow_renegotiation=False,
                          ):
@@ -48,8 +48,8 @@ def hardened_ssl_context(configuration, keyfile, certfile, dhparamsfile=None,
     _logger = configuration.logger
     _logger.info("enforcing strong SSL/TLS connections")
     _logger.debug("using SSL/TLS ciphers: %s" % ciphers)
-    ssl_protocol = ssl.PROTOCOL_SSLv23
-    ssl_ctx = ssl.SSLContext(ssl_protocol)
+    ssl_ctx = ssl.create_default_context()
+    ssl_ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ssl_ctx.load_cert_chain(certfile, keyfile)
     ssl_options = 0
     # NOTE: Override a number of weak and insecure legacy configurations
@@ -58,11 +58,7 @@ def hardened_ssl_context(configuration, keyfile, certfile, dhparamsfile=None,
     ssl_options |= getattr(ssl, 'OP_NO_SSLv2', 0x1000000)
     ssl_options |= getattr(ssl, 'OP_NO_SSLv3', 0x2000000)
     ssl_options |= getattr(ssl, 'OP_NO_TLSv1', 0x4000000)
-    ssl_ctx.minimum_version = ssl.TLSVersion.TLSv1_1
-    # NOTE: refuse weak TLS protocols unless allow_pre_tlsv12
-    if not allow_pre_tlsv12:
-        ssl_options |= getattr(ssl, 'OP_NO_TLSv1_1', 0x10000000)
-        ssl_ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    ssl_options |= getattr(ssl, 'OP_NO_TLSv1_1', 0x10000000)
     # NOTE: refuse slightly dated TLS 1.2 protocol unless allow_pre_tlsv13
     if not allow_pre_tlsv13:
         if getattr(ssl, 'HAS_TLSv1_3', False):
@@ -78,17 +74,13 @@ def hardened_ssl_context(configuration, keyfile, certfile, dhparamsfile=None,
     ssl_options |= getattr(ssl, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000)
     ssl_options |= getattr(ssl, 'OP_SINGLE_ECDH_USE', 0x80000)
     ssl_options |= getattr(ssl, 'OP_SINGLE_DH_USE', 0x100000)
-    # Useful for debugging
-    # ssl_options |= getattr(ssl, 'OP_NO_TICKET',  0x0004000)
-    # ssl_options |= getattr(ssl, 'OP_NO_TLSv1_1', 0x10000000)
-    # ssl_options |= getattr(ssl, 'OP_NO_TLSv1_2', 0x8000000)
-    if sys.version_info[:2] >= (2, 7) and ssl_ctx:
+    if sys.version_info[:2] >= (3, 7) and ssl_ctx:
         _logger.info("enforcing strong SSL/TLS options")
         _logger.debug("SSL/TLS options: %s" % ssl_options)
         ssl_ctx.options |= ssl_options
     else:
         _logger.info("can't enforce strong SSL/TLS options")
-        _logger.warning("Upgrade to python 2.7.9+ for maximum security")
+        _logger.warning("Upgrade to python 3.7+ for maximum security")
 
     pfs_available = False
     if dhparamsfile:
@@ -134,7 +126,6 @@ def hardened_openssl_context(configuration, OpenSSL, keyfile, certfile,
                              cacertfile=None, dhparamsfile=None,
                              ciphers=STRONG_TLS_CIPHERS,
                              curve_priority=STRONG_TLS_CURVES,
-                             allow_pre_tlsv12=False,
                              allow_pre_tlsv13=True,
                              allow_renegotiation=False,
                              ):
@@ -143,8 +134,10 @@ def hardened_openssl_context(configuration, OpenSSL, keyfile, certfile,
     SSL, crypto = OpenSSL.SSL, OpenSSL.crypto
     _logger.info("enforcing strong SSL/TLS connections")
     _logger.debug("using SSL/TLS ciphers: %s" % ciphers)
-    ssl_protocol = SSL.SSLv23_METHOD
-    ssl_ctx = SSL.Context(ssl_protocol)
+    ssl_ctx = SSL.Context(SSL.TLS_SERVER_METHOD)
+    ssl_ctx.set_min_proto_version(SSL.TLS1_2_VERSION)
+    # Mimic native ssl exposure of options
+    ssl_ctx._minimum_version = SSL.TLS1_2_VERSION
     ssl_ctx.use_certificate_chain_file(certfile)
     ssl_ctx.use_privatekey_file(keyfile)
     if cacertfile:
@@ -157,15 +150,7 @@ def hardened_openssl_context(configuration, OpenSSL, keyfile, certfile,
     ssl_options |= getattr(SSL, 'OP_NO_SSLv2', 0x1000000)
     ssl_options |= getattr(SSL, 'OP_NO_SSLv3', 0x2000000)
     ssl_options |= getattr(SSL, 'OP_NO_TLSv1', 0x4000000)
-    ssl_ctx.set_min_proto_version(SSL.TLS1_1_VERSION)
-    # Mimic native ssl exposure of options
-    ssl_ctx._minimum_version = SSL.TLS1_1_VERSION
-    # NOTE: refuse weak TLS protocols unless allow_pre_tlsv12
-    if not allow_pre_tlsv12:
-        ssl_options |= getattr(SSL, 'OP_NO_TLSv1_1', 0x10000000)
-        ssl_ctx.set_min_proto_version(SSL.TLS1_2_VERSION)
-        # Mimic native ssl exposure of options
-        ssl_ctx._minimum_version = SSL.TLS1_2_VERSION
+    ssl_options |= getattr(SSL, 'OP_NO_TLSv1_1', 0x10000000)
     # NOTE: refuse slightly dated TLS 1.2 protocol unless allow_pre_tlsv13
     if not allow_pre_tlsv13:
         # IMPORTANT: OpenSSL doesn't have TLSv1.3 support marker at the moment,
@@ -186,7 +171,7 @@ def hardened_openssl_context(configuration, OpenSSL, keyfile, certfile,
     ssl_options |= getattr(SSL, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000)
     ssl_options |= getattr(SSL, 'OP_SINGLE_ECDH_USE', 0x80000)
     ssl_options |= getattr(SSL, 'OP_SINGLE_DH_USE', 0x100000)
-    if sys.version_info[:2] >= (2, 7) and ssl_ctx:
+    if sys.version_info[:2] >= (3, 7) and ssl_ctx:
         _logger.info("enforcing strong SSL/TLS options")
         _logger.debug("SSL/TLS options: %s" % ssl_options)
         ssl_ctx.set_options(ssl_options)
@@ -194,7 +179,7 @@ def hardened_openssl_context(configuration, OpenSSL, keyfile, certfile,
         ssl_ctx._options = ssl_options
     else:
         _logger.info("can't enforce strong SSL/TLS options")
-        _logger.warning("Upgrade to python 2.7.9+ for maximum security")
+        _logger.warning("Upgrade to python 3.7+ for maximum security")
         # Mimic native ssl exposure of options
         ssl_ctx._options = None
 

--- a/tests/fixture/confs-stdlocal/MiGserver.conf
+++ b/tests/fixture/confs-stdlocal/MiGserver.conf
@@ -586,24 +586,15 @@ enable_sftp_subsys = False
 # Pure Python WsgiDAV-based webdav(s) daemon
 enable_davs = False
 # Allow sub-optimal but still relatively strong legacy TLS support in WebDAVS
-# NOTE: Python-2.7.x ssl supports TLSv1.2+ with strong ciphers and all popular
+# NOTE: Python-2.7+ ssl supports TLSv1.2+ with strong ciphers and all popular
 #       clients (including Windows 10+ native WebDAVS) also work with those.
-# NOTE: Apparently Win 7 (+8.1?) native WebDAVS only works with semi-strong
-#       legacy ciphers and TLSv1.0+v1.1 unless updated and enabled 
-# NOTE: Win 7 went EoL in January 2020 and should no longer be needed
 #enable_davs_legacy_tls = False
 # Pure Python pyftpdlib-based ftp(s) daemon
 enable_ftps = False
 # Allow sub-optimal but still relatively strong legacy TLS supports in FTPS
-# NOTE: Recent PyOpenSSL supports TLSv1.2+ with strong ciphers and all popular
+# NOTE: Modern PyOpenSSL supports TLSv1.2+ with strong ciphers and all popular
 #       clients also work with those.
-# NOTE: CentOS 7 native pyOpenSSL 0.13 does NOT support elliptic curve ciphers
-#       and FileZilla fails on listdir with remaining strong DHE ciphers.
-#       Installing a recent pyopenssl e.g. from the centos-openstack-X repo
-#       allows disabling legacy tls support without breaking FileZilla support.
-# TODO: disable as soon as a recent pyopenssl version is available - the one
-#       from pip breaks paramiko so do NOT go there.
-enable_ftps_legacy_tls = True
+#enable_ftps_legacy_tls = False
 # Enable WSGI served web pages (faster than CGI) - requires apache wsgi module
 enable_wsgi = True
 # Enable system notify helper used e.g. to warn about failed user logins
@@ -638,6 +629,10 @@ peers_explicit_fields =
 peers_contact_hint = employed here and authorized to invite external users
 # Enable OpenID daemon for web access with user/pw from local user DB
 enable_openid = False
+# Allow sub-optimal but still relatively strong legacy TLS support in OpenID 2.0
+# NOTE: Python-2.7+ ssl supports TLSv1.2+ with strong ciphers and all popular
+#       clients also work with those.
+#enable_openid_legacy_tls = False
 # Enable share links for easy external exchange of data with anyone
 enable_sharelinks = True
 # Enable storage quota

--- a/tests/test_mig_shared_tlsserver.py
+++ b/tests/test_mig_shared_tlsserver.py
@@ -185,11 +185,11 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            None,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            False
+            dhparamsfile=None,
+            ciphers=STRONG_TLS_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=True,
+            allow_renegotiation=False
         )
 
         # Verify options are set
@@ -221,11 +221,11 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            False
+            dhparamsfile=TEST_DHPARAMS_FILE,
+            ciphers=STRONG_TLS_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=True,
+            allow_renegotiation=False
         )
 
         # Verify options are set
@@ -257,11 +257,11 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            False,
-            False
+            dhparamsfile=TEST_DHPARAMS_FILE,
+            ciphers=STRONG_TLS_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=False,
+            allow_renegotiation=False
         )
 
         # Verify options are set
@@ -294,11 +294,11 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            True
+            dhparamsfile=TEST_DHPARAMS_FILE,
+            ciphers=STRONG_TLS_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=True,
+            allow_renegotiation=True
         )
 
         # Verify options are set
@@ -327,11 +327,11 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            False
+            dhparamsfile=TEST_DHPARAMS_FILE,
+            ciphers=STRONG_TLS_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=True,
+            allow_renegotiation=False
         )
 
         # Verify options are set
@@ -364,11 +364,11 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            False
+            dhparamsfile=TEST_DHPARAMS_FILE,
+            ciphers=STRONG_TLS_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=True,
+            allow_renegotiation=False
         )
         # NOTE: this may be too platform specific
         expected_start = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:"
@@ -386,11 +386,11 @@ class MigSharedTlsServer(MigTestCase):
             config,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_LEGACY_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            False
+            dhparamsfile=TEST_DHPARAMS_FILE,
+            ciphers=STRONG_TLS_LEGACY_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=True,
+            allow_renegotiation=False
         )
         # NOTE: this may be too platform specific
         expected_start = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:"
@@ -411,12 +411,12 @@ class MigSharedTlsServer(MigTestCase):
             OpenSSL,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_CACERT_FILE,
-            None,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            False
+            cacertfile=TEST_CACERT_FILE,
+            dhparamsfile=None,
+            ciphers=STRONG_TLS_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=True,
+            allow_renegotiation=False
         )
 
         # Verify options are set
@@ -451,12 +451,12 @@ class MigSharedTlsServer(MigTestCase):
             OpenSSL,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_CACERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            False
+            cacertfile=TEST_CACERT_FILE,
+            dhparamsfile=TEST_DHPARAMS_FILE,
+            ciphers=STRONG_TLS_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=True,
+            allow_renegotiation=False
         )
 
         # Verify options are set
@@ -491,12 +491,12 @@ class MigSharedTlsServer(MigTestCase):
             OpenSSL,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_CACERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            False,
-            False
+            cacertfile=TEST_CACERT_FILE,
+            dhparamsfile=TEST_DHPARAMS_FILE,
+            ciphers=STRONG_TLS_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=False,
+            allow_renegotiation=False
         )
 
         # Verify options are set
@@ -532,12 +532,12 @@ class MigSharedTlsServer(MigTestCase):
             OpenSSL,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_CACERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            True
+            cacertfile=TEST_CACERT_FILE,
+            dhparamsfile=TEST_DHPARAMS_FILE,
+            ciphers=STRONG_TLS_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=True,
+            allow_renegotiation=True
         )
 
         # Verify options are set
@@ -569,12 +569,12 @@ class MigSharedTlsServer(MigTestCase):
             OpenSSL,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_CACERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            False
+            cacertfile=TEST_CACERT_FILE,
+            dhparamsfile=TEST_DHPARAMS_FILE,
+            ciphers=STRONG_TLS_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=True,
+            allow_renegotiation=False
         )
 
         # Verify options are set
@@ -610,12 +610,12 @@ class MigSharedTlsServer(MigTestCase):
             OpenSSL,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_CACERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            False
+            cacertfile=TEST_CACERT_FILE,
+            dhparamsfile=TEST_DHPARAMS_FILE,
+            ciphers=STRONG_TLS_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=True,
+            allow_renegotiation=False
         )
         # NOTE: this may be too platform specific
         expected_start = "ECDHE-ECDSA-AES128-GCM-SHA256:"
@@ -636,12 +636,12 @@ class MigSharedTlsServer(MigTestCase):
             OpenSSL,
             TEST_KEY_FILE,
             TEST_CERT_FILE,
-            TEST_CACERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_LEGACY_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            False
+            cacertfile=TEST_CACERT_FILE,
+            dhparamsfile=TEST_DHPARAMS_FILE,
+            ciphers=STRONG_TLS_LEGACY_CIPHERS,
+            curve_priority=STRONG_TLS_CURVES,
+            allow_pre_tlsv13=True,
+            allow_renegotiation=False
         )
         # NOTE: this may be too platform specific
         expected_start = "ECDHE-RSA-AES128-GCM-SHA256:"

--- a/tests/test_mig_shared_tlsserver.py
+++ b/tests/test_mig_shared_tlsserver.py
@@ -188,7 +188,6 @@ class MigSharedTlsServer(MigTestCase):
             None,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
-            False,
             True,
             False
         )
@@ -225,7 +224,6 @@ class MigSharedTlsServer(MigTestCase):
             TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
-            False,
             True,
             False
         )
@@ -250,42 +248,6 @@ class MigSharedTlsServer(MigTestCase):
         minimum_version = context.minimum_version
         self.assertEqual(minimum_version, ssl.TLSVersion.TLSv1_2)
 
-    def test_hardened_ssl_context_options_tls1_1(self):
-        """Test SSL context options are set correctly with TLS 1.1 enabled"""
-        config = self.configuration
-        config.logger = self.logger
-
-        context = hardened_ssl_context(
-            config,
-            TEST_KEY_FILE,
-            TEST_CERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            True,
-            False
-        )
-
-        # Verify options are set
-        expected_options = (
-            getattr(ssl, 'OP_NO_SSLv2', 0x1000000) |
-            getattr(ssl, 'OP_NO_SSLv3', 0x2000000) |
-            getattr(ssl, 'OP_NO_TLSv1', 0x4000000) |
-            getattr(ssl, 'OP_NO_COMPRESSION', 0x20000) |
-            getattr(ssl, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
-            getattr(ssl, 'OP_SINGLE_ECDH_USE', 0x80000) |
-            getattr(ssl, 'OP_SINGLE_DH_USE', 0x100000) |
-            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000)
-        )
-
-        # Verify the options were OR'd into the context
-        options = context.options
-        self.assertEqual(options & expected_options, expected_options)
-        # Verify that the minimum TLS version is enforced
-        minimum_version = context.minimum_version
-        self.assertEqual(minimum_version, ssl.TLSVersion.TLSv1_1)
-
     def test_hardened_ssl_context_options_tls1_3_only(self):
         """Test SSL context options are set correctly with TLS 1.3 only"""
         config = self.configuration
@@ -298,7 +260,6 @@ class MigSharedTlsServer(MigTestCase):
             TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
-            False,
             False,
             False
         )
@@ -336,7 +297,6 @@ class MigSharedTlsServer(MigTestCase):
             TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
-            False,
             True,
             True
         )
@@ -355,45 +315,11 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertNotEqual(
-            context.options & expected_options, expected_options)
-
-    def test_hardened_ssl_context_options_fail_tls1_1(self):
-        """Test SSL context options fail when different"""
-        config = self.configuration
-        config.logger = self.logger
-
-        context = hardened_ssl_context(
-            config,
-            TEST_KEY_FILE,
-            TEST_CERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            True,
-            False
-        )
-
-        # Verify options are set
-        expected_options = (
-            getattr(ssl, 'OP_NO_SSLv2', 0x1000000) |
-            getattr(ssl, 'OP_NO_SSLv3', 0x2000000) |
-            getattr(ssl, 'OP_NO_TLSv1', 0x4000000) |
-            getattr(ssl, 'OP_NO_TLSv1_1', 0x10000000) |
-            getattr(ssl, 'OP_NO_COMPRESSION', 0x20000) |
-            getattr(ssl, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
-            getattr(ssl, 'OP_SINGLE_ECDH_USE', 0x80000) |
-            getattr(ssl, 'OP_SINGLE_DH_USE', 0x100000) |
-            getattr(ssl, 'OP_NO_RENEGOTIATION', 0x40000000)
-        )
-
-        # Verify the options were OR'd into the context
-        self.assertNotEqual(
-            context.options & expected_options, expected_options)
+        options = context.options
+        self.assertNotEqual(options & expected_options, expected_options)
 
     def test_hardened_ssl_context_options_fail_tls1_2(self):
-        """Test SSL context options fail when different"""
+        """Test SSL context options fail when conflicting"""
         config = self.configuration
         config.logger = self.logger
 
@@ -405,7 +331,6 @@ class MigSharedTlsServer(MigTestCase):
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
             True,
-            False,
             False
         )
 
@@ -415,6 +340,7 @@ class MigSharedTlsServer(MigTestCase):
             getattr(ssl, 'OP_NO_SSLv3', 0x2000000) |
             getattr(ssl, 'OP_NO_TLSv1', 0x4000000) |
             getattr(ssl, 'OP_NO_TLSv1_1', 0x10000000) |
+            getattr(ssl, 'OP_NO_TLSv1_2', 0x8000000) |
             getattr(ssl, 'OP_NO_COMPRESSION', 0x20000) |
             getattr(ssl, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
             getattr(ssl, 'OP_SINGLE_ECDH_USE', 0x80000) |
@@ -423,8 +349,11 @@ class MigSharedTlsServer(MigTestCase):
         )
 
         # Verify the options were OR'd into the context
-        self.assertNotEqual(
-            context.options & expected_options, expected_options)
+        options = context.options
+        self.assertNotEqual(options & expected_options, expected_options)
+        # Verify that the minimum TLS version is still enforced
+        minimum_version = context.minimum_version
+        self.assertEqual(minimum_version, ssl.TLSVersion.TLSv1_2)
 
     def test_hardened_ssl_context_ciphers(self):
         """Test SSL context ciphers are set correctly"""
@@ -438,7 +367,6 @@ class MigSharedTlsServer(MigTestCase):
             TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
-            False,
             True,
             False
         )
@@ -461,7 +389,6 @@ class MigSharedTlsServer(MigTestCase):
             TEST_DHPARAMS_FILE,
             STRONG_TLS_LEGACY_CIPHERS,
             STRONG_TLS_CURVES,
-            False,
             True,
             False
         )
@@ -488,7 +415,6 @@ class MigSharedTlsServer(MigTestCase):
             None,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
-            False,
             True,
             False
         )
@@ -529,7 +455,6 @@ class MigSharedTlsServer(MigTestCase):
             TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
-            False,
             True,
             False
         )
@@ -555,46 +480,6 @@ class MigSharedTlsServer(MigTestCase):
         self.assertEqual(minimum_version, SSL.TLS1_2_VERSION)
 
     @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
-    def test_hardened_openssl_context_options_tls1_1(self):
-        """Test OpenSSL context options are set correctly with TLS 1.1 enabled"""
-        config = self.configuration
-        config.logger = self.logger
-        SSL = OpenSSL.SSL
-
-        context = hardened_openssl_context(
-            config,
-            OpenSSL,
-            TEST_KEY_FILE,
-            TEST_CERT_FILE,
-            TEST_CACERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            True,
-            False
-        )
-
-        # Verify options are set
-        expected_options = (
-            getattr(SSL, 'OP_NO_SSLv2', 0x1000000) |
-            getattr(SSL, 'OP_NO_SSLv3', 0x2000000) |
-            getattr(SSL, 'OP_NO_TLSv1', 0x4000000) |
-            getattr(SSL, 'OP_NO_COMPRESSION', 0x20000) |
-            getattr(SSL, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
-            getattr(SSL, 'OP_SINGLE_ECDH_USE', 0x80000) |
-            getattr(SSL, 'OP_SINGLE_DH_USE', 0x100000) |
-            getattr(SSL, 'OP_NO_RENEGOTIATION', 0x40000000)
-        )
-
-        # Verify the options were OR'd into the context
-        options = getattr(context, '_options', None)
-        self.assertEqual(options & expected_options, expected_options)
-        # Verify that the minimum TLS version is enforced
-        minimum_version = getattr(context, '_minimum_version', None)
-        self.assertEqual(minimum_version, SSL.TLS1_1_VERSION)
-
-    @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
     def test_hardened_openssl_context_options_tls1_3_only(self):
         """Test OpenSSL context options are set correctly with TLS 1.3 only"""
         config = self.configuration
@@ -610,7 +495,6 @@ class MigSharedTlsServer(MigTestCase):
             TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
-            False,
             False,
             False
         )
@@ -652,7 +536,6 @@ class MigSharedTlsServer(MigTestCase):
             TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
-            False,
             True,
             True
         )
@@ -675,46 +558,8 @@ class MigSharedTlsServer(MigTestCase):
         self.assertNotEqual(options & expected_options, expected_options)
 
     @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
-    def test_hardened_openssl_context_options_fail_tls1_1(self):
-        """Test OpenSSL context options fail when different"""
-        config = self.configuration
-        config.logger = self.logger
-        SSL = OpenSSL.SSL
-
-        context = hardened_openssl_context(
-            config,
-            OpenSSL,
-            TEST_KEY_FILE,
-            TEST_CERT_FILE,
-            TEST_CACERT_FILE,
-            TEST_DHPARAMS_FILE,
-            STRONG_TLS_CIPHERS,
-            STRONG_TLS_CURVES,
-            True,
-            True,
-            False
-        )
-
-        # Verify options are set
-        expected_options = (
-            getattr(SSL, 'OP_NO_SSLv2', 0x1000000) |
-            getattr(SSL, 'OP_NO_SSLv3', 0x2000000) |
-            getattr(SSL, 'OP_NO_TLSv1', 0x4000000) |
-            getattr(SSL, 'OP_NO_TLSv1_1', 0x10000000) |
-            getattr(SSL, 'OP_NO_COMPRESSION', 0x20000) |
-            getattr(SSL, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
-            getattr(SSL, 'OP_SINGLE_ECDH_USE', 0x80000) |
-            getattr(SSL, 'OP_SINGLE_DH_USE', 0x100000) |
-            getattr(SSL, 'OP_NO_RENEGOTIATION', 0x40000000)
-        )
-
-        # Verify the options were OR'd into the context
-        options = getattr(context, '_options', None)
-        self.assertNotEqual(options & expected_options, expected_options)
-
-    @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
     def test_hardened_openssl_context_options_fail_tls1_2(self):
-        """Test OpenSSL context options fail when different"""
+        """Test OpenSSL context options fail when conflicting"""
         config = self.configuration
         config.logger = self.logger
         SSL = OpenSSL.SSL
@@ -729,7 +574,6 @@ class MigSharedTlsServer(MigTestCase):
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
             True,
-            False,
             False
         )
 
@@ -739,6 +583,7 @@ class MigSharedTlsServer(MigTestCase):
             getattr(SSL, 'OP_NO_SSLv3', 0x2000000) |
             getattr(SSL, 'OP_NO_TLSv1', 0x4000000) |
             getattr(SSL, 'OP_NO_TLSv1_1', 0x10000000) |
+            getattr(SSL, 'OP_NO_TLSv1_2', 0x8000000) |
             getattr(SSL, 'OP_NO_COMPRESSION', 0x20000) |
             getattr(SSL, 'OP_CIPHER_SERVER_PREFERENCE', 0x400000) |
             getattr(SSL, 'OP_SINGLE_ECDH_USE', 0x80000) |
@@ -749,6 +594,9 @@ class MigSharedTlsServer(MigTestCase):
         # Verify the options were OR'd into the context
         options = getattr(context, '_options', None)
         self.assertNotEqual(options & expected_options, expected_options)
+        # Verify that the minimum TLS version is still enforced
+        minimum_version = getattr(context, '_minimum_version', None)
+        self.assertEqual(minimum_version, SSL.TLS1_2_VERSION)
 
     @unittest.skipIf(OpenSSL is None, "pyOpenSSL is required for openssl test")
     def test_hardened_openssl_context_ciphers(self):
@@ -766,7 +614,6 @@ class MigSharedTlsServer(MigTestCase):
             TEST_DHPARAMS_FILE,
             STRONG_TLS_CIPHERS,
             STRONG_TLS_CURVES,
-            False,
             True,
             False
         )
@@ -793,7 +640,6 @@ class MigSharedTlsServer(MigTestCase):
             TEST_DHPARAMS_FILE,
             STRONG_TLS_LEGACY_CIPHERS,
             STRONG_TLS_CURVES,
-            False,
             True,
             False
         )


### PR DESCRIPTION
Drop unused TLSv1.1 support completely in `tlsserver` module and align `enable_SVC_legacy_tls` conf options across services to only enable older compatibility ciphers over the same TLSv1.2+ protocols. Adjust unit tests accordingly.
Should make it clear even for code scans that we always enforce TLSv1.2+ everywhere.

Tested on one of our dev/test deployments in:
 1. default configuration (all `enable_SVC_legacy_tls = False`)
 2. with all legacy ciphers (all `enable_SVC_legacy_tls = True`)
 3. with TLSv1.3 only (`allow_pre_tlsv13` manually toggled off in `tlsserver.py`)

and the scan results with `testssl.sh` look sane for all three.

NOTE: this PR incorporates the pending #504 so it should be rebased after that one is reviewed and merged.