### PR TITLE
Fix lint errors in the sbin folder scripts

### DIFF
--- a/sbin/grid_accounting.py
+++ b/sbin/grid_accounting.py
@@ -116,7 +116,7 @@ unless it is available in mig/server/MiGserver.conf
                 % os.getpid()
             logger.info(msg)
             print("%s %s" % (datetime.datetime.now(), msg))
-        except Exception as exc:
+        except Exception:
             throttle = True
             msg = "(%s) Caught unexpected exception:\n%s" \
                   % (os.getpid(), traceback.format_exc())

--- a/sbin/grid_quota.py
+++ b/sbin/grid_quota.py
@@ -128,7 +128,7 @@ unless it is available in mig/server/MiGserver.conf
                 % os.getpid()
             logger.info(msg)
             print("%s %s" % (datetime.datetime.now(), msg))
-        except Exception as exc:
+        except Exception:
             throttle = True
             msg = "(%s) Caught unexpected exception:\n%s" \
                   % (os.getpid(), traceback.format_exc())


### PR DESCRIPTION
Let `ruff` fix 2 simple lint errors in the sbin folder itself as pointed out by
`make lint-python LINT_ENFORCE_DIRS=sbin`

Symlinks to `mig/server/X.py` are kept out of this round so only targets accounting and quota.

This is a step towards enforcing linting and style rules in the migrated FHSesque locations.