### PR TITLE
Rework email sending to operate via a notification context

### DIFF
--- a/mig/server/grid_notify.py
+++ b/mig/server/grid_notify.py
@@ -130,12 +130,10 @@ def send_notifications(configuration):
         notify_message = "Found %s new events since: %s\n\n" \
             % (total_events, timestr) \
             + notify_message
-        status = send_email(
+        status = send_email(configuration,
             recipient,
             subject,
-            notify_message,
-            logger,
-            configuration)
+            notify_message)
         if status:
             logger.info("Send email with %s events to: %s"
                         % (total_events, recipient))

--- a/mig/shared/conf.py
+++ b/mig/shared/conf.py
@@ -75,11 +75,6 @@ class RuntimeConfiguration:
         """
         self._context[context_key] = context_value
 
-    @classmethod
-    def is_runtime_configuration(cls, obj):
-        """Is the given object a runtime configuration."""
-        return isinstance(obj, cls)
-
 
 def get_configuration_object(config_file=None,
                              skip_log=False,

--- a/mig/shared/functionality/accountaction.py
+++ b/mig/shared/functionality/accountaction.py
@@ -141,11 +141,10 @@ Renewed account:
         email_msg = email_header + email_msg_template
         recipient = user_dict.get('email', '')
         # Notify user
-        notify_status = send_email(recipient,
+        notify_status = send_email(configuration,
+                                   recipient,
                                    email_subject,
-                                   email_msg,
-                                   _logger,
-                                   configuration)
+                                   email_msg)
         if not notify_status:
             _logger.error("Failed to send account renew notification to %s"
                           % recipient)
@@ -155,11 +154,10 @@ Renewed account:
             email_header = "Your %s external peer made an account renewal\n\n" \
                 % configuration.short_title
             email_msg = email_header + email_msg_template
-            notify_status = send_email(recipient,
+            notify_status = send_email(configuration,
+                                       recipient,
                                        email_subject,
-                                       email_msg,
-                                       _logger,
-                                       configuration)
+                                       email_msg)
             if not notify_status:
                 _logger.error("Failed to send account renew notification" \
                               + " to peer %s" % recipient)

--- a/mig/shared/functionality/autocreate.py
+++ b/mig/shared/functionality/autocreate.py
@@ -740,8 +740,7 @@ The %(short_title)s Admins
         logger.info('Send email: to: %s, header: %s, smtp_server: %s'
                     % (email, email_header, smtp_server))
         logger.debug('email body:  %s' % email_msg)
-        if not send_email(email, email_header, email_msg, logger,
-                          configuration):
+        if not send_email(configuration, email, email_header, email_msg):
             output_objects.append({
                 'object_type': 'error_text', 'text': """An error occurred trying
 to send your account welcome email. Please contact support (%s) and include the

--- a/mig/shared/functionality/extcertaction.py
+++ b/mig/shared/functionality/extcertaction.py
@@ -316,8 +316,7 @@ Command to delete user again on %(site)s server:
 
     logger.info('Sending email: to: %s, header: %s, msg: %s, smtp_server: %s'
                 % (admin_email, email_header, email_msg, smtp_server))
-    if not send_email(admin_email, email_header, email_msg, logger,
-                      configuration):
+    if not send_email(configuration, admin_email, email_header, email_msg):
         output_objects.append({'object_type': 'error_text', 'text':
                                """An error occurred trying to inform the site
 admins about your request for existing certificate sign up. Please contact %s site

--- a/mig/shared/functionality/extoidaction.py
+++ b/mig/shared/functionality/extoidaction.py
@@ -282,8 +282,7 @@ Command to delete user again on %(site)s server:
 
     logger.info('Sending email: to: %s, header: %s, msg: %s, smtp_server: %s'
                 % (admin_email, email_header, email_msg, smtp_server))
-    if not send_email(admin_email, email_header, email_msg, logger,
-                      configuration):
+    if not send_email(configuration, admin_email, email_header, email_msg):
         output_objects.append({'object_type': 'error_text', 'text':
                                """An error occurred trying to inform the site
 admins about your request for OpenID account access. Please contact %s site

--- a/mig/shared/functionality/peersaction.py
+++ b/mig/shared/functionality/peersaction.py
@@ -309,8 +309,7 @@ site administrators (%s).
                     logger.info('Sending invitation: to: %s, header: %s, msg: %s, smtp_server: %s'
                                 % (peer_email, email_header, email_msg,
                                    smtp_server))
-                    if send_email(peer_email, email_header, email_msg, logger,
-                                  configuration):
+                    if send_email(configuration, peer_email, email_header, email_msg):
                         succeeded.append(peer_email)
                     else:
                         failed.append(peer_email)
@@ -369,8 +368,7 @@ Kind: %(kind)s , Expire: %(expire)s, Label: %(label)s , Peers:
 
     logger.info('Sending email: to: %s, header: %s, msg: %s, smtp_server: %s'
                 % (admin_email, email_header, email_msg, smtp_server))
-    if not send_email(admin_email, email_header, email_msg, logger,
-                      configuration):
+    if not send_email(configuration, admin_email, email_header, email_msg):
         output_objects.append({'object_type': 'error_text', 'text': '''
 An error occurred trying to send the email about your %s peers to the site
 administrators. Please contact %s site support at %s or manually inform the

--- a/mig/shared/functionality/reqcertaction.py
+++ b/mig/shared/functionality/reqcertaction.py
@@ -346,8 +346,7 @@ Command to delete user again on %(site)s server:
 
     logger.info('Sending email: to: %s, header: %s, msg: %s, smtp_server: %s'
                 % (admin_email, email_header, email_msg, smtp_server))
-    if not send_email(admin_email, email_header, email_msg, logger,
-                      configuration):
+    if not send_email(configuration, admin_email, email_header, email_msg):
         output_objects.append({'object_type': 'error_text', 'text':
                                """An error occurred trying to inform the site
 admins about your request for certificate sign up. Please contact %s site

--- a/mig/shared/functionality/reqoidaction.py
+++ b/mig/shared/functionality/reqoidaction.py
@@ -357,8 +357,7 @@ Command to delete user again on %(site)s server:
 
     logger.info('Sending email: to: %s, header: %s, msg: %s, smtp_server: %s'
                 % (admin_email, email_header, email_msg, smtp_server))
-    if not send_email(admin_email, email_header, email_msg, logger,
-                      configuration):
+    if not send_email(configuration, admin_email, email_header, email_msg):
         output_objects.append({'object_type': 'error_text', 'text':
                                """An error occurred trying to inform the site
 admins about your request for OpenID account access. Please contact %s site

--- a/mig/shared/functionality/reqpwresetaction.py
+++ b/mig/shared/functionality/reqpwresetaction.py
@@ -271,8 +271,7 @@ mind about it you can safely just ignore this message.
 
         logger.info('Sending email: to: %s, header: %s, msg: %s, smtp_server: %s'
                     % (email_to, email_header, email_msg, smtp_server))
-        if not send_email(email_to, email_header, email_msg, logger,
-                          configuration):
+        if not send_email(configuration, email_to, email_header, email_msg):
             output_objects.append({'object_type': 'error_text', 'text':
                                    """An error occurred trying to send the email
 for an account %s password reset request. Please contact %s site support at %s

--- a/mig/shared/gdp/base.py
+++ b/mig/shared/gdp/base.py
@@ -683,12 +683,10 @@ in reaction to the %(action)s for %(project_name)s .
 
 Attached you'll find the details registered in relation to the operation.
         """ % mail_fill
-        status = send_email(
+        status = send_email(configuration,
             recipients,
             subject,
             message,
-            _logger,
-            configuration,
             files=[pdf_filepath],
         )
         if status:

--- a/mig/shared/notification.py
+++ b/mig/shared/notification.py
@@ -52,6 +52,7 @@ except ImportError as ierr:
 
 from mig.shared.base import force_utf8, generate_https_urls, extract_field, \
     canonical_user_with_peers, cert_field_map, get_site_base_url
+from mig.shared.conf import RuntimeConfiguration
 from mig.shared.defaults import email_keyword_list, job_output_dir, \
     transfer_output_dir, keyword_auto, cert_auto_extend_days, \
     oid_auto_extend_days
@@ -561,11 +562,35 @@ def send_instant_message(
 
 
 def send_email(
+        configuration,
+        recipients,
+        subject,
+        message,
+        files=[],
+        custom_sender=None):
+    """Send email to recipients via the actively configured method."""
+
+    assert RuntimeConfiguration.is_runtime_configuration(configuration)
+
+    notifier = configuration.context_get('notifier')
+    if not notifier:
+        notifier = Notifier(configuration)
+        configuration.context_set('notifier', notifier)
+
+    return notifier.send_email(
+        recipients,
+        subject,
+        message,
+        files=files,
+        custom_sender=custom_sender,
+    )
+
+
+def direct_send_email(
+    configuration,
     recipients,
     subject,
     message,
-    logger,
-    configuration,
     files=[],
     custom_sender=None
 ):
@@ -589,13 +614,14 @@ def send_email(
     """
 
     _logger = configuration.logger
+
     gpg_sign = False
     if configuration.site_gpg_passphrase is not None:
         if gnupg is None:
-            logger.warning("the gnupg module is required for gpg signing")
+            _logger.warning("the gnupg module is required for gpg signing")
         else:
             gpg_sign = True
-            logger.debug("enabling automatic gpg signing of email")
+            _logger.debug("enabling automatic gpg signing of email")
 
     if recipients.find(', ') > -1:
         recipients_list = recipients.split(', ')
@@ -631,7 +657,7 @@ def send_email(
         basemsg = MIMEText(force_utf8(message), "plain", "utf8")
         mime_msg.attach(basemsg)
         if gpg_sign:
-            logger.info("signing message with gpg")
+            _logger.info("signing message with gpg")
             gpg = gnupg.GPG()
             basetext = basemsg.as_string().replace('\n', '\r\n')
             signature = gpg.sign(basetext, detach=True,
@@ -643,7 +669,7 @@ def send_email(
                 msg_sig.set_payload("%s" % signature)
                 mime_msg.attach(msg_sig)
             else:
-                logger.warning("failed to create gnupg signature")
+                _logger.warning("failed to create gnupg signature")
 
         for name in files:
             part = MIMEBase('application', "octet-stream")
@@ -652,7 +678,7 @@ def send_email(
             part.add_header('Content-Disposition',
                             'attachment', filename=os.path.basename(name))
             mime_msg.attach(part)
-        logger.debug('sending email from %s to %s:\n%s' %
+        _logger.debug('sending email from %s to %s:\n%s' %
                      (from_email, recipients, mime_msg.as_string()))
         server = smtplib.SMTP(configuration.smtp_server)
         server.set_debuglevel(0)
@@ -664,10 +690,10 @@ def send_email(
                             % errors)
             return False
         else:
-            logger.debug('Email was sent to %s' % recipients)
+            _logger.debug('Email was sent to %s' % recipients)
             return True
     except Exception as err:
-        logger.error('Sending email to %s through %s failed!: %s'
+        _logger.error('Sending email to %s through %s failed!: %s'
                      % (recipients, configuration.smtp_server, err))
         return False
 
@@ -819,8 +845,8 @@ def notify_user(
 
                     continue
 
-                if send_email(single_dest, header, message, logger,
-                              configuration, custom_sender=email_sender):
+                if send_email(configuration, single_dest, header, message,
+                              custom_sender=email_sender):
                     logger.info('email sent to %s telling that %s %s'
                                 % (single_dest, jobid, status))
                 else:
@@ -906,7 +932,7 @@ Resource creation command to run from 'mig' base directory:
         os.path.basename(pending_file),
     )
 
-    status = send_email(recipients, subject, txt, logger, configuration)
+    status = send_email(configuration, recipients, subject, txt)
     if status:
         msg += '\nEmail was sent to admins'
     else:
@@ -961,3 +987,13 @@ def send_system_notification(user_id, category, message, configuration):
     return send_message_to_grid_notify(pickled_notification,
                                        configuration.logger,
                                        configuration)
+
+
+class Notifier:
+    def __init__(self, configuration):
+        self.configuration = configuration
+
+    def send_email(self, recipients, subject, message, files=[], custom_sender=None):
+        return direct_send_email(self.configuration, recipients, subject, message,
+                                                        files=[],
+                                                        custom_sender=None)

--- a/mig/shared/notification.py
+++ b/mig/shared/notification.py
@@ -570,8 +570,6 @@ def send_email(
         custom_sender=None):
     """Send email to recipients via the actively configured method."""
 
-    assert RuntimeConfiguration.is_runtime_configuration(configuration)
-
     notifier = configuration.context_get('notifier')
     if not notifier:
         notifier = Notifier(configuration)

--- a/mig/shared/notification.py
+++ b/mig/shared/notification.py
@@ -990,10 +990,27 @@ def send_system_notification(user_id, category, message, configuration):
 
 
 class Notifier:
+    """
+    Instances of this class provide bound notification primitives to other
+    logic which can be persisted for the duration of a request.
+    """
+
     def __init__(self, configuration):
         self.configuration = configuration
 
-    def send_email(self, recipients, subject, message, files=[], custom_sender=None):
-        return direct_send_email(self.configuration, recipients, subject, message,
-                                                        files=[],
-                                                        custom_sender=None)
+    def send_email(
+        self, recipients, subject, message, files=[], custom_sender=None
+    ):
+        """
+        Email sending notification primitive whose output is done via
+        a direct connection to an SMTP service.
+        """
+
+        return direct_send_email(
+            self.configuration,
+            recipients,
+            subject,
+            message,
+            files=files,
+            custom_sender=custom_sender,
+        )

--- a/tests/fixture/mig_shared_configuration--new.json
+++ b/tests/fixture/mig_shared_configuration--new.json
@@ -29,7 +29,6 @@
   "ca_user": "mig-ca",
   "certs_path": "/some/place/certs",
   "cloud_services": [],
-  "config_file": null,
   "cputime_for_empty_jobs": 0,
   "default_page": [
     ""
@@ -81,14 +80,12 @@
   ],
   "log_dir": "",
   "logfile": "",
-  "logger": null,
   "logger_obj": null,
   "loglevel": "",
   "lrmstypes": [],
   "mig_code_base": "",
   "mig_path": "/some/place/mig",
   "mig_server_home": "",
-  "mig_server_id": null,
   "mig_system_files": "",
   "mig_system_run": "",
   "mig_system_storage": "",

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -48,6 +48,7 @@ from tests.support.fixturesupp import _PreparedFixture
 from tests.support.suppconst import MIG_BASE, TEST_BASE, \
     TEST_DATA_DIR, TEST_OUTPUT_DIR, ENVHELP_OUTPUT_DIR
 from tests.support.usersupp import UserAssertMixin
+import tests.support.fakes as fakes
 
 from tests.support._env import MIG_ENV, PY2
 
@@ -251,6 +252,8 @@ class MigTestCase(TestCase):
             os.mkdir(log_path)
 
         self._configuration = configuration_instance
+
+        fakes.instrument_test_case(self, self._configuration)
 
         return configuration_instance
 

--- a/tests/support/fakes.py
+++ b/tests/support/fakes.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# __init__ - package marker and core package functions
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# -- END_HEADER ---
+#
+
+import inspect
+from types import SimpleNamespace
+
+
+"""Fake implementations of various assistant functionality used by MiG logic."""
+
+class FakeSendEmail:
+    """
+    Fake for the interception of email sending calls.
+    """
+
+    def __init__(self):
+        self.calls = []
+        self._checked = False
+
+    def __call__(self, *args, **kwargs):
+        # Record any arguments upon a call to send email (discarding the
+        # leading configuration argument)
+        self.calls.append((args, kwargs))
+        return True
+
+    def _recipients(self):
+        recipients = set()
+        for args, kwargs in self.calls:
+            email_address = args[0]
+            recipients.add(email_address)
+        return recipients
+
+    def check_empty_and_reset(self):
+        if self._checked:
+            # nothing to do
+            return
+
+        has_calls = len(self.calls) > 0
+        if has_calls:
+            suprise_recipients = []
+            for args, kwargs in self.calls:
+                email_address = args[0]
+                suprise_recipients.append(email_address)
+            raise AssertionError('detected email sending without expectation: \n  %s'
+                                    % ('\n  '.join(suprise_recipients),))
+
+    def forgive_email(self):
+        self._checked = True
+
+    @property
+    def called_once(self):
+        self._checked = True
+        return len(self.calls) == 1
+
+    def email_was_sent_to(self, email_address):
+        recipients = self._recipients()
+        assert email_address in recipients, \
+                f"no email was not set to recipient: {email_address}"
+        self._checked = True
+        return email_address in recipients
+
+
+def make_fake_notifier(mig_test_case=None):
+    fake_send_email = FakeSendEmail()
+
+    if mig_test_case:
+        mig_test_case._register_check(fake_send_email.check_empty_and_reset)
+
+    return SimpleNamespace(send_email=fake_send_email)
+
+
+def instrument_test_case(mig_test_case=None, mig_configuration=None):
+    assert inspect.ismethod(getattr(mig_configuration, 'context_set', None)), \
+            "supplied configuration must be usable at runtime"
+
+    fakes_by_context_key = {
+        'notifier': make_fake_notifier(mig_test_case=mig_test_case),
+    }
+    for content_key, context_value in fakes_by_context_key.items():
+        mig_configuration.context_set(content_key, context_value)

--- a/tests/support/fakes.py
+++ b/tests/support/fakes.py
@@ -24,11 +24,11 @@
 # -- END_HEADER ---
 #
 
+"""Fake implementations of various assistant functionality used by MiG logic."""
+
 import inspect
 from types import SimpleNamespace
 
-
-"""Fake implementations of various assistant functionality used by MiG logic."""
 
 class FakeSendEmail:
     """
@@ -59,12 +59,14 @@ class FakeSendEmail:
 
         has_calls = len(self.calls) > 0
         if has_calls:
-            suprise_recipients = []
+            surprise_recipients = []
             for args, kwargs in self.calls:
                 email_address = args[0]
-                suprise_recipients.append(email_address)
-            raise AssertionError('detected email sending without expectation: \n  %s'
-                                    % ('\n  '.join(suprise_recipients),))
+                surprise_recipients.append(email_address)
+            raise AssertionError(
+                "detected email sending without expectation: \n  %s"
+                % ("\n  ".join(surprise_recipients),)
+            )
 
     def forgive_email(self):
         self._checked = True
@@ -76,8 +78,9 @@ class FakeSendEmail:
 
     def email_was_sent_to(self, email_address):
         recipients = self._recipients()
-        assert email_address in recipients, \
-                f"no email was not set to recipient: {email_address}"
+        assert (
+            email_address in recipients
+        ), "no email was not set to recipient: %s" % (email_address,)
         self._checked = True
         return email_address in recipients
 
@@ -92,11 +95,12 @@ def make_fake_notifier(mig_test_case=None):
 
 
 def instrument_test_case(mig_test_case=None, mig_configuration=None):
-    assert inspect.ismethod(getattr(mig_configuration, 'context_set', None)), \
-            "supplied configuration must be usable at runtime"
+    assert inspect.ismethod(
+        getattr(mig_configuration, "context_set", None)
+    ), "supplied configuration must be usable at runtime"
 
     fakes_by_context_key = {
-        'notifier': make_fake_notifier(mig_test_case=mig_test_case),
+        "notifier": make_fake_notifier(mig_test_case=mig_test_case),
     }
     for content_key, context_value in fakes_by_context_key.items():
         mig_configuration.context_set(content_key, context_value)

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -329,6 +329,10 @@ class MigLibJanitor(MigTestCase):
         # self.assertEqual(handled, 1)
         self.assertEqual(handled, 2)  # counted stale and expired (see above)
 
+        fake_send_email = self.configuration.context_get('notifier').send_email
+        self.assertTrue(fake_send_email.called_once)
+        self.assertTrue(fake_send_email.email_was_sent_to('test@example.com'))
+
     def test_handle_pending_requests(self):
         """Test combined request handling"""
         # Create requests (valid, expired)
@@ -379,8 +383,13 @@ class MigLibJanitor(MigTestCase):
         # self.assertEqual(handled, 2)  # 1 manage + 1 expire
         self.assertEqual(handled, 3)  # 1 manage + 1 expire + 1 stale
 
+        fake_send_email = self.configuration.context_get('notifier').send_email
+        self.assertTrue(fake_send_email.called_once)
+        self.assertTrue(fake_send_email.email_was_sent_to('test@example.com'))
+
     def test_handle_janitor_tasks_full(self):
         """Test full janitor task scheduler"""
+        self.configuration.context_get('notifier').send_email.forgive_email()
         # Prepare environment with pending tasks of each kind
         mig_stamp = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1
         mig_path = os.path.join(self.configuration.mig_system_files,
@@ -497,9 +506,13 @@ class MigLibJanitor(MigTestCase):
 
         self.assertTrue(any('invalid account request' in msg
                             for msg in log_capture.output))
-        # TODO: enable check for removed req once skip email allows it
-        # self.assertFalse(os.path.exists(req_path),
-        #                 "Failed to clean invalid req for %s" % req_path)
+        self.assertFalse(os.path.exists(req_path),
+                        "Failed to clean invalid req for %s" % req_path)
+
+        # FIXME: should this really be sending email?
+        fake_send_email = self.configuration.context_get('notifier').send_email
+        self.assertTrue(fake_send_email.called_once)
+        self.assertTrue(fake_send_email.email_was_sent_to('test@example.com'))
 
     def test_manage_single_req_expired_token(self):
         """Test request handling with expired reset token"""
@@ -540,12 +553,15 @@ class MigLibJanitor(MigTestCase):
 
         self.assertTrue(any('reject expired reset token' in msg
                             for msg in log_capture.output))
-        # TODO: enable check for removed req once skip email allows it
-        # self.assertFalse(os.path.exists(req_path),
-        #                 "Failed to clean token req for %s" % req_path)
+        self.assertFalse(os.path.exists(req_path),
+                        "Failed to clean token req for %s" % req_path)
+
+        fake_send_email = self.configuration.context_get('notifier').send_email
+        self.assertTrue(fake_send_email.called_once)
+        self.assertTrue(fake_send_email.email_was_sent_to('test@example.com'))
 
     @unittest.skip("TODO: enable once fernet decrypt err handling is improved")
-    def test_manage_single_req_invalid_token(self):
+    def test_manage_single_req_invalid_token_decrypt(self):
         """Test request handling with invalid reset token"""
         req_dict = {
             'client_id': TEST_USER_DN,
@@ -578,6 +594,11 @@ class MigLibJanitor(MigTestCase):
                             for msg in log_capture.output))
         self.assertFalse(os.path.exists(req_path),
                          "Failed to clean token req for %s" % req_path)
+
+        # FIXME: should this really be sending an email?
+        fake_send_email = self.configuration.context_get('notifier').send_email
+        self.assertTrue(fake_send_email.called_once)
+        self.assertTrue(fake_send_email.email_was_sent_to('test@example.com'))
 
     def test_manage_single_req_collision(self):
         """Test request handling with existing user collision"""
@@ -612,9 +633,14 @@ class MigLibJanitor(MigTestCase):
             )
             self.assertTrue(any('ID collision' in msg
                                 for msg in log_capture.output))
-        # TODO: enable check for removed req once skip email allows it
-        # self.assertFalse(os.path.exists(req_path),
-        #                 "Failed cleanup collision for %s" % req_path)
+
+        self.assertFalse(os.path.exists(req_path),
+                         "Failed cleanup collision for %s" % req_path)
+
+        fake_send_email = self.configuration.context_get('notifier').send_email
+        self.assertTrue(fake_send_email.called_once)
+        self.assertTrue(fake_send_email.email_was_sent_to('test@example.com'))
+
 
     def test_manage_single_req_auth_change(self):
         """Test request handling with auth password change"""
@@ -636,10 +662,6 @@ class MigLibJanitor(MigTestCase):
         saved, req_path = save_account_request(self.configuration, req_dict)
         req_id = os.path.basename(req_path)
 
-        # NOTE: when using real user mail we currently hit send email errors.
-        #       We forgive those errors here and only check any known warnings.
-        # TODO: integrate generic skip email support and adjust here to fit
-        self.logger.forgive_errors()
         with self.assertLogs(level='INFO') as log_capture:
             manage_single_req(
                 self.configuration,
@@ -653,6 +675,10 @@ class MigLibJanitor(MigTestCase):
             any('accepted' in msg for msg in log_capture.output))
         self.assertFalse(os.path.exists(req_path),
                          "Failed to clean token req for %s" % req_path)
+
+        fake_send_email = self.configuration.context_get('notifier').send_email
+        self.assertTrue(fake_send_email.called_once)
+        self.assertTrue(fake_send_email.email_was_sent_to('test@example.com'))
 
     def test_handle_cache_updates_stub(self):
         """Test handle_cache_updates placeholder returns zero"""
@@ -801,9 +827,13 @@ class MigLibJanitor(MigTestCase):
 
         self.assertTrue(any('wrong hash' in msg.lower()
                             for msg in log_capture.output))
-        # TODO: enable check for removed req once skip email allows it
-        # self.assertFalse(os.path.exists(req_path),
-        #                 "Failed cleanup invalid token for %s" % req_path)
+        self.assertFalse(os.path.exists(req_path),
+                        "Failed cleanup invalid token for %s" % req_path)
+
+        # FIXME: should this really be sending email?
+        fake_send_email = self.configuration.context_get('notifier').send_email
+        self.assertTrue(fake_send_email.called_once)
+        self.assertTrue(fake_send_email.email_was_sent_to('test@example.com'))
 
     def test_verify_reset_token_success(self):
         """Test token verification success with valid token"""
@@ -843,12 +873,16 @@ class MigLibJanitor(MigTestCase):
 
         self.assertTrue(any('accepted' in msg.lower()
                             for msg in log_capture.output))
-        # TODO: enable check for removed req once skip email allows it
-        # self.assertFalse(os.path.exists(req_path),
-        #                 "Failed cleanup invalid token for %s" % req_path)
+        self.assertFalse(os.path.exists(req_path),
+                        "Failed cleanup invalid token for %s" % req_path)
+
+        fake_send_email = self.configuration.context_get('notifier').send_email
+        self.assertTrue(fake_send_email.called_once)
+        self.assertTrue(fake_send_email.email_was_sent_to('test@example.com'))
 
     def test_remind_and_expire_edge_cases(self):
         """Test request expiration with exact boundary timestamps"""
+        self.configuration.context_get('notifier').send_email.forgive_email()
         now = time.time()
         test_cases = [
             ('exact_remind', now - REMIND_REQ_DAYS * SECS_PER_DAY),
@@ -991,10 +1025,7 @@ class MigLibJanitor(MigTestCase):
         # Verify initial existence
         self.assertTrue(os.path.exists(req_path))
 
-        # NOTE: when using real user mail we currently hit send email errors.
-        #       We forgive those errors here and only check any known warnings.
-        # TODO: integrate generic skip email support and adjust here to fit
-        self.logger.forgive_errors()
+
         manage_single_req(
             self.configuration,
             req_id,
@@ -1003,9 +1034,12 @@ class MigLibJanitor(MigTestCase):
             time.time()
         )
 
-        # TODO: enable check for removed req once skip email allows it
-        # self.assertFalse(os.path.exists(req_path),
-        #                 "Failed cleanup after reject for %s" % req_path)
+        self.assertFalse(os.path.exists(req_path),
+                        "Failed cleanup after reject for %s" % req_path)
+
+        fake_send_email = self.configuration.context_get('notifier').send_email
+        fake_send_email.email_was_sent_to('test@example.com')
+
 
     def test_cleaner_with_multiple_patterns(self):
         """Test state cleaner with multiple filename patterns"""

--- a/tests/test_mig_shared_accountreq.py
+++ b/tests/test_mig_shared_accountreq.py
@@ -156,6 +156,10 @@ class MigSharedAccountreq__peers(MigTestCase, FixtureAssertMixin):
 
         self.assertTrue(success)
 
+        fake_send_email = self.configuration.context_get('notifier').send_email
+        self.assertTrue(fake_send_email.called_once)
+        self.assertTrue(fake_send_email.email_was_sent_to('peer@example.com'))
+
 
 class MigSharedAccountreq__filters(MigTestCase, UserAssertMixin):
     """Unit tests for filter related functions within the accountreq module"""

--- a/tests/test_mig_shared_configuration.py
+++ b/tests/test_mig_shared_configuration.py
@@ -38,11 +38,6 @@ from mig.shared.configuration import Configuration, \
     _CONFIGURATION_ARGUMENTS, _CONFIGURATION_PROPERTIES
 
 
-def _to_dict(obj):
-    return {k: v for k, v in inspect.getmembers(obj)
-            if not (k.startswith('__') or inspect.ismethod(v) or inspect.isfunction(v))}
-
-
 class MigSharedConfiguration__static_definitions(MigTestCase):
     """Coverage of the static definitions underlying Configuration objects."""
 
@@ -349,7 +344,7 @@ class MigSharedConfiguration__new_instance(MigTestCase, FixtureAssertMixin):
         configuration.state_path = '/some/place/state'
         configuration.mig_path = '/some/place/mig'
 
-        actual_values = _to_dict(configuration)
+        actual_values = Configuration.to_dict(configuration)
 
         prepared_fixture.assertAgainstFixture(actual_values)
 


### PR DESCRIPTION
With the context support offered by RuntimeConfiguration in hand, rework email sending to be context aware - that is, one can simply make use of send_email as before. Internally it will check whether sending was previously done (by consulting the context) and skip any construction steps if so.

As a result of this small change, we become able to centrally intercept email sending without threading arguments through multiple levels of the call stack of logic code purely to override email sending and we can do useful general enforcement.

Add a means for tests to check the the number of emails sent and whether an email was sent to a particular recipient. By default, enforce disallowing unexpected outgoing emails. This has the effect of nudging test writers to account for emails as a covered side effect of the logic being exercised. For cases where the email send is not relevant t, there is an escape hatch.