### PR TITLE
Address a couple of old lint errors about missing variable init in configuration.py

### DIFF
--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -775,6 +775,8 @@ class Configuration:
         self.default_page = None
         self.auth_logger_obj = None
         self.gdp_logger_obj = None
+        self.logger_obj = None
+        self.logger = None
 
         configuration_properties = copy.deepcopy(_CONFIGURATION_PROPERTIES)
 


### PR DESCRIPTION
~This is a placeholder to a~ Address a couple of old lint errors about missing variable init in `mig/shared/configuration.py` module.