### PR TITLE
Pull in the actual code format and lint bits from PR497 (thanks @albu-diku)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,9 @@ ifndef PY
 	PY = 3
 endif
 
-FORMAT_ENFORCE_DIRS = state/
-FORMAT_EXCLUDE_REGEX = '.*'
-FORMAT_EXCLUDE_GLOB = '*'
-FORMAT_LINE_LENGTH = 80
-
+# TODO: enable on these dirs when ready, but just leave to dummy init for now
+#LINT_ENFORCE_DIRS = ./bin ./mig/lib ./sbin ./tests
+LINT_ENFORCE_DIRS = ./mig/__init__.py
 LOCAL_PYTHON_BIN = './envhelp/lpython'
 
 ifdef PYTHON_BIN
@@ -42,15 +40,11 @@ ifneq ($(MIG_ENV),'local')
 endif
 	@make format-python
 
-.PHONY:format-python
+# NOTE: black and isort use pyproject.toml to temporarily exclude a few paths
+.PHONY: format-python
 format-python:
-	@$(LOCAL_PYTHON_BIN) -m black $(FORMAT_ENFORCE_DIRS) \
-			--line-length=$(FORMAT_LINE_LENGTH) \
-			--exclude=$(FORMAT_EXCLUDE_REGEX)
-	@$(LOCAL_PYTHON_BIN) -m isort $(FORMAT_ENFORCE_DIRS) \
-			--profile=black \
-			--line-length=$(FORMAT_LINE_LENGTH) \
-			--skip-glob=$(FORMAT_EXCLUDE_GLOB)
+	@$(LOCAL_PYTHON_BIN) -m black $(LINT_ENFORCE_DIRS)
+	@$(LOCAL_PYTHON_BIN) -m isort $(LINT_ENFORCE_DIRS)
 
 .PHONY: lint
 lint:
@@ -60,17 +54,11 @@ ifneq ($(MIG_ENV),'local')
 endif
 	@make lint-python
 
+# NOTE: black and isort use pyproject.toml to temporarily exclude a few paths
 .PHONY: lint-python
 lint-python:
-	@$(LOCAL_PYTHON_BIN) -m black $(FORMAT_ENFORCE_DIRS) \
-			--check \
-			--line-length=$(FORMAT_LINE_LENGTH) \
-			--exclude $(FORMAT_EXCLUDE_REGEX)
-	@$(LOCAL_PYTHON_BIN) -m isort $(FORMAT_ENFORCE_DIRS) \
-			--check-only \
-			--profile=black \
-			--line-length=$(FORMAT_LINE_LENGTH) \
-			--skip-glob=$(FORMAT_EXCLUDE_GLOB)
+	@$(LOCAL_PYTHON_BIN) -m black $(LINT_ENFORCE_DIRS) --check
+	@$(LOCAL_PYTHON_BIN) -m isort $(LINT_ENFORCE_DIRS) --check-only
 
 .PHONY: clean
 clean:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ extend-exclude = '''
 [tool.isort]
 profile = "black"
 line_length = 80
+skip_glob = [".git/*", "tests/data/*", "tests/fixture/*"]
 # NOTE: the following paths must be kept in sync with black extend-exclude
 skip = [
     "bin/checkconf.py",
@@ -33,4 +34,3 @@ skip = [
     "sbin/grid_sftp.py",
     "sbin/grid_webdavs.py"
 ]
-skip_glob = [".git/*", "tests/data/*", "tests/fixture/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+# Project wide settings including tooling.
+
+# Linting tools
+# TODO: fix CodeQL errors in symlinked files and disable extend-exclude+skip
+
+[tool.black]
+line-length = 80
+exclude = '''
+      tests/data/
+    | tests/fixture/
+'''
+# NOTE: the following regex matches must be kept in sync with isort skip
+extend-exclude = '''
+      bin/checkconf.py
+    | bin/createresource.py
+    | bin/notifypassword.py
+    | sbin/grid_ftps.py
+    | sbin/grid_openid.py
+    | sbin/grid_sftp.py
+    | sbin/grid_webdavs.py
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 80
+# NOTE: the following paths must be kept in sync with black extend-exclude
+skip = [
+    "bin/checkconf.py",
+    "bin/createresource.py",
+    "bin/notifypassword.py",
+    "sbin/grid_ftps.py",
+    "sbin/grid_openid.py",
+    "sbin/grid_sftp.py",
+    "sbin/grid_webdavs.py"
+]
+skip_glob = [".git/*", "tests/data/*", "tests/fixture/*"]


### PR DESCRIPTION
Pull in the actual code format and lint bits from PR497 (thanks @albu-diku) but without applying any formatting yet.
Minor adjustments to get the comments and 'exclude' layout I tried but clearly failed to fully explain in the #497 review comments.

This is _not_ to hijack it but I'd really like to get the changes in before we diverge further and in order to add a more thorough lint target using pylint and ruff on top of black and isort.