### PR TITLE
janitor: Handle 'stale' state file entries such broken symlinks

### DIFF
--- a/mig/lib/janitor.py
+++ b/mig/lib/janitor.py
@@ -121,6 +121,11 @@ def _clean_stale_state_files(
                 if os.path.exists(tmp_path):
                     tmp_age = now - os.path.getmtime(tmp_path)
                 else:
+                    # File may be a broken symlink or was removed concurrently
+                    _logger.debug(
+                        "state file %r missing or broken symlink"
+                        ", treating as stale" % tmp_path
+                    )
                     tmp_age = sys.maxsize
             else:
                 continue

--- a/mig/lib/janitor.py
+++ b/mig/lib/janitor.py
@@ -34,10 +34,14 @@ from __future__ import absolute_import, print_function
 
 import fnmatch
 import os
+import sys
 import time
 
-from mig.shared.accountreq import accept_account_req, existing_user_collision, \
-    reject_account_req
+from mig.shared.accountreq import (
+    accept_account_req,
+    existing_user_collision,
+    reject_account_req,
+)
 from mig.shared.base import get_user_id
 from mig.shared.fileio import delete_file, listdir
 from mig.shared.pwcrypto import verify_reset_token
@@ -114,7 +118,10 @@ def _clean_stale_state_files(
         for pattern in filename_patterns:
             if fnmatch.fnmatch(filename, pattern):
                 _logger.debug("checking if state file %r is stale" % tmp_path)
-                tmp_age = now - os.path.getmtime(tmp_path)
+                if os.path.exists(tmp_path):
+                    tmp_age = now - os.path.getmtime(tmp_path)
+                else:
+                    tmp_age = sys.maxsize
             else:
                 continue
             tmp_age_days = tmp_age / SECS_PER_DAY
@@ -127,7 +134,12 @@ def _clean_stale_state_files(
                     "remove stale tmp file in %r : %dd"
                     % (tmp_path, tmp_age_days)
                 )
-                if not delete_file(tmp_path, _logger):
+                if not delete_file(
+                    tmp_path,
+                    _logger,
+                    allow_broken_symlink=True,
+                    allow_missing=True,
+                ):
                     _logger.error("failed to remove stale file %r" % tmp_path)
                 handled += 1
     _logger.debug("handled %d stale state file cleanups" % handled)
@@ -284,21 +296,27 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
         )
         if not rej_status:
             _logger.warning(
-                "failed to reject invalid %r account request: %s" % (client_id,
-                                                                     rej_err)
+                "failed to reject invalid %r account request: %s"
+                % (client_id, rej_err)
             )
         else:
             _logger.info("rejected invalid %r account request" % client_id)
     elif authorized:
-        _logger.info("%r requested renew and authorized password change" %
-                     client_id)
+        _logger.info(
+            "%r requested renew and authorized password change" % client_id
+        )
         peer_id = user_dict.get("peers", [None])[0]
         # NOTE: let authorized reqs (with valid peer) renew even with pw change
         default_renew = True
-        if accept_account_req(req_id, configuration, peer_id,
-                              user_copy=user_copy, admin_copy=admin_copy,
-                              auth_type=auth_type,
-                              default_renew=default_renew):
+        if accept_account_req(
+            req_id,
+            configuration,
+            peer_id,
+            user_copy=user_copy,
+            admin_copy=admin_copy,
+            auth_type=auth_type,
+            default_renew=default_renew,
+        ):
             _logger.info("accepted authorized %r access renew" % client_id)
         else:
             _logger.warning("failed authorized %r access renew" % client_id)
@@ -324,15 +342,15 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
             )
             if not acc_status:
                 _logger.warning(
-                    "failed to accept %r password reset: %s" % (client_id,
-                                                                acc_err)
+                    "failed to accept %r password reset: %s"
+                    % (client_id, acc_err)
                 )
             else:
                 _logger.info("accepted %r password reset" % client_id)
         else:
             _logger.warning(
-                "%r requested password reset with bad token: %s" % (
-                    client_id, reset_token)
+                "%r requested password reset with bad token: %s"
+                % (client_id, reset_token)
             )
             reason = "invalid password reset token"
             (rej_status, rej_err) = reject_account_req(
@@ -345,8 +363,8 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
             )
             if not rej_status:
                 _logger.warning(
-                    "failed to reject %r password reset: %s" % (client_id,
-                                                                rej_err)
+                    "failed to reject %r password reset: %s"
+                    % (client_id, rej_err)
                 )
             else:
                 _logger.info("rejected %r password reset" % client_id)
@@ -363,9 +381,9 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
             auth_type=auth_type,
         )
         if not rej_status:
-            _logger.warning("failed to reject expired %r request: %s" %
-                            (client_id, rej_err)
-                            )
+            _logger.warning(
+                "failed to reject expired %r request: %s" % (client_id, rej_err)
+            )
         else:
             _logger.info("rejected %r request now past expire" % client_id)
     elif existing_user_collision(configuration, req_dict, client_id):
@@ -381,8 +399,8 @@ def manage_single_req(configuration, req_id, req_path, db_path, now):
         )
         if not rej_status:
             _logger.warning(
-                "failed to reject %r request with ID collision: %s" %
-                (client_id, rej_err)
+                "failed to reject %r request with ID collision: %s"
+                % (client_id, rej_err)
             )
         else:
             _logger.info("rejected %r request with ID collision" % client_id)
@@ -417,8 +435,7 @@ def manage_trivial_user_requests(configuration, now=None):
             continue
         req_id = filename
         req_path = os.path.join(configuration.user_pending, req_id)
-        _logger.debug("checking if account request in %r is trivial" %
-                      req_path)
+        _logger.debug("checking if account request in %r is trivial" % req_path)
         req_age = now - os.path.getmtime(req_path)
         req_age_minutes = req_age / SECS_PER_MINUTE
         if req_age_minutes > MANAGE_TRIVIAL_REQ_MINUTES:
@@ -428,8 +445,7 @@ def manage_trivial_user_requests(configuration, now=None):
             )
             manage_single_req(configuration, req_id, req_path, db_path, now)
             handled += 1
-    _logger.debug("handled %d trivial user account request action(s)" %
-                  handled)
+    _logger.debug("handled %d trivial user account request action(s)" % handled)
     return handled
 
 
@@ -483,11 +499,12 @@ def remind_and_expire_user_pending(configuration, now=None):
                 auth_type=auth_type,
             )
             if not rej_status:
-                _logger.warning("failed to expire %s request from %r: %s" %
-                                (req_id, client_id, rej_err))
+                _logger.warning(
+                    "failed to expire %s request from %r: %s"
+                    % (req_id, client_id, rej_err)
+                )
             else:
-                _logger.info("expired %s request from %r" % (req_id,
-                                                             client_id))
+                _logger.info("expired %s request from %r" % (req_id, client_id))
             handled += 1
     _logger.debug("handled %d user account request action(s)" % handled)
     return handled

--- a/mig/lib/janitor.py
+++ b/mig/lib/janitor.py
@@ -123,8 +123,11 @@ def _clean_stale_state_files(
                 else:
                     # File may be a broken symlink or was removed concurrently
                     _logger.debug(
-                        "state file %r missing or broken symlink"
-                        ", treating as stale" % tmp_path
+                        (
+                            "state file %r missing or broken symlink,"
+                            " treating as stale"
+                        )
+                        % tmp_path
                     )
                     tmp_age = sys.maxsize
             else:

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -29,7 +29,6 @@
 
 from string import ascii_letters, digits
 import os
-import pickle
 import random
 import time
 import unittest
@@ -45,7 +44,7 @@ from mig.lib.janitor import EXPIRE_DUMMY_JOBS_DAYS, EXPIRE_REQ_DAYS, \
     manage_single_req, manage_trivial_user_requests, \
     remind_and_expire_user_pending, task_triggers
 from mig.shared.accountreq import save_account_request
-from mig.shared.base import distinguished_name_to_user, client_id_dir
+from mig.shared.base import client_id_dir
 from mig.shared.pwcrypto import generate_reset_token
 from tests.support import MigTestCase, ensure_dirs_exist
 
@@ -341,7 +340,6 @@ class MigLibJanitor(MigTestCase):
 
     def test_manage_pending_user_request(self):
         """Test pending user request management"""
-        req_id = 'req_id'
         req_dict = {
             'client_id': TEST_USER_DN,
             'distinguished_name': TEST_USER_DN,
@@ -371,7 +369,6 @@ class MigLibJanitor(MigTestCase):
 
     def test_expire_user_pending(self):
         """Test pending user request expiration reminders"""
-        req_id = 'expired_req'
         req_dict = {
             'client_id': TEST_USER_DN,
             'distinguished_name': TEST_USER_DN,
@@ -422,7 +419,6 @@ class MigLibJanitor(MigTestCase):
                                                      valid_dict)
         self.assertTrue(saved, "failed to save valid req")
         self.assertDirNotEmpty(self.configuration.user_pending)
-        valid_id = os.path.basename(valid_req_path)
 
         expired_id = 'expired_req'
         expired_dict = {
@@ -471,7 +467,6 @@ class MigLibJanitor(MigTestCase):
             self._prepare_test_file(stale_path, (stale_stamp, stale_stamp))
             self.assertTrue(os.path.exists(stale_path))
 
-        req_id = 'expired_request'
         req_dict = {
             'client_id': TEST_USER_DN,
             'distinguished_name': TEST_USER_DN,

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -209,6 +209,63 @@ class MigLibJanitor(MigTestCase):
         self.assertFalse(os.path.exists(stale_path))
         self.assertTrue(os.path.exists(valid_path))
 
+    def test_clean_twofactor_sessions_with_working_symlink(self):
+        """Test clean twofactor sessions with an active session symlink"""
+        test_dir = self.configuration.twofactor_home
+        # arrange pre-existing symlink pointing to session file
+        symlink_filename = 'sessionlink'
+        session_filename = 'session'
+        symlink_path = os.path.join(test_dir, symlink_filename)
+        session_path = os.path.join(test_dir, session_filename)
+        self._prepare_test_file(session_path)
+        os.symlink(session_path, symlink_path)
+        self.assertTrue(os.path.lexists(symlink_path))
+        self.assertTrue(os.path.exists(session_path))
+        err = None
+        try:
+            # Put 'now' into the future to force cleanup
+            future = time.time() + (2  * EXPIRE_TWOFACTOR_DAYS * SECS_PER_DAY)
+            handled = clean_twofactor_sessions(self.configuration, now=future)
+            self.assertEqual(handled, 2)
+            self.assertFalse(os.path.exists(session_path))
+            self.assertFalse(os.path.lexists(symlink_path))
+        except AssertionError as ase:
+            err = ase
+        finally:
+            # NOTE: File only exist 
+            #       if clean_twofactor_sessions fail to remove it
+            if os.path.exists(session_path):
+                os.remove(session_path)
+            if os.path.lexists(symlink_path):
+                os.remove(symlink_path)
+        self.assertEqual(err, None)
+
+    def test_clean_twofactor_sessions_with_dead_symlink(self):
+        """Test clean twofactor sessions with a stale session symlink"""
+        test_dir = self.configuration.twofactor_home
+        # arrange pre-existing symlink pointing nowhere
+        symlink_filename = 'stalelink'
+        nowhere_filename = 'nowhere'
+        symlink_path = os.path.join(test_dir, symlink_filename)
+        nowhere_path = os.path.join(test_dir, nowhere_filename)
+        os.symlink(nowhere_path, symlink_path)
+        self.assertTrue(os.path.lexists(symlink_path))
+        self.assertFalse(os.path.exists(nowhere_path))
+        err = None
+        try:
+            handled = clean_twofactor_sessions(self.configuration)
+            self.assertEqual(handled, 1)
+            self.assertFalse(os.path.exists(nowhere_path))
+            self.assertFalse(os.path.lexists(symlink_path))
+        except FileNotFoundError as fnf:
+            err = fnf
+        finally:
+            # NOTE: Files only exist
+            #       if clean_twofactor_sessions fail to remove it
+            if os.path.lexists(symlink_path):
+                os.remove(symlink_path)
+        self.assertEqual(err, None)
+
     def test_clean_sessid_to_mrls_link_home(self):
         """Test clean session MRSL link files"""
         stale_stamp = time.time() - EXPIRE_STATE_DAYS * SECS_PER_DAY - 1

--- a/tests/test_mig_lib_janitor.py
+++ b/tests/test_mig_lib_janitor.py
@@ -27,8 +27,10 @@
 
 """Unit tests for the migrid module pointed to in the filename"""
 
+from string import ascii_letters, digits
 import os
 import pickle
+import random
 import time
 import unittest
 
@@ -212,32 +214,43 @@ class MigLibJanitor(MigTestCase):
     def test_clean_twofactor_sessions_with_working_symlink(self):
         """Test clean twofactor sessions with an active session symlink"""
         test_dir = self.configuration.twofactor_home
-        # arrange pre-existing symlink pointing to session file
-        symlink_filename = 'sessionlink'
-        session_filename = 'session'
-        symlink_path = os.path.join(test_dir, symlink_filename)
-        session_path = os.path.join(test_dir, session_filename)
-        self._prepare_test_file(session_path)
-        os.symlink(session_path, symlink_path)
-        self.assertTrue(os.path.lexists(symlink_path))
-        self.assertTrue(os.path.exists(session_path))
+        # arrange pre-existing symlinks pointing to session files
+        test_pairs = []
+        # NOTE: use cnt random files to limit risk that listdir sorting matters
+        cnt = 16
+        for _ in range(cnt):
+            # Mimic IP_SESSION link to SESSION from gdp-mode
+            prefix = '.'.join(random.choices(digits[1:], k=4))
+            # Make suffix long enough to rule out collisions in practice
+            suffix = ''.join(random.choices(ascii_letters + digits, k=8))
+            session_filename = 'session-%s' % suffix
+            symlink_filename = '%s_session-%s' % (prefix, suffix)
+            symlink_path = os.path.join(test_dir, symlink_filename)
+            session_path = os.path.join(test_dir, session_filename)
+            self._prepare_test_file(session_path)
+            os.symlink(session_path, symlink_path)
+            self.assertTrue(os.path.lexists(symlink_path))
+            self.assertTrue(os.path.exists(session_path))
+            test_pairs.append((symlink_path, session_path))
         err = None
         try:
             # Put 'now' into the future to force cleanup
-            future = time.time() + (2  * EXPIRE_TWOFACTOR_DAYS * SECS_PER_DAY)
+            future = time.time() + (2 * EXPIRE_TWOFACTOR_DAYS * SECS_PER_DAY)
             handled = clean_twofactor_sessions(self.configuration, now=future)
-            self.assertEqual(handled, 2)
-            self.assertFalse(os.path.exists(session_path))
-            self.assertFalse(os.path.lexists(symlink_path))
+            self.assertEqual(handled, 2 * cnt)
+            for (symlink_path, session_path) in test_pairs:
+                self.assertFalse(os.path.exists(session_path))
+                self.assertFalse(os.path.lexists(symlink_path))
         except AssertionError as ase:
             err = ase
         finally:
-            # NOTE: File only exist 
-            #       if clean_twofactor_sessions fail to remove it
-            if os.path.exists(session_path):
-                os.remove(session_path)
-            if os.path.lexists(symlink_path):
-                os.remove(symlink_path)
+            # NOTE: File only exists if clean_twofactor_sessions fails to
+            #       remove it
+            for (symlink_path, session_path) in test_pairs:
+                if os.path.exists(session_path):
+                    os.remove(session_path)
+                if os.path.lexists(symlink_path):
+                    os.remove(symlink_path)
         self.assertEqual(err, None)
 
     def test_clean_twofactor_sessions_with_dead_symlink(self):
@@ -260,8 +273,8 @@ class MigLibJanitor(MigTestCase):
         except FileNotFoundError as fnf:
             err = fnf
         finally:
-            # NOTE: Files only exist
-            #       if clean_twofactor_sessions fail to remove it
+            # NOTE: Files only exist if clean_twofactor_sessions fails to
+            #       remove them
             if os.path.lexists(symlink_path):
                 os.remove(symlink_path)
         self.assertEqual(err, None)
@@ -564,7 +577,7 @@ class MigLibJanitor(MigTestCase):
         self.assertTrue(any('invalid account request' in msg
                             for msg in log_capture.output))
         self.assertFalse(os.path.exists(req_path),
-                        "Failed to clean invalid req for %s" % req_path)
+                         "Failed to clean invalid req for %s" % req_path)
 
         # FIXME: should this really be sending email?
         fake_send_email = self.configuration.context_get('notifier').send_email
@@ -611,7 +624,7 @@ class MigLibJanitor(MigTestCase):
         self.assertTrue(any('reject expired reset token' in msg
                             for msg in log_capture.output))
         self.assertFalse(os.path.exists(req_path),
-                        "Failed to clean token req for %s" % req_path)
+                         "Failed to clean token req for %s" % req_path)
 
         fake_send_email = self.configuration.context_get('notifier').send_email
         self.assertTrue(fake_send_email.called_once)
@@ -697,7 +710,6 @@ class MigLibJanitor(MigTestCase):
         fake_send_email = self.configuration.context_get('notifier').send_email
         self.assertTrue(fake_send_email.called_once)
         self.assertTrue(fake_send_email.email_was_sent_to('test@example.com'))
-
 
     def test_manage_single_req_auth_change(self):
         """Test request handling with auth password change"""
@@ -885,7 +897,7 @@ class MigLibJanitor(MigTestCase):
         self.assertTrue(any('wrong hash' in msg.lower()
                             for msg in log_capture.output))
         self.assertFalse(os.path.exists(req_path),
-                        "Failed cleanup invalid token for %s" % req_path)
+                         "Failed cleanup invalid token for %s" % req_path)
 
         # FIXME: should this really be sending email?
         fake_send_email = self.configuration.context_get('notifier').send_email
@@ -931,7 +943,7 @@ class MigLibJanitor(MigTestCase):
         self.assertTrue(any('accepted' in msg.lower()
                             for msg in log_capture.output))
         self.assertFalse(os.path.exists(req_path),
-                        "Failed cleanup invalid token for %s" % req_path)
+                         "Failed cleanup invalid token for %s" % req_path)
 
         fake_send_email = self.configuration.context_get('notifier').send_email
         self.assertTrue(fake_send_email.called_once)
@@ -1082,7 +1094,6 @@ class MigLibJanitor(MigTestCase):
         # Verify initial existence
         self.assertTrue(os.path.exists(req_path))
 
-
         manage_single_req(
             self.configuration,
             req_id,
@@ -1092,11 +1103,10 @@ class MigLibJanitor(MigTestCase):
         )
 
         self.assertFalse(os.path.exists(req_path),
-                        "Failed cleanup after reject for %s" % req_path)
+                         "Failed cleanup after reject for %s" % req_path)
 
         fake_send_email = self.configuration.context_get('notifier').send_email
         fake_send_email.email_was_sent_to('test@example.com')
-
 
     def test_cleaner_with_multiple_patterns(self):
         """Test state cleaner with multiple filename patterns"""


### PR DESCRIPTION
Janitor `state` cleanup fails on broken symlinks.

Try to cleanup every entry in a `state` and allow `delete` errors to avoid blocking further janitor tasks.