### PR TITLE
Fix lint errors in the bin folder scripts

### DIFF
--- a/mig/server/checkcloud.py
+++ b/mig/server/checkcloud.py
@@ -31,7 +31,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import getopt
-import pickle
 import sys
 
 from mig.shared.defaults import keyword_all

--- a/mig/server/checktwofactor.py
+++ b/mig/server/checktwofactor.py
@@ -31,7 +31,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import getopt
-import pickle
 import sys
 
 from mig.shared.defaults import keyword_auto

--- a/mig/server/createuser.py
+++ b/mig/server/createuser.py
@@ -36,7 +36,6 @@ import datetime
 import getopt
 import os
 import sys
-import time
 
 from mig.shared.accountstate import default_account_expire
 from mig.shared.base import fill_distinguished_name, fill_user, canonical_user, \

--- a/mig/server/importusers.py
+++ b/mig/server/importusers.py
@@ -35,7 +35,6 @@ import os
 import re
 import ssl
 import sys
-import time
 
 from mig.shared import returnvalues
 from mig.shared.accountstate import default_account_expire
@@ -46,9 +45,7 @@ from mig.shared.defaults import csrf_field, keyword_auto, valid_auth_types
 from mig.shared.functionality.sendrequestaction import main
 from mig.shared.handlers import get_csrf_limit, make_csrf_token
 from mig.shared.output import format_output
-from mig.shared.pwcrypto import generate_random_password, unscramble_password, \
-    scramble_password
-from mig.shared.safeinput import valid_password_chars
+from mig.shared.pwcrypto import generate_random_password, scramble_password
 from mig.shared.url import urlopen
 from mig.shared.useradm import init_user_adm, default_search, create_user, \
     search_users

--- a/mig/server/managecloud.py
+++ b/mig/server/managecloud.py
@@ -33,7 +33,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import getopt
-import pickle
 import sys
 
 from mig.shared.defaults import keyword_all
@@ -105,7 +104,7 @@ if '__main__' == __name__:
     action_map = {'start': start_cloud_instance, 'stop': stop_cloud_instance,
                   'restart': restart_cloud_instance,
                   'status': status_of_cloud_instance}
-    if not action in action_map:
+    if action not in action_map:
         print('Error: action must be one of %s' % action_map.keys())
         usage()
         sys.exit(1)
@@ -142,7 +141,7 @@ if '__main__' == __name__:
                 list(saved_instances), instance_fields)
             action_helper = action_map[action]
             for (instance_id, instance_dict) in saved_instances.items():
-                if not instance_id in instance_list:
+                if instance_id not in instance_list:
                     continue
                 instance_label = instance_dict.get('INSTANCE_LABEL',
                                                    instance_id)

--- a/mig/server/notifyexpire.py
+++ b/mig/server/notifyexpire.py
@@ -201,7 +201,7 @@ if '__main__' == __name__:
 
         # Don't warn about already disabled or suspended accounts
         account_state = user_dict.get('status', 'active')
-        if not account_state in ('active', 'temporal'):
+        if account_state not in ('active', 'temporal'):
             if verbose:
                 print('Skip handling of already %s user %s' % (account_state,
                                                                user_id))
@@ -322,7 +322,7 @@ if '__main__' == __name__:
                                   (cloud_title, instance_id, user_id))
                         continue
                     else:
-                        if not 'cloud' in affected:
+                        if 'cloud' not in affected:
                             affected.append('cloud')
 
         (_, username, full_name, addresses, errors) = user_account_notify(

--- a/mig/server/reqacceptpeer.py
+++ b/mig/server/reqacceptpeer.py
@@ -41,12 +41,11 @@ import os
 import sys
 
 from mig.shared.accountreq import peers_permit_allowed, manage_pending_peers
-from mig.shared.base import fill_distinguished_name, client_id_dir
+from mig.shared.base import fill_distinguished_name
 from mig.shared.conf import get_configuration_object
-from mig.shared.defaults import keyword_auto, gdp_distinguished_field, \
-    pending_peers_filename
+from mig.shared.defaults import keyword_auto, gdp_distinguished_field
 from mig.shared.notification import notify_user
-from mig.shared.serial import load, dump
+from mig.shared.serial import load
 from mig.shared.useradm import init_user_adm, search_users, default_search, \
     user_account_notify
 from mig.shared.validstring import valid_email_addresses

--- a/mig/server/reset2fakey.py
+++ b/mig/server/reset2fakey.py
@@ -85,7 +85,7 @@ def enable2fa(configuration, user_id, verbose, force=False):
 
     try:
         os.remove(tmptopicfile)
-    except Exception as exc:
+    except Exception:
         pass  # probably deleted by parser!
 
     return parse_status
@@ -251,7 +251,7 @@ if '__main__' == __name__:
             print("Detected HEX seed, re-encoding to base32")
         try:
             seed = base64.b32encode(base64.b16decode(seed))
-        except Exception as exc:
+        except Exception:
             print("Failed to base32 encode seed")
             if not force:
                 sys.exit(1)
@@ -263,7 +263,7 @@ if '__main__' == __name__:
     if interval:
         try:
             interval = int(interval)
-        except:
+        except Exception:
             print("Skipping non-int interval: %s" % interval)
             interval = None
 

--- a/mig/server/resetcaches.py
+++ b/mig/server/resetcaches.py
@@ -33,7 +33,6 @@ import os
 import sys
 
 
-from mig.shared.base import client_id_dir
 from mig.shared.conf import get_configuration_object
 from mig.shared.fileio import delete_file
 from mig.shared.vgridaccess import refresh_vgrid_map, refresh_user_map, \

--- a/mig/server/searchusers.py
+++ b/mig/server/searchusers.py
@@ -33,7 +33,6 @@ from __future__ import absolute_import
 from past.builtins import basestring
 import getopt
 import sys
-import time
 
 from mig.shared.useradm import init_user_adm, search_users, default_search
 

--- a/mig/server/sftpfailinfo.py
+++ b/mig/server/sftpfailinfo.py
@@ -127,9 +127,9 @@ if '__main__' == __name__:
         match = extract_regex.match(line)
         if match:
             stamp, source_ip, source_port, err_cond = match.group(1, 2, 3, 4)
-            if not source_ip in ip_fail_map:
+            if source_ip not in ip_fail_map:
                 ip_fail_map[source_ip] = {'source_ip': source_ip}
-            if not err_cond in ip_fail_map[source_ip]:
+            if err_cond not in ip_fail_map[source_ip]:
                 ip_fail_map[source_ip][err_cond] = 0
             ip_fail_map[source_ip][err_cond] += 1
             ip_fail_map[source_ip]['last'] = stamp

--- a/mig/server/usagestats.py
+++ b/mig/server/usagestats.py
@@ -35,10 +35,8 @@ import os
 import sys
 import time
 
-from mig.shared.base import extract_field
 from mig.shared.defaults import freeze_meta_filename, keyword_auto
-from mig.shared.fileio import unpickle, walk
-from mig.shared.notification import send_email
+from mig.shared.fileio import walk
 from mig.shared.safeeval import subprocess_popen, subprocess_pipe
 from mig.shared.serial import dump
 from mig.shared.useradm import init_user_adm, search_users, default_search
@@ -454,7 +452,7 @@ if '__main__' == __name__:
                 dirs.remove(i)
             continue
         if sub_parts[-1].find('archive-') == -1 or \
-                not freeze_meta_filename in files:
+                freeze_meta_filename not in files:
             continue
         meta_path = os.path.join(root, freeze_meta_filename)
         meta_mtime = os.path.getmtime(meta_path)

--- a/mig/server/verifyarchives.py
+++ b/mig/server/verifyarchives.py
@@ -75,7 +75,7 @@ def check_archive_integrity(configuration, user_id, freeze_path,
     # NOTE: if archive has no actual files it has no cache file either
     if not os.path.exists(cache_path):
         archive_list = os.listdir(freeze_path)
-        if [i for i in archive_list if not i in ignore_files]:
+        if [i for i in archive_list if i not in ignore_files]:
             print("Archive %s has data content but no file cache in %s" %
                   (freeze_path, cache_path))
             return False


### PR DESCRIPTION
Let `ruff` fix 25 lint errors in the bin folder scripts as pointed out by
`make lint-python LINT_ENFORCE_DIRS=bin`
One manual fix of the last one to avoid using plain `except:` as well.

This is a step towards enforcing linting and style rules in the migrated FHSesque locations