### PR TITLE
Extend migerrors cron job to monitor most daemon logs

### DIFF
--- a/mig/install/migerrors-template.sh.cronjob
+++ b/mig/install/migerrors-template.sh.cronjob
@@ -30,6 +30,15 @@ ENABLE_FTPS="__ENABLE_FTPS__"
 ENABLE_SFTP="__ENABLE_SFTP__"
 ENABLE_SFTP_SUBSYS="__ENABLE_SFTP_SUBSYS__"
 ENABLE_DAVS="__ENABLE_DAVS__"
+ENABLE_OPENID="__ENABLE_OPENID__"
+ENABLE_CRONTAB="__ENABLE_CRONTAB__"
+ENABLE_EVENTS="__ENABLE_EVENTS__"
+ENABLE_TRANSFERS="__ENABLE_TRANSFERS__"
+ENABLE_NOTIFY="__ENABLE_NOTIFY__"
+ENABLE_JANITOR="__ENABLE_JANITOR__"
+ENABLE_ACCOUNTING="__ENABLE_ACCOUNTING__"
+ENABLE_QUOTA="__ENABLE_QUOTA__"
+
 {
 [ "$ENABLE_DAVS" == "True" ] && grep -H "Internal Server Error" $LOGDIR/webdavs.out | tail -n $MAXLINES
 [ "$ENABLE_DAVS" == "True" ] && grep -H -A 12 "Traceback" $LOGDIR/webdavs.out | tail -n $MAXLINES
@@ -42,6 +51,22 @@ ENABLE_DAVS="__ENABLE_DAVS__"
 	grep -E -v "Password authentication failed for|Socket exception: Connection reset by peer|Error reading SSH protocol banner|check_banner|list_folder on missing path|chmod (292|365) rejected on path|symlink rejected on path|ERROR mkdir .* failed: \[Errno 17\] File exists|ERROR rmdir .* failed: \[Errno 39\] Directory not empty|ERROR (open|remove) .* failed: \[Errno 21\] Is a directory|ERROR open for modify on read-only path|ERROR open existing file on missing path |ERROR rmdir rejected on link path |ERROR Exception.*: Incompatible ssh|ERROR Exception.*: Incompatible version |Exception.*: Invalid SSH banner|ERROR Exception.*: no moduli available|ERROR Exception.*: Expecting packet from \(20,\), got 0|ERROR Socket exception: Connection timed out|ERROR Exception.*: Key-exchange timed out|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|ERROR Exception.*: Client kex .* is out of range|ERROR Exception.*: Expecting packet from .*|get_fs_path failed: Invalid path characters|ERROR $" | tail -n $MAXLINES
 
 [ "$ENABLE_DAVS" == "True" ] && grep -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES
+
+[ "$ENABLE_OPENID" == "True" ] && grep -H " ERROR " $LOGDIR/openid.log | grep -E -v "crashed: Unexpected query variable|retry_url: shorter than minimum length|invalid retry_url: found invalid character|crashed: int\(\) argument must be a string|input: shorter than minimum length|input: found invalid character:" | tail -n $MAXLINES
+
+[ "$ENABLE_CRONTAB" == "True" ] && grep -H " ERROR " $LOGDIR/cron.log | tail -n $MAXLINES
+
+[ "$ENABLE_EVENTS" == "True" ] && grep -H " ERROR " $LOGDIR/events.log | tail -n $MAXLINES
+
+[ "$ENABLE_TRANSFERS" == "True" ] && grep -H " ERROR " $LOGDIR/transfers.log | tail -n $MAXLINES
+
+[ "$ENABLE_NOTIFY" == "True" ] && grep -H " ERROR " $LOGDIR/notify.log | tail -n $MAXLINES
+
+[ "$ENABLE_JANITOR" == "True" ] && grep -H " ERROR " $LOGDIR/janitor.log | tail -n $MAXLINES
+
+[ "$ENABLE_ACCOUNTING" == "True" ] && grep -H " ERROR " $LOGDIR/accounting.log | tail -n $MAXLINES
+
+[ "$ENABLE_QUOTA" == "True" ] && grep -H " ERROR " $LOGDIR/quota.log | tail -n $MAXLINES
 
 grep -H " ERROR " $LOGDIR/chkchroot.log | grep -E -v " from ${SECSCANIP} "| \
         grep -E -v "__CRACK_WEB_REGEX__" | \

--- a/tests/fixture/confs-stdlocal/migerrors
+++ b/tests/fixture/confs-stdlocal/migerrors
@@ -30,6 +30,15 @@ ENABLE_FTPS="False"
 ENABLE_SFTP="False"
 ENABLE_SFTP_SUBSYS="False"
 ENABLE_DAVS="False"
+ENABLE_OPENID="False"
+ENABLE_CRONTAB="True"
+ENABLE_EVENTS="False"
+ENABLE_TRANSFERS="False"
+ENABLE_NOTIFY="False"
+ENABLE_JANITOR="False"
+ENABLE_ACCOUNTING="False"
+ENABLE_QUOTA="False"
+
 {
 [ "$ENABLE_DAVS" == "True" ] && grep -H "Internal Server Error" $LOGDIR/webdavs.out | tail -n $MAXLINES
 [ "$ENABLE_DAVS" == "True" ] && grep -H -A 12 "Traceback" $LOGDIR/webdavs.out | tail -n $MAXLINES
@@ -42,6 +51,22 @@ ENABLE_DAVS="False"
 	grep -E -v "Password authentication failed for|Socket exception: Connection reset by peer|Error reading SSH protocol banner|check_banner|list_folder on missing path|chmod (292|365) rejected on path|symlink rejected on path|ERROR mkdir .* failed: \[Errno 17\] File exists|ERROR rmdir .* failed: \[Errno 39\] Directory not empty|ERROR (open|remove) .* failed: \[Errno 21\] Is a directory|ERROR open for modify on read-only path|ERROR open existing file on missing path |ERROR rmdir rejected on link path |ERROR Exception.*: Incompatible ssh|ERROR Exception.*: Incompatible version |Exception.*: Invalid SSH banner|ERROR Exception.*: no moduli available|ERROR Exception.*: Expecting packet from \(20,\), got 0|ERROR Socket exception: Connection timed out|ERROR Exception.*: Key-exchange timed out|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|ERROR Exception.*: Client kex .* is out of range|ERROR Exception.*: Expecting packet from .*|get_fs_path failed: Invalid path characters|ERROR $" | tail -n $MAXLINES
 
 [ "$ENABLE_DAVS" == "True" ] && grep -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES
+
+[ "$ENABLE_OPENID" == "True" ] && grep -H " ERROR " $LOGDIR/openid.log | grep -E -v "crashed: Unexpected query variable|retry_url: shorter than minimum length|invalid retry_url: found invalid character|crashed: int\(\) argument must be a string|input: shorter than minimum length|input: found invalid character:" | tail -n $MAXLINES
+
+[ "$ENABLE_CRONTAB" == "True" ] && grep -H " ERROR " $LOGDIR/cron.log | tail -n $MAXLINES
+
+[ "$ENABLE_EVENTS" == "True" ] && grep -H " ERROR " $LOGDIR/events.log | tail -n $MAXLINES
+
+[ "$ENABLE_TRANSFERS" == "True" ] && grep -H " ERROR " $LOGDIR/transfers.log | tail -n $MAXLINES
+
+[ "$ENABLE_NOTIFY" == "True" ] && grep -H " ERROR " $LOGDIR/notify.log | tail -n $MAXLINES
+
+[ "$ENABLE_JANITOR" == "True" ] && grep -H " ERROR " $LOGDIR/janitor.log | tail -n $MAXLINES
+
+[ "$ENABLE_ACCOUNTING" == "True" ] && grep -H " ERROR " $LOGDIR/accounting.log | tail -n $MAXLINES
+
+[ "$ENABLE_QUOTA" == "True" ] && grep -H " ERROR " $LOGDIR/quota.log | tail -n $MAXLINES
 
 grep -H " ERROR " $LOGDIR/chkchroot.log | grep -E -v " from ${SECSCANIP} "| \
         grep -E -v "((HNAP1|GponForm|provisioning|provision|prov|polycom|yealink|CertProv|phpmyadmin|admin|cfg|wp|wordpress|cms|blog|old|new|test|dev|tmp|temp|remote|mgmt|properties|authenticate|tmui|ddem|a2billing|vtigercrm|secure|rpc|recordings|dana-na)(/.*|)|.*(Login|login|logon|configuration|header|admin|index)\.(php|jsp|asp)|(api/v1/pods|Telerik.Web.UI.WebResource.axd))" | \


### PR DESCRIPTION
Extend migerrors cron job to monitor openid, cron, events, transfers, notify, janitor, accounting and quota daemon logs for each of those daemons if enabled.

Follow-up to #565 where we would have noticed the bug a lot earlier if we had included janitor log monitoring.

I have tried to select sensible ignores on the daemons where I could find expected errors. E.g. from running as an internet service with various robots and scanners probing. Input on additional ignore patterns for the remaining ones is welcome.