### PR TITLE
Update requirements and friends to drop all python versions before 3.7

### DIFF
--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -1,16 +1,13 @@
 # migrid dependencies on a format suitable for pip install as described on
 # https://pip.pypa.io/en/stable/reference/requirement-specifiers/
 # This list is mainly used to specify addons needed for the unit tests.
-# We only need autopep8 on py 3 as it's used in 'make fmt' (with py3)
-autopep8;python_version >= "3"
+autopep8
 black
 isort
 pylint
 ruff
 # We need paramiko for the ssh unit tests
-# NOTE: paramiko-3.0.0 dropped python2 and python3.6 support
-paramiko;python_version >= "3.7"
-paramiko<3;python_version < "3.7"
+paramiko
 werkzeug
 # We need pyOpenSSL for the FTPS service and related tlsserver unit tests
 pyOpenSSL

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -7,7 +7,9 @@ isort
 pylint
 ruff
 # We need paramiko for the ssh unit tests
-paramiko
+# IMPORTANT: there's a known security issue (CVE-2023-48795) in paramiko<3.4.0
+#            as explained on https://www.paramiko.org/changelog.html#3.4.0
+paramiko>=3.4.0
 werkzeug
 # We need pyOpenSSL for the FTPS service and related tlsserver unit tests
 pyOpenSSL

--- a/recommended.txt
+++ b/recommended.txt
@@ -1,36 +1,22 @@
 # migrid full dependencies on a format suitable for pip install as described on
 # https://pip.pypa.io/en/stable/reference/requirement-specifiers/
 future
-# NOTE: python-3.6 and earlier versions require older pyotp, whereas 3.7+
-#       should work with any modern version. We tested 2.9.0 to work.
-pyotp;python_version >= "3.7"
-pyotp<2.8;python_version > "3" and python_version < "3.7"
-pyotp<2.4;python_version < "3"
+pyotp
 pyyaml
-# NOTE: python-2.7 requires older dnspython, whereas 3.x should work with any
-#       modern version. We tested 2.6.1 to work.
+# NOTE: python-3.x should work with any modern dnspython.
 # IMPORTANT: there's a known security issue (CVE-2023-29483) in dnspython<2.6.1
 #            as explained on https://www.dnspython.org/news/2.6.1/
-dnspython>=2.6.1;python_version >= "3.7"
-# NOTE: one should use a patched 2.x version e.g. from RHEL/Rocky 8 if on python3.6
-dnspython<2.4;python_version > "3" and python_version < "3.7"
-# NOTE: one should use a patched 1.x version e.g. from RHEL/Rocky 8 if on python2
-dnspython<2;python_version < "3"
-# NOTE: python-3.6 and earlier versions require older email-validator, whereas
-#       3.7+ should work with any modern version. We tested 2.2.0 to work.
-email-validator;python_version >= "3.7"
-email-validator<2.0;python_version >= "3" and python_version < "3.7"
-email-validator<1.3;python_version < "3"
+dnspython>=2.6.1
+email-validator
 
 # migrid recommended libs on a format suitable for pip install as described on
 # https://pip.pypa.io/en/stable/reference/requirement-specifiers/
 wsgidav
-paramiko
+# IMPORTANT: there's a known security issue (CVE-2023-48795) in paramiko<3.4.0
+#            as explained on https://www.paramiko.org/changelog.html#3.4.0
+paramiko>=3.4.0
 pyOpenSSL
-# NOTE: python-2.7 versions require pyftpdlib-1.x
-# NOTE: python-3.6 versions with dated pyopenssl (rocky8) require pyftpdlib-1.x
-pyftpdlib;python_version > "3.6"
-pyftpdlib<2.0;python_version <= "3.6"
+pyftpdlib
 watchdog
 scandir
 python-openid
@@ -47,10 +33,7 @@ nbformat
 more-itertools
 nbconvert
 papermill
-# NOTE: python-2.7 and possibly early python-3 version require older
-# notebook_parameterizer, whereas 3.6+ should work with later versions.
-notebook_parameterizer;python_version >= "3.6"
-notebook_parameterizer<0.0.4;python_version < "3.6"
+notebook_parameterizer
 psutil
 # sslkeylog requires libssl-dev or similar system package to build
 #sslkeylog

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,26 +5,13 @@ future
 # cgi was removed from the standard library in Python 3.13
 legacy-cgi;python_version >= "3.13"
 
-# NOTE: python-3.6 and earlier versions require older pyotp, whereas 3.7+
-#       should work with any modern version. We tested 2.9.0 to work.
-pyotp;python_version >= "3.7"
-pyotp<2.8;python_version > "3" and python_version < "3.7"
-pyotp<2.4;python_version < "3"
+pyotp
 pyyaml
-# NOTE: python-2.7 requires older dnspython, whereas 3.x should work with any
-#       modern version. We tested 2.6.1 to work.
+# NOTE: python-3.x should work with any modern dnspython.
 # IMPORTANT: there's a known security issue (CVE-2023-29483) in dnspython<2.6.1
 #            as explained on https://www.dnspython.org/news/2.6.1/
-dnspython>=2.6.1;python_version >= "3.7"
-# NOTE: one should use a patched 2.x version e.g. from RHEL/Rocky 8 if on python3.6
-dnspython<2.4;python_version > "3" and python_version < "3.7"
-# NOTE: one should use a patched 1.x version e.g. from RHEL/Rocky 8 if on python2
-dnspython<2;python_version < "3"
-# NOTE: python-3.6 and earlier versions require older email-validator, whereas
-#       3.7+ should work with any modern version. We tested 2.2.0 to work.
-email-validator;python_version >= "3.7"
-email-validator<2.0;python_version >= "3" and python_version < "3.7"
-email-validator<1.3;python_version < "3"
+dnspython>=2.6.1
+email-validator
 
 # NOTE: additional optional dependencies depending on site conf are listed
 #       in recommended.txt and can be installed in the same manner by pointing


### PR DESCRIPTION
Update requirements and friends to drop all python versions before 3.7. We just need to support 3.9+ from Rocky9 and similar.
Also addresses some code scan warnings about outdated python package dependencies we no longer use anywhere.