### PR TITLE
Add the pylint and ruff linters on top of the lint bits from PR497

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,19 @@ ifneq ($(MIG_ENV),'local')
 	@echo "unavailable outside local development environment"
 	@exit 1
 endif
+	@make style-check-python
 	@make lint-python
 
 # NOTE: black and isort use pyproject.toml to temporarily exclude a few paths
-.PHONY: lint-python
-lint-python:
+.PHONY: style-check-python
+style-check-python:
 	@$(LOCAL_PYTHON_BIN) -m black $(LINT_ENFORCE_DIRS) --check
 	@$(LOCAL_PYTHON_BIN) -m isort $(LINT_ENFORCE_DIRS) --check-only
+
+.PHONY: lint-python
+lint-python:
+	@$(LOCAL_PYTHON_BIN) -m pylint $(LINT_ENFORCE_DIRS) --errors-only
+	@$(LOCAL_PYTHON_BIN) -m ruff check $(LINT_ENFORCE_DIRS)
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ style-check-python:
 	@$(LOCAL_PYTHON_BIN) -m black $(LINT_ENFORCE_DIRS) --check
 	@$(LOCAL_PYTHON_BIN) -m isort $(LINT_ENFORCE_DIRS) --check-only
 
+# NOTE: pylint and ruff use pyproject.toml to temporarily exclude a few paths
 .PHONY: lint-python
 lint-python:
 	@$(LOCAL_PYTHON_BIN) -m pylint $(LINT_ENFORCE_DIRS) --errors-only

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -5,6 +5,8 @@
 autopep8;python_version >= "3"
 black
 isort
+pylint
+ruff
 # We need paramiko for the ssh unit tests
 # NOTE: paramiko-3.0.0 dropped python2 and python3.6 support
 paramiko;python_version >= "3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 # Project wide settings including tooling.
 
 # Linting tools
-# TODO: fix CodeQL errors in symlinked files and disable extend-exclude+skip
+
+# TODO: fix CodeQL errors and disable temporary named files with NOTEs below
 
 [tool.black]
 line-length = 80
@@ -9,7 +10,7 @@ exclude = '''
       tests/data/
     | tests/fixture/
 '''
-# NOTE: the following regex matches must be kept in sync with isort skip
+# NOTE: the following temporay excludes must be kept in sync between tools
 extend-exclude = '''
       bin/checkconf.py
     | bin/createresource.py
@@ -24,7 +25,7 @@ extend-exclude = '''
 profile = "black"
 line_length = 80
 skip_glob = [".git/*", "tests/data/*", "tests/fixture/*"]
-# NOTE: the following paths must be kept in sync with black extend-exclude
+# NOTE: the following temporay excludes must be kept in sync between tools
 skip = [
     "bin/checkconf.py",
     "bin/createresource.py",
@@ -41,7 +42,7 @@ ignore-pattern = '''
       tests/data/
     | tests/fixture/
 '''
-# NOTE: the following paths must be kept in sync with black extend-exclude
+# NOTE: the following temporay excludes must be kept in sync between tools
 ignore-paths = [
     "bin/checkconf.py",
     "bin/createresource.py",
@@ -55,7 +56,7 @@ ignore-paths = [
 [tool.ruff]
 line-length = 80
 exclude = [".git/", "tests/data/", "tests/fixture/"]
-# NOTE: the following regex matches must be kept in sync with isort skip
+# NOTE: the following temporay excludes must be kept in sync between tools
 extend-exclude = [
     "bin/checkconf.py",
     "bin/createresource.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,34 @@ skip = [
     "sbin/grid_sftp.py",
     "sbin/grid_webdavs.py"
 ]
+
+[tool.pylint]
+max-line-length = 80
+ignore-pattern = '''
+      tests/data/
+    | tests/fixture/
+'''
+# NOTE: the following paths must be kept in sync with black extend-exclude
+ignore-paths = [
+    "bin/checkconf.py",
+    "bin/createresource.py",
+    "bin/notifypassword.py",
+    "sbin/grid_ftps.py",
+    "sbin/grid_openid.py",
+    "sbin/grid_sftp.py",
+    "sbin/grid_webdavs.py"
+]
+
+[tool.ruff]
+line-length = 80
+exclude = [".git/", "tests/data/", "tests/fixture/"]
+# NOTE: the following regex matches must be kept in sync with isort skip
+extend-exclude = [
+    "bin/checkconf.py",
+    "bin/createresource.py",
+    "bin/notifypassword.py",
+    "sbin/grid_ftps.py",
+    "sbin/grid_openid.py",
+    "sbin/grid_sftp.py",
+    "sbin/grid_webdavs.py"
+]


### PR DESCRIPTION
Extend #525 with ruff and pylint to get a more thorough linting of the paths pointed to by `LINT_ENFORCE_DIRS`. It is still not enabled or applied to anything but the dummy package marker in `mig/__init__.py` but prepared to be applied to all new code as per https://github.com/ucphhpc/migrid-sync/milestone/7 .
One can test with `make lint-python LINT_ENFORCE_DIRS='./bin ./mig/lib ./sbin ./tests'` or any other file or directory path in `LINT_ENFORCE_DIRS`.

This PR was rebased to be quite a bit simpler after #525 was merged into `next`.