### PR TITLE
Implement fundamental unit test coverage of the accountstate module.

### DIFF
--- a/mig/shared/accountstate.py
+++ b/mig/shared/accountstate.py
@@ -118,7 +118,11 @@ def reset_account_expire_cache(configuration, client_id=None):
     _logger = configuration.logger
     res = True
     base_dir = os.path.join(configuration.mig_system_run, expire_marks_dir)
-    reset_filemark(configuration, base_dir, client_id)
+    if client_id is None:
+        target = client_id
+    else:
+        target = client_id_dir(client_id)
+    reset_filemark(configuration, base_dir, target)
     return res
 
 

--- a/tests/test_mig_shared_accountstate.py
+++ b/tests/test_mig_shared_accountstate.py
@@ -37,6 +37,7 @@ from mig.shared.accountstate import (
     check_account_accessible,
     check_account_expire,
     check_account_status,
+    check_update_account_expire,
     default_account_expire,
     default_account_valid_days,
     detect_special_login,
@@ -61,7 +62,7 @@ from mig.shared.defaults import (
     status_marks_dir,
 )
 from mig.shared.useradm import _ensure_dirs_needed_for_userdb
-from mig.shared.userdb import update_user_dict
+from mig.shared.userdb import load_user_dict, update_user_dict
 
 # Imports required for the unit tests themselves
 from tests.support import (
@@ -76,6 +77,8 @@ from tests.support.usersupp import OTHER_USER_DN, TEST_USER_DN
 TEST_EXPIRE_TIMESTAMP = 1776031200
 TEST_STATUS_ACTIVE = "active"
 TEST_STATUS_LOCKED = "locked"
+TEST_STATUS_SUSPENDED = "suspended"
+TEST_STATUS_TEMPORAL = "temporal"
 TEST_RW_SHARE_ID = "klmnop4567"
 TEST_JOB_ID = "0419b45ebc1dedbdcb91fa6251035a2096758f5d700e15478b27a90734454107"
 TEST_JUPYTER_SESSION_ID = (
@@ -215,11 +218,11 @@ class TestMigSharedAccountstate__update_account_expire_cache(MigTestCase):
     def before_each(self):
         """Set up test environment for expire cache tests."""
         configuration = self.configuration
-        # Ensure the mig_system_run sub directory exists for expire marks
-        marks_path = os.path.join(
-            configuration.mig_system_run, expire_marks_dir
+        # Ensure necessary directories exist
+        ensure_dirs_exist(configuration.mig_system_files)
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, expire_marks_dir)
         )
-        ensure_dirs_exist(marks_path)
 
     def test_update_account_expire_cache_creates_mark(self):
         """Test that update_account_expire_cache creates an expire mark."""
@@ -323,11 +326,11 @@ class TestMigSharedAccountstate__get_account_expire_cache(MigTestCase):
     def before_each(self):
         """Set up test environment for expire cache tests."""
         configuration = self.configuration
-        # Ensure the mig_system_run sub directory exists for expire marks
-        marks_path = os.path.join(
-            configuration.mig_system_run, expire_marks_dir
+        # Ensure necessary directories exist
+        ensure_dirs_exist(configuration.mig_system_files)
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, expire_marks_dir)
         )
-        ensure_dirs_exist(marks_path)
 
     def test_get_account_expire_cache_returns_cached_value(self):
         """Test that get_account_expire_cache returns cached expire value."""
@@ -365,12 +368,11 @@ class TestMigSharedAccountstate__reset_account_expire_cache(MigTestCase):
     def before_each(self):
         """Set up test environment for expire cache tests."""
         configuration = self.configuration
-        # Ensure the mig_system_run sub directory exists for expire marks
-        marks_path = os.path.join(
-            configuration.mig_system_run, expire_marks_dir
+        # Ensure necessary directories exist
+        ensure_dirs_exist(configuration.mig_system_files)
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, expire_marks_dir)
         )
-        ensure_dirs_exist(marks_path)
-
         self.expire_base = os.path.join(
             configuration.mig_system_run, expire_marks_dir
         )
@@ -442,11 +444,11 @@ class TestMigSharedAccountstate__update_account_status_cache(MigTestCase):
     def before_each(self):
         """Set up test environment for status cache tests."""
         configuration = self.configuration
-        # Ensure the mig_system_run sub directory exists for status marks
-        marks_path = os.path.join(
-            configuration.mig_system_run, status_marks_dir
+        # Ensure necessary directories exist
+        ensure_dirs_exist(configuration.mig_system_files)
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, status_marks_dir)
         )
-        ensure_dirs_exist(marks_path)
 
     def test_update_account_status_cache_creates_mark(self):
         """Test that update_account_status_cache creates a status mark."""
@@ -565,11 +567,11 @@ class TestMigSharedAccountstate__get_account_status_cache(MigTestCase):
     def before_each(self):
         """Set up test environment for status cache tests."""
         configuration = self.configuration
-        # Ensure the mig_system_run sub directory exists for status marks
-        marks_path = os.path.join(
-            configuration.mig_system_run, status_marks_dir
+        # Ensure necessary directories exist
+        ensure_dirs_exist(configuration.mig_system_files)
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, status_marks_dir)
         )
-        ensure_dirs_exist(marks_path)
 
     def test_get_account_status_cache_returns_cached_value(self):
         """Test that get_account_status_cache returns cached status value."""
@@ -614,12 +616,12 @@ class TestMigSharedAccountstate__check_account_expire(MigTestCase):
     def before_each(self):
         """Set up test environment for check_account_expire."""
         configuration = self.configuration
-        # Ensure the mig_system_run directory exists for expire marks
-        marks_path = os.path.join(
-            configuration.mig_system_run, expire_marks_dir
+        # Ensure necessary directories exist
+        ensure_dirs_exist(configuration.mig_system_files)
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, expire_marks_dir)
         )
-        ensure_dirs_exist(marks_path)
-
+        # Set up user DB and keep paths for later use
         _ensure_dirs_needed_for_userdb(configuration)
         self.expected_user_db_home = os.path.normpath(
             configuration.user_db_home
@@ -778,16 +780,15 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
     def before_each(self):
         """Set up test environment for account_expire_info."""
         configuration = self.configuration
-        # Ensure the mig_system_run directory exists for expire and status marks
-        marks_path = os.path.join(
-            configuration.mig_system_run, expire_marks_dir
+        # Ensure necessary directories exist
+        ensure_dirs_exist(configuration.mig_system_files)
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, expire_marks_dir)
         )
-        ensure_dirs_exist(marks_path)
-        marks_path = os.path.join(
-            configuration.mig_system_run, status_marks_dir
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, status_marks_dir)
         )
-        ensure_dirs_exist(marks_path)
-
+        # Set up user DB and keep paths for later use
         _ensure_dirs_needed_for_userdb(configuration)
         self.expected_user_db_home = os.path.normpath(
             configuration.user_db_home
@@ -802,6 +803,41 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
         configuration.auto_add_oidc_user = True
         configuration.auto_add_cert_user = True
         configuration.site_user_id_format = "X509"  # Default format
+
+    def test_account_expire_info_about_to_expire_cert(self):
+        """Test account_expire_info for certificate user about to expire."""
+        configuration = self.configuration
+        logger = self.logger
+        # Set expire to be within min_days_left (14 days)
+        expect_expire = time.time() + (10 * 24 * 3600)  # 10 days from now
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": expect_expire,
+            "status": "active",
+        }
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        environ = {
+            "REMOTE_ADDR": "127.0.0.1",
+            "HTTP_USER_AGENT": "some agent",
+        }
+        base_url = "https://cert.example.com"
+        configuration.migserver_https_ext_cert_url = base_url
+        environ["SCRIPT_URI"] = "%s/wsgi-bin/something.py" % base_url
+
+        expire_warn, account_expire, renew_days, extend_days = (
+            account_expire_info(
+                configuration, TEST_USER_DN, environ, min_days_left=14
+            )
+        )
+        self.assertTrue(expire_warn)
+        self.assertEqual(account_expire, expect_expire)
+        self.assertEqual(renew_days, configuration.cert_valid_days)
+        self.assertEqual(extend_days, cert_auto_extend_days)
 
     def test_account_expire_info_about_to_expire_oid(self):
         """Test account_expire_info for OID user about to expire."""
@@ -839,6 +875,42 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
         self.assertEqual(renew_days, configuration.oid_valid_days)
         self.assertEqual(extend_days, oid_auto_extend_days)
 
+    def test_account_expire_info_about_to_expire_oidc(self):
+        """Test account_expire_info for OIDC user about to expire."""
+        configuration = self.configuration
+        logger = self.logger
+        # Set expire to be within min_days_left (14 days)
+        expect_expire = time.time() + (10 * 24 * 3600)  # 10 days from now
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": expect_expire,
+            "status": "active",
+        }
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        # Simulate OIDC login environment
+        environ = {
+            "REMOTE_ADDR": "127.0.0.1",
+            "HTTP_USER_AGENT": "some agent",
+        }
+        base_url = "https://oidc.example.com"
+        configuration.migserver_https_ext_oidc_url = base_url
+        environ["SCRIPT_URI"] = "%s/wsgi-bin/something.py" % base_url
+
+        expire_warn, account_expire, renew_days, extend_days = (
+            account_expire_info(
+                configuration, TEST_USER_DN, environ, min_days_left=14
+            )
+        )
+        self.assertTrue(expire_warn)
+        self.assertEqual(account_expire, expect_expire)
+        self.assertEqual(renew_days, configuration.oidc_valid_days)
+        self.assertEqual(extend_days, oidc_auto_extend_days)
+
     def test_account_expire_info_not_about_to_expire(self):
         """Test account_expire_info for user not about to expire."""
         configuration = self.configuration
@@ -860,8 +932,8 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
             "REMOTE_ADDR": "127.0.0.1",
             "HTTP_USER_AGENT": "some agent",
         }
-        base_url = "https://oid.example.com"
-        configuration.migserver_https_ext_oid_url = base_url
+        base_url = "https://oidc.example.com"
+        configuration.migserver_https_ext_oidc_url = base_url
         environ["SCRIPT_URI"] = "%s/wsgi-bin/something.py" % base_url
 
         expire_warn, account_expire, renew_days, extend_days = (
@@ -912,76 +984,6 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
         self.assertEqual(renew_days, configuration.oid_valid_days)
         self.assertEqual(extend_days, 0)  # Because auto-renew is disabled
 
-    def test_account_expire_info_about_to_expire_cert(self):
-        """Test account_expire_info for certificate user about to expire."""
-        configuration = self.configuration
-        logger = self.logger
-        # Set expire to be within min_days_left (14 days)
-        expect_expire = time.time() + (10 * 24 * 3600)  # 10 days from now
-        user_dict = {
-            "distinguished_name": TEST_USER_DN,
-            "expire": expect_expire,
-            "status": "active",
-        }
-        update_user_dict(
-            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
-        )
-        update_account_expire_cache(configuration, user_dict)
-        update_account_status_cache(configuration, user_dict)
-
-        environ = {
-            "REMOTE_ADDR": "127.0.0.1",
-            "HTTP_USER_AGENT": "some agent",
-        }
-        base_url = "https://cert.example.com"
-        configuration.migserver_https_ext_cert_url = base_url
-        environ["SCRIPT_URI"] = "%s/wsgi-bin/something.py" % base_url
-
-        expire_warn, account_expire, renew_days, extend_days = (
-            account_expire_info(
-                configuration, TEST_USER_DN, environ, min_days_left=14
-            )
-        )
-        self.assertTrue(expire_warn)
-        self.assertEqual(account_expire, expect_expire)
-        self.assertEqual(renew_days, configuration.cert_valid_days)
-        self.assertEqual(extend_days, cert_auto_extend_days)
-
-    def test_account_expire_info_about_to_expire_oidc(self):
-        """Test account_expire_info for OIDC user about to expire."""
-        configuration = self.configuration
-        logger = self.logger
-        # Set expire to be within min_days_left (14 days)
-        expect_expire = time.time() + (10 * 24 * 3600)  # 10 days from now
-        user_dict = {
-            "distinguished_name": TEST_USER_DN,
-            "expire": expect_expire,
-            "status": "active",
-        }
-        update_user_dict(
-            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
-        )
-        update_account_expire_cache(configuration, user_dict)
-        update_account_status_cache(configuration, user_dict)
-
-        environ = {
-            "REMOTE_ADDR": "127.0.0.1",
-            "HTTP_USER_AGENT": "some agent",
-        }
-        base_url = "https://oidc.example.com"
-        configuration.migserver_https_ext_oidc_url = base_url
-        environ["SCRIPT_URI"] = "%s/wsgi-bin/something.py" % base_url
-
-        expire_warn, account_expire, renew_days, extend_days = (
-            account_expire_info(
-                configuration, TEST_USER_DN, environ, min_days_left=14
-            )
-        )
-        self.assertTrue(expire_warn)
-        self.assertEqual(account_expire, expect_expire)
-        self.assertEqual(renew_days, configuration.oidc_valid_days)
-        self.assertEqual(extend_days, oidc_auto_extend_days)
-
     def test_account_expire_info_with_different_min_days_left(self):
         """Test account_expire_info with a custom min_days_left."""
         configuration = self.configuration
@@ -1003,8 +1005,8 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
             "REMOTE_ADDR": "127.0.0.1",
             "HTTP_USER_AGENT": "some agent",
         }
-        base_url = "https://oid.example.com"
-        configuration.migserver_https_ext_oid_url = base_url
+        base_url = "https://oidc.example.com"
+        configuration.migserver_https_ext_oidc_url = base_url
         environ["SCRIPT_URI"] = "%s/wsgi-bin/something.py" % base_url
 
         # Test with min_days_left=7 (so 10 days is beyond 7 -> not about to expire)
@@ -1026,8 +1028,8 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
         )
         self.assertTrue(expire_warn)
         self.assertEqual(account_expire, expect_expire)
-        self.assertEqual(renew_days, configuration.oid_valid_days)
-        self.assertEqual(extend_days, oid_auto_extend_days)
+        self.assertEqual(renew_days, configuration.oidc_valid_days)
+        self.assertEqual(extend_days, oidc_auto_extend_days)
 
 
 class TestMigSharedAccountstate__detect_special_login(MigTestCase):
@@ -1140,7 +1142,11 @@ class TestMigSharedAccountstate__check_account_status(
     def before_each(self):
         """Set up test environment for check_account_status tests."""
         configuration = self.configuration
-        # Ensure the status‑marks directory exists
+        # Ensure necessary directories exist
+        ensure_dirs_exist(self.configuration.mig_system_files)
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, expire_marks_dir)
+        )
         ensure_dirs_exist(
             os.path.join(configuration.mig_system_run, status_marks_dir)
         )
@@ -1152,7 +1158,6 @@ class TestMigSharedAccountstate__check_account_status(
         self.expected_user_db_file = os.path.join(
             self.expected_user_db_home, "MiG-users.db"
         )
-        ensure_dirs_exist(self.configuration.mig_system_files)
         # Provision a known test user
         self._provision_test_user(self, TEST_USER_DN)
 
@@ -1181,7 +1186,7 @@ class TestMigSharedAccountstate__check_account_status(
         configuration = self.configuration
         user_dict = {
             "distinguished_name": TEST_USER_DN,
-            "status": "locked",
+            "status": TEST_STATUS_LOCKED,
         }
         update_user_dict(
             self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
@@ -1192,14 +1197,14 @@ class TestMigSharedAccountstate__check_account_status(
             configuration, TEST_USER_DN
         )
         self.assertFalse(accessible)
-        self.assertEqual(status, "locked")
+        self.assertEqual(status, TEST_STATUS_LOCKED)
 
     def test_check_account_status_suspended(self):
         """Test that a suspended account is reported as not accessible."""
         configuration = self.configuration
         user_dict = {
             "distinguished_name": TEST_USER_DN,
-            "status": "suspended",
+            "status": TEST_STATUS_SUSPENDED,
         }
         update_user_dict(
             self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
@@ -1210,7 +1215,7 @@ class TestMigSharedAccountstate__check_account_status(
             configuration, TEST_USER_DN
         )
         self.assertFalse(accessible)
-        self.assertEqual(status, "suspended")
+        self.assertEqual(status, TEST_STATUS_SUSPENDED)
 
     def test_check_account_status_unset_means_active(self):
         """Test that an account without status is active and accessible."""
@@ -1280,8 +1285,14 @@ class TestMigSharedAccountstate__check_account_accessible(
         self.configuration.site_enable_jupyter = True
         # Ensure necessary directories exist
         ensure_dirs_exist(configuration.mig_system_files)
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, expire_marks_dir)
+        )
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, status_marks_dir)
+        )
+        # Set up user DB and keep paths for later use
         _ensure_dirs_needed_for_userdb(configuration)
-        # Keep paths for possible later use
         self.expected_user_db_home = os.path.normpath(
             configuration.user_db_home
         )
@@ -1385,7 +1396,7 @@ class TestMigSharedAccountstate__check_account_accessible(
         configuration = self.configuration
         user_dict = {
             "distinguished_name": TEST_USER_DN,
-            "status": "locked",
+            "status": TEST_STATUS_LOCKED,
         }
         update_user_dict(
             self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
@@ -1402,7 +1413,7 @@ class TestMigSharedAccountstate__check_account_accessible(
         configuration = self.configuration
         user_dict = {
             "distinguished_name": TEST_USER_DN,
-            "status": "locked",
+            "status": TEST_STATUS_LOCKED,
         }
         update_user_dict(
             self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
@@ -1572,6 +1583,297 @@ class TestMigSharedAccountstate__check_account_accessible(
             configuration, TEST_USER_DN, "oid", io_login=False
         )
         self.assertTrue(accessible)  # Because OpenID expire is disabled
+
+
+class TestMigSharedAccountstate__check_update_account_expire(
+    MigTestCase, UserAssertMixin
+):
+    """Coverage of accountstate check_update_account_expire function."""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test environment for check_update_account_expire tests."""
+        configuration = self.configuration
+        # Ensure necessary directories exist
+        ensure_dirs_exist(configuration.mig_system_files)
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, expire_marks_dir)
+        )
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, status_marks_dir)
+        )
+        # Set up user DB and keep paths for later use
+        _ensure_dirs_needed_for_userdb(configuration)
+        self.expected_user_db_home = os.path.normpath(
+            configuration.user_db_home
+        )
+        self.expected_user_db_file = os.path.join(
+            self.expected_user_db_home, "MiG-users.db"
+        )
+        self._provision_test_user(self, TEST_USER_DN)
+
+    def _update_account_in_db_and_cache(
+        self, expire, status=TEST_STATUS_ACTIVE
+    ):
+        """Write account status and expire data to the DB and cache."""
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": status,
+            "expire": expire,
+        }
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(self.configuration, user_dict)
+        update_account_status_cache(self.configuration, user_dict)
+        return user_dict
+
+    def test_check_update_account_expire_auto_extends_oid(self):
+        """Test auto extension for an OID user about to expire."""
+        configuration = self.configuration
+        expire = time.time() + 5 * 24 * 3600
+        self._update_account_in_db_and_cache(expire)
+        base_url = "https://oidc.example.com"
+        configuration.migserver_https_ext_oid_url = base_url
+        configuration.auto_add_oid_user = True
+        environ = {
+            "REMOTE_ADDR": "192.0.2.10",
+            "HTTP_USER_AGENT": "test agent",
+            "SCRIPT_URI": "%s/wsgi-bin/something.py" % base_url,
+        }
+
+        pending, cached_expire, user_dict = check_update_account_expire(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+
+        self.assertTrue(pending)
+        self.assertEqual(cached_expire, expire)
+        self.assertTrue(user_dict)
+        self.assertTrue(user_dict["expire"] > expire)
+        self.assertEqual(
+            get_account_expire_cache(configuration, TEST_USER_DN),
+            user_dict["expire"],
+        )
+        self.assertEqual(
+            load_user_dict(
+                self.logger, TEST_USER_DN, self.expected_user_db_file
+            )["expire"],
+            user_dict["expire"],
+        )
+
+    def test_check_update_account_expire_auto_extends_oidc(self):
+        """Test auto extension for an OIDC user about to expire."""
+        configuration = self.configuration
+        expire = time.time() + 5 * 24 * 3600
+        self._update_account_in_db_and_cache(expire)
+        base_url = "https://oidc.example.com"
+        configuration.migserver_https_ext_oidc_url = base_url
+        configuration.auto_add_oidc_user = True
+        environ = {
+            "REMOTE_ADDR": "192.0.2.10",
+            "HTTP_USER_AGENT": "test agent",
+            "SCRIPT_URI": "%s/wsgi-bin/something.py" % base_url,
+        }
+
+        pending, cached_expire, user_dict = check_update_account_expire(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+
+        self.assertTrue(pending)
+        self.assertEqual(cached_expire, expire)
+        self.assertTrue(user_dict)
+        self.assertTrue(user_dict["expire"] > expire)
+        self.assertEqual(
+            get_account_expire_cache(configuration, TEST_USER_DN),
+            user_dict["expire"],
+        )
+
+    def test_check_update_account_expire_auto_extends_cert(self):
+        """Test auto extension for a certificate user about to expire."""
+        configuration = self.configuration
+        expire = time.time() + 5 * 24 * 3600
+        self._update_account_in_db_and_cache(expire)
+        base_url = "https://cert.example.com"
+        configuration.migserver_https_ext_cert_url = base_url
+        configuration.auto_add_cert_user = True
+        environ = {
+            "REMOTE_ADDR": "192.0.2.10",
+            "HTTP_USER_AGENT": "test agent",
+            "SCRIPT_URI": "%s/wsgi-bin/something.py" % base_url,
+        }
+
+        pending, cached_expire, user_dict = check_update_account_expire(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+
+        self.assertTrue(pending)
+        self.assertEqual(cached_expire, expire)
+        self.assertTrue(user_dict)
+        self.assertTrue(user_dict["expire"] > expire)
+        self.assertEqual(
+            get_account_expire_cache(configuration, TEST_USER_DN),
+            user_dict["expire"],
+        )
+
+    def test_check_update_account_expire_not_near_expiry(self):
+        """Test that users not near expiry are not auto-extended."""
+        configuration = self.configuration
+        expire = time.time() + 30 * 24 * 3600
+        self._update_account_in_db_and_cache(expire)
+        base_url = "https://oidc.example.com"
+        configuration.migserver_https_ext_oidc_url = base_url
+        configuration.auto_add_oidc_user = True
+        environ = {
+            "REMOTE_ADDR": "192.0.2.10",
+            "HTTP_USER_AGENT": "test agent",
+            "SCRIPT_URI": "%s/wsgi-bin/something.py" % base_url,
+        }
+
+        pending, cached_expire, user_dict = check_update_account_expire(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+
+        self.assertTrue(pending)
+        self.assertEqual(cached_expire, expire)
+        # NOTE: for expired users with cache mark no user_dict is loaded
+        self.assertEqual(user_dict, None)
+        self.assertEqual(
+            get_account_expire_cache(configuration, TEST_USER_DN),
+            expire,
+        )
+
+    def test_check_update_account_expire_no_matching_auto_update(self):
+        """Test that near-expiry users keep expire without matching vhost."""
+        configuration = self.configuration
+        expire = time.time() + 5 * 24 * 3600
+        self._update_account_in_db_and_cache(expire)
+        configuration.migserver_https_ext_oidc_url = "https://oidc.example.com"
+        configuration.auto_add_oidc_user = True
+        environ = {
+            "REMOTE_ADDR": "192.0.2.10",
+            "HTTP_USER_AGENT": "test agent",
+            "SCRIPT_URI": "https://unknown.example.com/wsgi-bin/page.py",
+        }
+
+        pending, cached_expire, user_dict = check_update_account_expire(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+
+        self.assertTrue(pending)
+        self.assertEqual(cached_expire, expire)
+        # NOTE: for expired users with cache mark no user_dict is loaded
+        self.assertEqual(user_dict, None)
+        self.assertEqual(
+            get_account_expire_cache(configuration, TEST_USER_DN),
+            expire,
+        )
+
+    def test_check_update_account_expire_skips_temporal_user_without_peer(self):
+        """Test that local (typically external) temporal users are not auto-extended without peer."""
+        configuration = self.configuration
+        expire = 42
+        self._update_account_in_db_and_cache(expire, TEST_STATUS_TEMPORAL)
+        base_url = "https://ext.example.com"
+        configuration.migserver_https_mig_oid_url = base_url
+        # Enable renew with peers but test without any active
+        configuration.auto_add_oid_user = True
+        self.site_enable_peers = True
+        self.site_peers_mandatory = True
+        self.site_peers_explicit_fields = ["email"]
+        environ = {
+            "REMOTE_ADDR": "127.0.0.1",
+            "HTTP_USER_AGENT": "test agent",
+            "SCRIPT_URI": "%s/wsgi-bin/something.py" % base_url,
+        }
+
+        pending, cached_expire, user_dict = check_update_account_expire(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+
+        self.assertFalse(pending)
+        self.assertEqual(cached_expire, expire)
+        # NOTE: for expired users with cache mark no user_dict is loaded
+        self.assertEqual(user_dict, None)
+        self.assertEqual(
+            get_account_expire_cache(configuration, TEST_USER_DN),
+            expire,
+        )
+
+    def test_check_update_account_expire_does_not_extend_locked_user(self):
+        """Test that locked users are not auto-extended."""
+        configuration = self.configuration
+        expire = time.time() + 5 * 24 * 3600
+        self._update_account_in_db_and_cache(expire, status=TEST_STATUS_LOCKED)
+        base_url = "https://oid.example.com"
+        configuration.migserver_https_ext_oidc_url = base_url
+        configuration.auto_add_oidc_user = True
+        environ = {
+            "REMOTE_ADDR": "192.0.2.10",
+            "HTTP_USER_AGENT": "test agent",
+            "SCRIPT_URI": "%s/wsgi-bin/something.py" % base_url,
+        }
+
+        pending, cached_expire, user_dict = check_update_account_expire(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+
+        self.assertTrue(pending)
+        self.assertEqual(cached_expire, expire)
+        self.assertTrue(user_dict)
+        self.assertEqual(user_dict["expire"], expire)
+        self.assertEqual(
+            get_account_expire_cache(configuration, TEST_USER_DN),
+            expire,
+        )
+
+    def test_check_update_account_expire_expired_without_auto_update(self):
+        """Test that expired users stay expired without matching auto update."""
+        configuration = self.configuration
+        expire = 42
+        self._update_account_in_db_and_cache(expire)
+        base_url = "https://ext.example.com"
+        configuration.migserver_https_mig_oid_url = base_url
+        configuration.auto_add_oid_user = False
+        environ = {
+            "REMOTE_ADDR": "192.0.2.10",
+            "HTTP_USER_AGENT": "test agent",
+            "SCRIPT_URI": "%s/wsgi-bin/page.py" % base_url,
+        }
+
+        pending, cached_expire, user_dict = check_update_account_expire(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+
+        self.assertFalse(pending)
+        self.assertEqual(cached_expire, expire)
+        # NOTE: for expired users with cache mark no user_dict is loaded
+        self.assertEqual(user_dict, None)
+        self.assertEqual(
+            get_account_expire_cache(configuration, TEST_USER_DN),
+            expire,
+        )
+
+    def test_check_update_account_expire_missing_user(self):
+        """Test that missing users are reported as expired."""
+        configuration = self.configuration
+        base_url = "https://oid.example.com"
+        environ = {
+            "REMOTE_ADDR": "192.0.2.10",
+            "HTTP_USER_AGENT": "test agent",
+            "SCRIPT_URI": "%s/wsgi-bin/something.py" % base_url,
+        }
+        with self.assertLogs(level="ERROR") as log_capture:
+            pending, expire, user_dict = check_update_account_expire(
+                configuration, OTHER_USER_DN, environ, min_days_left=14
+            )
+        self.assertFalse(pending)
+        self.assertEqual(expire, -42)
+        self.assertIsNone(user_dict)
+        self.assertTrue(
+            any("no such account" in msg for msg in log_capture.output)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_mig_shared_accountstate.py
+++ b/tests/test_mig_shared_accountstate.py
@@ -35,6 +35,7 @@ import unittest
 from mig.shared.accountstate import (
     account_expire_info,
     check_account_expire,
+    check_account_status,
     default_account_expire,
     default_account_valid_days,
     detect_special_login,
@@ -64,6 +65,7 @@ from mig.shared.userdb import update_user_dict
 # Imports required for the unit tests themselves
 from tests.support import (
     MigTestCase,
+    UserAssertMixin,
     ensure_dirs_exist,
     testmain,
 )
@@ -1100,6 +1102,130 @@ class TestMigSharedAccountstate__detect_special_login(MigTestCase):
         configuration = self.configuration
         result = detect_special_login(configuration, "", "sftp")
         self.assertFalse(result)
+
+
+class TestMigSharedAccountstate__check_account_status(
+    MigTestCase, UserAssertMixin
+):
+    """Coverage of accountstate check_account_status function."""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test environment for check_account_status tests."""
+        configuration = self.configuration
+        # Ensure the status‑marks directory exists
+        ensure_dirs_exist(
+            os.path.join(configuration.mig_system_run, status_marks_dir)
+        )
+        # Set up user DB and keep paths for later use
+        _ensure_dirs_needed_for_userdb(configuration)
+        self.expected_user_db_home = os.path.normpath(
+            configuration.user_db_home)
+        self.expected_user_db_file = os.path.join(
+            self.expected_user_db_home, "MiG-users.db"
+        )
+        ensure_dirs_exist(self.configuration.mig_system_files)
+        # Provision a known test user
+        self._provision_test_user(self, TEST_USER_DN)
+
+    def test_check_account_status_active(self):
+        """Test that an active account is reported as accessible."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "active",
+        }
+        # Create a DB entry for the user
+        update_user_dict(self.logger, TEST_USER_DN, user_dict,
+                         self.expected_user_db_file)
+        # Populate the status cache
+        update_account_status_cache(configuration, user_dict)
+
+        accessible, status, _ = check_account_status(configuration,
+                                                     TEST_USER_DN)
+        self.assertTrue(accessible)
+        self.assertEqual(status, "active")
+
+    def test_check_account_status_locked(self):
+        """Test that a locked account is reported as not accessible."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "locked",
+        }
+        update_user_dict(self.logger, TEST_USER_DN, user_dict,
+                         self.expected_user_db_file)
+        update_account_status_cache(configuration, user_dict)
+
+        accessible, status, _ = check_account_status(configuration,
+                                                     TEST_USER_DN)
+        self.assertFalse(accessible)
+        self.assertEqual(status, "locked")
+
+    def test_check_account_status_suspended(self):
+        """Test that a suspended account is reported as not accessible."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "suspended",
+        }
+        update_user_dict(self.logger, TEST_USER_DN, user_dict,
+                         self.expected_user_db_file)
+        update_account_status_cache(configuration, user_dict)
+
+        accessible, status, _ = check_account_status(configuration,
+                                                     TEST_USER_DN)
+        self.assertFalse(accessible)
+        self.assertEqual(status, "suspended")
+
+    def test_check_account_status_unset_means_active(self):
+        """Test that an account without status is active and accessible."""
+        configuration = self.configuration
+        expire_ts = time.time() + 42 * 24 * 3600  # expired in 42 days
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": expire_ts,
+        }
+        update_user_dict(self.logger, TEST_USER_DN, user_dict,
+                         self.expected_user_db_file)
+        update_account_status_cache(configuration, user_dict)
+
+        accessible, status, _ = check_account_status(configuration,
+                                                     TEST_USER_DN)
+        self.assertTrue(accessible)
+        self.assertEqual(status, 'active')
+
+    def test_check_account_status_unchanged_by_expire(self):
+        """Test that account status itself remains unchanged after expire."""
+        configuration = self.configuration
+        expire_ts = time.time() - 42 * 24 * 3600  # expired 42 days ago
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "active",
+            "expire": expire_ts,
+        }
+        update_user_dict(self.logger, TEST_USER_DN, user_dict,
+                         self.expected_user_db_file)
+        update_account_status_cache(configuration, user_dict)
+
+        accessible, status, _ = check_account_status(configuration,
+                                                     TEST_USER_DN)
+        self.assertTrue(accessible)
+        self.assertEqual(status, 'active')
+
+    def test_check_account_status_missing_user(self):
+        """Test that check_account_status fails gracefully for a missing user."""
+        configuration = self.configuration
+        with self.assertLogs(level="WARNING") as log_capture:
+            accessible, _, _ = check_account_status(
+                configuration, OTHER_USER_DN
+            )
+        self.assertFalse(accessible)
+        self.assertTrue(
+            any("no such account" in msg for msg in log_capture.output)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_mig_shared_accountstate.py
+++ b/tests/test_mig_shared_accountstate.py
@@ -55,6 +55,7 @@ from mig.shared.defaults import (
     AUTH_GENERIC,
     AUTH_OPENID_CONNECT,
     AUTH_OPENID_V2,
+    DEFAULT_USER_ID_FORMAT,
     cert_auto_extend_days,
     expire_marks_dir,
     oid_auto_extend_days,
@@ -88,6 +89,9 @@ TEST_USER_EMAIL = TEST_USER_DN.split("/emailAddress=", 1)[-1]
 TEST_USER_DIR = client_id_dir(TEST_USER_DN)
 OTHER_USER_DIR = client_id_dir(OTHER_USER_DN)
 
+
+
+# TODO: test gdp usernames, too
 
 class TestMigSharedAccountstate__default_account_valid_days(MigTestCase):
     """Coverage of accountstate default_account_valid_days function."""
@@ -1007,7 +1011,8 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
         self.assertTrue(expire_warn)
         self.assertEqual(account_expire, expect_expire)
         self.assertEqual(renew_days, configuration.oid_valid_days)
-        self.assertEqual(extend_days, 0)  # Because auto-renew is disabled
+        # NOTE: should be 0 because auto-renew is disabled
+        self.assertEqual(extend_days, 0)
 
     def test_account_expire_info_with_different_min_days_left(self):
         """Test account_expire_info with a custom min_days_left."""
@@ -1305,6 +1310,8 @@ class TestMigSharedAccountstate__check_account_accessible(
     def before_each(self):
         """Set up test environment for check_account_accessible tests."""
         configuration = self.configuration
+        # Force X509 user ID format
+        configuration.site_user_id_format = DEFAULT_USER_ID_FORMAT
         configuration.site_enable_sharelinks = True
         configuration.site_enable_jobs = True
         configuration.site_enable_jupyter = True
@@ -1582,13 +1589,14 @@ class TestMigSharedAccountstate__check_account_accessible(
         update_account_expire_cache(configuration, user_dict)
         update_account_status_cache(configuration, user_dict)
 
+        # NOTE: should succeed because IO expire is disabled
         accessible = check_account_accessible(
             configuration, TEST_USER_DN, "sftp", io_login=True
         )
-        self.assertTrue(accessible)  # Because IO expire is disabled
+        self.assertTrue(accessible)
 
-    def test_check_account_accessible_openid_expire_disabled(self):
-        """Test that account remains accessible on OpenID (non-IO) when expire is not enforced."""
+    def test_check_account_accessible_openid_expire_disabled_direct(self):
+        """Test that account remains accessible on OpenID (non-IO) with direct DN when expire is not enforced."""
         configuration = self.configuration
         configuration.user_openid_enforce_expire = False
         # Set expire to past
@@ -1604,10 +1612,35 @@ class TestMigSharedAccountstate__check_account_accessible(
         update_account_expire_cache(configuration, user_dict)
         update_account_status_cache(configuration, user_dict)
 
+        # NOTE: should succeed because OpenID expire is disabled
+        # NOTE: we can also check with DN even if not really used
         accessible = check_account_accessible(
             configuration, TEST_USER_DN, "oid", io_login=False
         )
-        self.assertTrue(accessible)  # Because OpenID expire is disabled
+        self.assertTrue(accessible)
+
+    def test_check_account_accessible_openid_expire_disabled_on_email_alias(self):
+        """Test that account remains accessible on OpenID (non-IO) with email when expire is not enforced."""
+        configuration = self.configuration
+        configuration.user_openid_enforce_expire = False
+        # Set expire to past
+        expire_ts = 42
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "active",
+            "expire": expire_ts,
+        }
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        # NOTE: should succeed because OpenID expire is disabled
+        accessible = check_account_accessible(
+            configuration, TEST_USER_EMAIL, "oid", io_login=False
+        )
+        self.assertTrue(accessible)
 
 
 class TestMigSharedAccountstate__check_update_account_expire(

--- a/tests/test_mig_shared_accountstate.py
+++ b/tests/test_mig_shared_accountstate.py
@@ -686,22 +686,40 @@ class TestMigSharedAccountstate__check_account_expire(MigTestCase):
         self.assertEqual(expire, -1)
 
     def test_check_account_expire_invalid_expire_type(self):
-        """Test that check_account_expire returns expired if expire is not a number."""
+        """Test that check_account_expire returns expired if expire is not a valid number."""
         configuration = self.configuration
         logger = self.logger
         user_dict = {
             "distinguished_name": TEST_USER_DN,
+            # Example invalid values that will pass assertions
             "expire": "invalid",
+            # "expire": "-41"
+            # "expire": "-41.2"
+            # "expire": "11111111111111141.2"
+            #
+            # Example valid values that will fail assertions
+            # "expire": "4242"
+            # "expire": 4242
+            # "expire": -41.2
+            # "expire": 11111111111111141.2
         }
         update_user_dict(
             logger, TEST_USER_DN, user_dict, self.expected_user_db_file
         )
+        # Make sure cache doesn't interfere with type parsing
+        reset_account_expire_cache(configuration)
+        # Use expected error values to trigger asserts if assertRaises doesn't
+        pending, expire = False, -42
+        # Make sure function under test either fails with TypeError or returns
+        # values indicating failure to prevent further login use.
         with self.assertRaises(TypeError):
             pending, expire, _ = check_account_expire(
                 configuration, TEST_USER_DN
             )
-            self.assertFalse(pending)
-            self.assertEqual(expire, -42)
+        self.assertFalse(pending, "got expected TypeError but not expired")
+        self.assertEqual(
+            expire, -42, "got expected TypeError but unexpected expire time"
+        )
 
     def test_check_account_expire_no_user_db_entry(self):
         """Test that check_account_expire returns expired if user is not in the DB."""
@@ -1042,9 +1060,9 @@ class TestMigSharedAccountstate__detect_special_login(MigTestCase):
     def before_each(self):
         """Create the directories that the function may touch."""
         configuration = self.configuration
-        self.configuration.site_enable_sharelinks = True
-        self.configuration.site_enable_jobs = True
-        self.configuration.site_enable_jupyter = True
+        configuration.site_enable_sharelinks = True
+        configuration.site_enable_jobs = True
+        configuration.site_enable_jupyter = True
         # Ensure the home directories that the function may reference exist
         ensure_dirs_exist(configuration.user_home)
         ensure_dirs_exist(configuration.mrsl_files_dir)
@@ -1263,7 +1281,7 @@ class TestMigSharedAccountstate__check_account_status(
             accessible, _, _ = check_account_status(
                 configuration, OTHER_USER_DN
             )
-        self.assertFalse(accessible)
+            self.assertFalse(accessible)
         self.assertTrue(
             any("no such account" in msg for msg in log_capture.output)
         )
@@ -1280,9 +1298,9 @@ class TestMigSharedAccountstate__check_account_accessible(
     def before_each(self):
         """Set up test environment for check_account_accessible tests."""
         configuration = self.configuration
-        self.configuration.site_enable_sharelinks = True
-        self.configuration.site_enable_jobs = True
-        self.configuration.site_enable_jupyter = True
+        configuration.site_enable_sharelinks = True
+        configuration.site_enable_jobs = True
+        configuration.site_enable_jupyter = True
         # Ensure necessary directories exist
         ensure_dirs_exist(configuration.mig_system_files)
         ensure_dirs_exist(
@@ -1868,9 +1886,9 @@ class TestMigSharedAccountstate__check_update_account_expire(
             pending, expire, user_dict = check_update_account_expire(
                 configuration, OTHER_USER_DN, environ, min_days_left=14
             )
-        self.assertFalse(pending)
-        self.assertEqual(expire, -42)
-        self.assertIsNone(user_dict)
+            self.assertFalse(pending)
+            self.assertEqual(expire, -42)
+            self.assertIsNone(user_dict)
         self.assertTrue(
             any("no such account" in msg for msg in log_capture.output)
         )

--- a/tests/test_mig_shared_accountstate.py
+++ b/tests/test_mig_shared_accountstate.py
@@ -34,6 +34,7 @@ import unittest
 # Imports of the code under test
 from mig.shared.accountstate import (
     account_expire_info,
+    check_account_accessible,
     check_account_expire,
     check_account_status,
     default_account_expire,
@@ -1039,6 +1040,7 @@ class TestMigSharedAccountstate__detect_special_login(MigTestCase):
     def before_each(self):
         """Create the directories that the function may touch."""
         configuration = self.configuration
+        self.configuration.site_enable_sharelinks = True
         self.configuration.site_enable_jobs = True
         self.configuration.site_enable_jupyter = True
         # Ensure the home directories that the function may reference exist
@@ -1260,6 +1262,316 @@ class TestMigSharedAccountstate__check_account_status(
         self.assertTrue(
             any("no such account" in msg for msg in log_capture.output)
         )
+
+
+class TestMigSharedAccountstate__check_account_accessible(
+    MigTestCase, UserAssertMixin
+):
+    """Coverage of accountstate check_account_accessible function."""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test environment for check_account_accessible tests."""
+        configuration = self.configuration
+        self.configuration.site_enable_sharelinks = True
+        self.configuration.site_enable_jobs = True
+        self.configuration.site_enable_jupyter = True
+        # Ensure necessary directories exist
+        ensure_dirs_exist(configuration.mig_system_files)
+        _ensure_dirs_needed_for_userdb(configuration)
+        # Keep paths for possible later use
+        self.expected_user_db_home = os.path.normpath(
+            configuration.user_db_home
+        )
+        self.expected_user_db_file = os.path.join(
+            self.expected_user_db_home, "MiG-users.db"
+        )
+        # Provision a known test user
+        self._provision_test_user(self, TEST_USER_DN)
+        # This simulates an existing short id link to X509 in user_home
+        short_id_link_in_home = os.path.join(
+            configuration.user_home, TEST_USER_EMAIL
+        )
+        os.symlink(TEST_USER_DIR, short_id_link_in_home)
+
+    def test_check_account_accessible_active_user_web_access(self):
+        """Test that an active user is accessible via web (non-IO)."""
+        configuration = self.configuration
+        # Ensure the user is active and not expired
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "active",
+            "expire": time.time() + 42 * 24 * 3600,  # far future
+        }
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        accessible = check_account_accessible(
+            configuration, TEST_USER_DN, "oidc", io_login=False
+        )
+        self.assertTrue(accessible)
+
+    def test_check_account_accessible_active_user_io_access(self):
+        """Test that an active user is accessible via SFTP (IO)."""
+        configuration = self.configuration
+        # Ensure the user is active and not expired
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "active",
+            "expire": time.time() + 42 * 24 * 3600,  # far future
+        }
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        accessible = check_account_accessible(
+            configuration, TEST_USER_DN, "sftp"
+        )
+        self.assertTrue(accessible)
+
+    def test_check_account_accessible_active_user_web_access_on_email_alias(
+        self,
+    ):
+        """Test that an active user is accessible via web (non-IO) using email alias."""
+        configuration = self.configuration
+        # Ensure the user is active and not expired
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "active",
+            "expire": time.time() + 42 * 24 * 3600,  # far future
+        }
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        accessible = check_account_accessible(
+            configuration, TEST_USER_EMAIL, "oidc", io_login=False
+        )
+        self.assertTrue(accessible)
+
+    def test_check_account_accessible_active_user_sftp_access_on_email_alias(
+        self,
+    ):
+        """Test that an active user is accessible via SFTP using email alias."""
+        configuration = self.configuration
+        # Ensure the user is active and not expired
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "active",
+            "expire": time.time() + 42 * 24 * 3600,  # far future
+        }
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        accessible = check_account_accessible(
+            configuration, TEST_USER_EMAIL, "sftp"
+        )
+        self.assertTrue(accessible)
+
+    def test_check_account_accessible_locked_user_web_blocked(self):
+        """Test that a locked user is not accessible on web (non-IO)."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "locked",
+        }
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_status_cache(configuration, user_dict)
+
+        accessible = check_account_accessible(
+            configuration, TEST_USER_DN, "oidc", io_login=False
+        )
+        self.assertFalse(accessible)
+
+    def test_check_account_accessible_locked_user_io_blocked(self):
+        """Test that a locked user is not accessible on SFTP (IO)."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "locked",
+        }
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_status_cache(configuration, user_dict)
+
+        accessible = check_account_accessible(
+            configuration, TEST_USER_DN, "sftp"
+        )
+        self.assertFalse(accessible)
+
+    def test_check_account_accessible_expired_user_blocked(self):
+        """Test that an expired user is inaccessible on web (non-ID) login."""
+        configuration = self.configuration
+        # Set expire to past
+        expire_ts = 42
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "active",
+            "expire": expire_ts,
+        }
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        accessible = check_account_accessible(
+            configuration, TEST_USER_DN, "oidc", io_login=False
+        )
+        self.assertFalse(accessible)
+
+    def test_check_account_accessible_expired_user_sftp_access_blocked(self):
+        """Test that an expired user is inaccessible on sftp if enenforced."""
+        configuration = self.configuration
+        configuration.site_io_account_expire = True
+        # Set expire to past
+        expire_ts = 42
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "active",
+            "expire": expire_ts,
+        }
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        accessible = check_account_accessible(
+            configuration, TEST_USER_DN, "sftp"
+        )
+        self.assertFalse(accessible)
+
+    def test_check_account_accessible_special_login_sharelink_access(self):
+        """Test that a sharelink is detected as special login and accessible."""
+        configuration = self.configuration
+        # Create a dummy RW sharelink to user home
+        sharelink_path = os.path.join(
+            configuration.sharelink_home, "read-write", TEST_RW_SHARE_ID
+        )
+        sharelink_target = os.path.join(configuration.user_home, TEST_USER_DIR)
+        ensure_dirs_exist(sharelink_target)
+        ensure_dirs_exist(os.path.dirname(sharelink_path))
+        os.symlink(sharelink_target, sharelink_path)
+
+        accessible = check_account_accessible(
+            configuration, TEST_RW_SHARE_ID, "sftp"
+        )
+        self.assertTrue(accessible)
+
+    def test_check_account_accessible_special_login_job_access(self):
+        """Test that a job ID is detected as special login and accessible."""
+        configuration = self.configuration
+        configuration.site_enable_jobs = True
+        # Create a dummy job link to mrsl files entry
+        job_target_path = os.path.join(
+            configuration.mrsl_files_dir, TEST_JOB_ID
+        )
+        ensure_dirs_exist(job_target_path)
+        job_link_path = os.path.join(
+            configuration.sessid_to_mrsl_link_home, TEST_JOB_ID + ".mRSL"
+        )
+        ensure_dirs_exist(os.path.dirname(job_link_path))
+        os.symlink(job_target_path, job_link_path)
+
+        accessible = check_account_accessible(
+            configuration, TEST_JOB_ID, "sftp"
+        )
+        self.assertTrue(accessible)
+
+    def test_check_account_accessible_special_login_jupyter_access(self):
+        """Test that a jupyter mount ID is detected as special login and accessible."""
+        configuration = self.configuration
+        configuration.site_enable_jupyter = True
+        # Create a dummy jupyter‑mount link to user home
+        jupyter_link_path = os.path.join(
+            configuration.sessid_to_jupyter_mount_link_home,
+            TEST_JUPYTER_SESSION_ID,
+        )
+        jupyter_target = os.path.join(configuration.user_home, TEST_USER_DIR)
+        ensure_dirs_exist(jupyter_target)
+        ensure_dirs_exist(os.path.dirname(jupyter_link_path))
+        os.symlink(jupyter_target, jupyter_link_path)
+
+        accessible = check_account_accessible(
+            configuration, TEST_JUPYTER_SESSION_ID, "sftp"
+        )
+        self.assertTrue(accessible)
+
+    def test_check_account_accessible_missing_user_web_rejected(self):
+        """Test that check_account_accessible rejects a missing user on web (non-IO)."""
+        configuration = self.configuration
+        accessible = check_account_accessible(
+            configuration, OTHER_USER_DN, "oidc", io_login=False
+        )
+        self.assertFalse(accessible)
+
+    def test_check_account_accessible_missing_user_io_rejected(self):
+        """Test that check_account_accessible rejects a missing user on SFTP (IO)."""
+        configuration = self.configuration
+        accessible = check_account_accessible(
+            configuration, OTHER_USER_DN, "sftp"
+        )
+        self.assertFalse(accessible)
+
+    def test_check_account_accessible_io_expire_disabled(self):
+        """Test that account remains accessible on SFTP (IO) when expire is not enforced."""
+        configuration = self.configuration
+        configuration.site_io_account_expire = False
+        # Set expire to past
+        expire_ts = 42
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "active",
+            "expire": expire_ts,
+        }
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        accessible = check_account_accessible(
+            configuration, TEST_USER_DN, "sftp", io_login=True
+        )
+        self.assertTrue(accessible)  # Because IO expire is disabled
+
+    def test_check_account_accessible_openid_expire_disabled(self):
+        """Test that account remains accessible on OpenID (non-IO) when expire is not enforced."""
+        configuration = self.configuration
+        configuration.user_openid_enforce_expire = False
+        # Set expire to past
+        expire_ts = 42
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "active",
+            "expire": expire_ts,
+        }
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        accessible = check_account_accessible(
+            configuration, TEST_USER_DN, "oid", io_login=False
+        )
+        self.assertTrue(accessible)  # Because OpenID expire is disabled
 
 
 if __name__ == "__main__":

--- a/tests/test_mig_shared_accountstate.py
+++ b/tests/test_mig_shared_accountstate.py
@@ -90,8 +90,8 @@ TEST_USER_DIR = client_id_dir(TEST_USER_DN)
 OTHER_USER_DIR = client_id_dir(OTHER_USER_DN)
 
 
-
 # TODO: test gdp usernames, too
+
 
 class TestMigSharedAccountstate__default_account_valid_days(MigTestCase):
     """Coverage of accountstate default_account_valid_days function."""
@@ -696,11 +696,16 @@ class TestMigSharedAccountstate__check_account_expire(MigTestCase):
         logger = self.logger
 
         # Invalid values that will trigger TypeError in function under test
-        for invalid_expire in ("invalid", "-41", "-41.2", "111111111141.2",
-                               (1, 2)):
+        for invalid_expire in (
+            "invalid",
+            "-41",
+            "-41.2",
+            "111111111141.2",
+            (1, 2),
+        ):
             user_dict = {
                 "distinguished_name": TEST_USER_DN,
-                "expire": invalid_expire
+                "expire": invalid_expire,
             }
             update_user_dict(
                 logger, TEST_USER_DN, user_dict, self.expected_user_db_file
@@ -720,7 +725,7 @@ class TestMigSharedAccountstate__check_account_expire(MigTestCase):
         for invalid_expire in ("4242", None, False):
             user_dict = {
                 "distinguished_name": TEST_USER_DN,
-                "expire": invalid_expire
+                "expire": invalid_expire,
             }
             update_user_dict(
                 logger, TEST_USER_DN, user_dict, self.expected_user_db_file
@@ -728,8 +733,9 @@ class TestMigSharedAccountstate__check_account_expire(MigTestCase):
             # Make sure cache doesn't interfere with parsing
             update_account_expire_cache(configuration, user_dict, delete=True)
             # Assure these values return expired to prevent further login use
-            pending, expire, _ = check_account_expire(configuration,
-                                                      TEST_USER_DN)
+            pending, expire, _ = check_account_expire(
+                configuration, TEST_USER_DN
+            )
             self.assertFalse(pending)
 
     def test_check_account_expire_no_user_db_entry(self):
@@ -1619,7 +1625,9 @@ class TestMigSharedAccountstate__check_account_accessible(
         )
         self.assertTrue(accessible)
 
-    def test_check_account_accessible_openid_expire_disabled_on_email_alias(self):
+    def test_check_account_accessible_openid_expire_disabled_on_email_alias(
+        self,
+    ):
         """Test that account remains accessible on OpenID (non-IO) with email when expire is not enforced."""
         configuration = self.configuration
         configuration.user_openid_enforce_expire = False

--- a/tests/test_mig_shared_accountstate.py
+++ b/tests/test_mig_shared_accountstate.py
@@ -685,41 +685,48 @@ class TestMigSharedAccountstate__check_account_expire(MigTestCase):
         self.assertTrue(pending)
         self.assertEqual(expire, -1)
 
+    # TODO: handle underlying type errors gracefully and drop this test
     def test_check_account_expire_invalid_expire_type(self):
-        """Test that check_account_expire returns expired if expire is not a valid number."""
+        """Test that check_account_expire fails if expire is not a valid type."""
         configuration = self.configuration
         logger = self.logger
-        user_dict = {
-            "distinguished_name": TEST_USER_DN,
-            # Example invalid values that will pass assertions
-            "expire": "invalid",
-            # "expire": "-41"
-            # "expire": "-41.2"
-            # "expire": "11111111111111141.2"
-            #
-            # Example valid values that will fail assertions
-            # "expire": "4242"
-            # "expire": 4242
-            # "expire": -41.2
-            # "expire": 11111111111111141.2
-        }
-        update_user_dict(
-            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
-        )
-        # Make sure cache doesn't interfere with type parsing
-        reset_account_expire_cache(configuration)
-        # Use expected error values to trigger asserts if assertRaises doesn't
-        pending, expire = False, -42
-        # Make sure function under test either fails with TypeError or returns
-        # values indicating failure to prevent further login use.
-        with self.assertRaises(TypeError):
-            pending, expire, _ = check_account_expire(
-                configuration, TEST_USER_DN
+
+        # Invalid values that will trigger TypeError in function under test
+        for invalid_expire in ("invalid", "-41", "-41.2", "111111111141.2",
+                               (1, 2)):
+            user_dict = {
+                "distinguished_name": TEST_USER_DN,
+                "expire": invalid_expire
+            }
+            update_user_dict(
+                logger, TEST_USER_DN, user_dict, self.expected_user_db_file
             )
-        self.assertFalse(pending, "got expected TypeError but not expired")
-        self.assertEqual(
-            expire, -42, "got expected TypeError but unexpected expire time"
-        )
+            # Make sure cache doesn't interfere with parsing
+            update_account_expire_cache(configuration, user_dict, delete=True)
+            # Ugly but TypeError here correctly prevents further login use
+            with self.assertRaises(TypeError):
+                _ = check_account_expire(configuration, TEST_USER_DN)
+
+    def test_check_account_expire_invalid_expire_value(self):
+        """Test that check_account_expire says expired if expire is an invalid value."""
+        configuration = self.configuration
+        logger = self.logger
+
+        # Invalid values that will fail without error in function under test
+        for invalid_expire in ("4242", None, False):
+            user_dict = {
+                "distinguished_name": TEST_USER_DN,
+                "expire": invalid_expire
+            }
+            update_user_dict(
+                logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+            )
+            # Make sure cache doesn't interfere with parsing
+            update_account_expire_cache(configuration, user_dict, delete=True)
+            # Assure these values return expired to prevent further login use
+            pending, expire, _ = check_account_expire(configuration,
+                                                      TEST_USER_DN)
+            self.assertFalse(pending)
 
     def test_check_account_expire_no_user_db_entry(self):
         """Test that check_account_expire returns expired if user is not in the DB."""

--- a/tests/test_mig_shared_accountstate.py
+++ b/tests/test_mig_shared_accountstate.py
@@ -1,0 +1,1106 @@
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# test_mig_shared_accountstate - unit test of the corresponding mig shared module
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# --- END_HEADER ---
+#
+
+"""Unit tests for the mig shared accountstate module"""
+
+import os
+import time
+import unittest
+
+# Imports of the code under test
+from mig.shared.accountstate import (
+    account_expire_info,
+    check_account_expire,
+    default_account_expire,
+    default_account_valid_days,
+    detect_special_login,
+    get_account_expire_cache,
+    get_account_status_cache,
+    reset_account_expire_cache,
+    update_account_expire_cache,
+    update_account_status_cache,
+)
+
+# Imports required for the unit test wrapping
+from mig.shared.base import client_id_dir
+from mig.shared.defaults import (
+    AUTH_CERTIFICATE,
+    AUTH_GENERIC,
+    AUTH_OPENID_CONNECT,
+    AUTH_OPENID_V2,
+    expire_marks_dir,
+    status_marks_dir,
+    oid_auto_extend_days,
+    oidc_auto_extend_days,
+    cert_auto_extend_days,
+)
+from mig.shared.useradm import _ensure_dirs_needed_for_userdb
+from mig.shared.userdb import update_user_dict
+
+# Imports required for the unit tests themselves
+from tests.support import (
+    MigTestCase,
+    ensure_dirs_exist,
+    testmain,
+)
+from tests.support.usersupp import OTHER_USER_DN, TEST_USER_DN
+
+# Test constants
+TEST_EXPIRE_TIMESTAMP = 1776031200
+TEST_STATUS_ACTIVE = "active"
+TEST_STATUS_LOCKED = "locked"
+TEST_RW_SHARE_ID = "klmnop4567"
+TEST_JOB_ID = "0419b45ebc1dedbdcb91fa6251035a2096758f5d700e15478b27a90734454107"
+TEST_JUPYTER_SESSION_ID = (
+    "ohNo4ii9geeyei3Jai8aif6gae6Eebiechai3chegh0moo9NieveKu3AC8ooshuo"
+)
+TEST_USER_EMAIL = TEST_USER_DN.split("/emailAddress=", 1)[-1]
+TEST_USER_DIR = client_id_dir(TEST_USER_DN)
+OTHER_USER_DIR = client_id_dir(OTHER_USER_DN)
+
+
+class TestMigSharedAccountstate__default_account_valid_days(MigTestCase):
+    """Coverage of accountstate default_account_valid_days function."""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        configuration = self.configuration
+        configuration.cert_valid_days = 365
+        configuration.oid_valid_days = 30
+        configuration.oidc_valid_days = 30
+        configuration.generic_valid_days = 14
+
+    def test_default_account_valid_days_auth_cert(self):
+        """Test that cert_valid_days is returned for AUTH_CERTIFICATE."""
+        configuration = self.configuration
+
+        result = default_account_valid_days(configuration, AUTH_CERTIFICATE)
+        self.assertEqual(result, 365)
+
+    def test_default_account_valid_days_auth_oid(self):
+        """Test that oid_valid_days is returned for AUTH_OPENID_V2."""
+        configuration = self.configuration
+
+        result = default_account_valid_days(configuration, AUTH_OPENID_V2)
+        self.assertEqual(result, 30)
+
+    def test_default_account_valid_days_auth_oidc(self):
+        """Test that oidc_valid_days is returned for AUTH_OPENID_CONNECT."""
+        configuration = self.configuration
+
+        result = default_account_valid_days(configuration, AUTH_OPENID_CONNECT)
+        self.assertEqual(result, 30)
+
+    def test_default_account_valid_days_auth_generic(self):
+        """Test that generic_valid_days is returned for AUTH_GENERIC."""
+        configuration = self.configuration
+
+        result = default_account_valid_days(configuration, AUTH_GENERIC)
+        self.assertEqual(result, 14)
+
+    def test_default_account_valid_days_auth_unknown(self):
+        """Test that generic_valid_days is fallback for unknown auth type."""
+        configuration = self.configuration
+
+        result = default_account_valid_days(configuration, "UNKNOWN_AUTH_TYPE")
+        self.assertEqual(result, 14)
+
+
+class TestMigSharedAccountstate__default_account_expire(MigTestCase):
+    """Coverage of accountstate default_account_expire function."""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        configuration = self.configuration
+        configuration.cert_valid_days = 365
+        configuration.oid_valid_days = 30
+        configuration.oidc_valid_days = 30
+        configuration.generic_valid_days = 14
+
+    def test_default_account_expire_for_auth_cert(self):
+        """Test expire calculation for AUTH_CERTIFICATE."""
+        configuration = self.configuration
+
+        start_time = time.time()
+        result = default_account_expire(
+            configuration, AUTH_CERTIFICATE, start_time=start_time
+        )
+        expected = int(start_time + 365 * 24 * 60 * 60)
+        self.assertEqual(result, expected)
+
+    def test_default_account_expire_for_auth_oid(self):
+        """Test expire calculation for AUTH_OPENID_V2."""
+        configuration = self.configuration
+
+        start_time = time.time()
+        result = default_account_expire(
+            configuration, AUTH_OPENID_V2, start_time=start_time
+        )
+        expected = int(start_time + 30 * 24 * 60 * 60)
+        self.assertEqual(result, expected)
+
+    def test_default_account_expire_for_auth_oidc(self):
+        """Test expire calculation for AUTH_OPENID_CONNECT."""
+        configuration = self.configuration
+
+        start_time = time.time()
+        result = default_account_expire(
+            configuration, AUTH_OPENID_CONNECT, start_time=start_time
+        )
+        expected = int(start_time + 30 * 24 * 60 * 60)
+        self.assertEqual(result, expected)
+
+    def test_default_account_expire_for_auth_generic(self):
+        """Test expire calculation for AUTH_GENERIC."""
+        configuration = self.configuration
+
+        start_time = time.time()
+        result = default_account_expire(
+            configuration, AUTH_GENERIC, start_time=start_time
+        )
+        expected = int(start_time + 14 * 24 * 60 * 60)
+        self.assertEqual(result, expected)
+
+    def test_default_account_expire_without_start_time(self):
+        """Test that current time is used when start_time is not provided."""
+        configuration = self.configuration
+
+        before = int(time.time())
+        result = default_account_expire(configuration, AUTH_CERTIFICATE)
+        after = int(time.time())
+
+        # Result should be between before + 364 days and after + 365 days
+        min_expected = before + 364 * 24 * 60 * 60
+        max_expected = after + 365 * 24 * 60 * 60
+        self.assertTrue(min_expected <= result <= max_expected)
+
+
+class TestMigSharedAccountstate__update_account_expire_cache(MigTestCase):
+    """Coverage of accountstate update_account_expire_cache function."""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test environment for expire cache tests."""
+        configuration = self.configuration
+        # Ensure the mig_system_run sub directory exists for expire marks
+        marks_path = os.path.join(
+            configuration.mig_system_run, expire_marks_dir
+        )
+        ensure_dirs_exist(marks_path)
+
+    def test_update_account_expire_cache_creates_mark(self):
+        """Test that update_account_expire_cache creates an expire mark."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": TEST_EXPIRE_TIMESTAMP,
+        }
+
+        result = update_account_expire_cache(configuration, user_dict)
+        self.assertTrue(result)
+
+        # Verify the mark was created
+        cached_expire = get_account_expire_cache(configuration, TEST_USER_DN)
+        self.assertEqual(cached_expire, TEST_EXPIRE_TIMESTAMP)
+
+    def test_update_account_expire_cache_with_missing_client_id(self):
+        """Test that update fails gracefully when client_id is missing."""
+        configuration = self.configuration
+        user_dict = {
+            "expire": TEST_EXPIRE_TIMESTAMP,
+        }
+
+        with self.assertLogs(level="ERROR") as log_capture:
+            result = update_account_expire_cache(configuration, user_dict)
+            self.assertFalse(result)
+        self.assertTrue(
+            any("no client ID" in msg for msg in log_capture.output)
+        )
+
+    def test_update_account_expire_cache_with_missing_expire(self):
+        """Test that update returns True when expire is missing."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+        }
+
+        with self.assertLogs(level="INFO") as log_capture:
+            result = update_account_expire_cache(configuration, user_dict)
+            self.assertTrue(result)
+        self.assertTrue(
+            any("no expire set" in msg for msg in log_capture.output)
+        )
+
+    def test_update_account_expire_cache_with_string_expire(self):
+        """Test that update fails when expire is a string."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": "not_a_number",
+        }
+
+        with self.assertLogs(level="WARNING") as log_capture:
+            result = update_account_expire_cache(configuration, user_dict)
+            self.assertFalse(result)
+        self.assertTrue(
+            any("string expire value" in msg for msg in log_capture.output)
+        )
+
+    def test_update_account_expire_cache_with_delete(self):
+        """Test that delete=True removes the expire mark."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": TEST_EXPIRE_TIMESTAMP,
+        }
+
+        # First create the mark
+        update_account_expire_cache(configuration, user_dict)
+        cached_expire = get_account_expire_cache(configuration, TEST_USER_DN)
+        self.assertEqual(cached_expire, TEST_EXPIRE_TIMESTAMP)
+
+        # Then delete it
+        result = update_account_expire_cache(
+            configuration, user_dict, delete=True
+        )
+        self.assertTrue(result)
+
+        # Verify the mark was removed
+        cached_expire = get_account_expire_cache(configuration, TEST_USER_DN)
+        self.assertIsNone(cached_expire)
+
+    def test_update_account_expire_cache_with_invalid_user_dict(self):
+        """Test that update fails when user_dict is not a dictionary."""
+        configuration = self.configuration
+
+        with self.assertLogs(level="ERROR") as log_capture:
+            result = update_account_expire_cache(configuration, "not_a_dict")
+            self.assertFalse(result)
+        self.assertTrue(
+            any("invalid user_dict" in msg for msg in log_capture.output)
+        )
+
+
+class TestMigSharedAccountstate__get_account_expire_cache(MigTestCase):
+    """Coverage of accountstate get_account_expire_cache function."""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test environment for expire cache tests."""
+        configuration = self.configuration
+        # Ensure the mig_system_run sub directory exists for expire marks
+        marks_path = os.path.join(
+            configuration.mig_system_run, expire_marks_dir
+        )
+        ensure_dirs_exist(marks_path)
+
+    def test_get_account_expire_cache_returns_cached_value(self):
+        """Test that get_account_expire_cache returns cached expire value."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": TEST_EXPIRE_TIMESTAMP,
+        }
+
+        # Create the mark first
+        update_account_expire_cache(configuration, user_dict)
+
+        # Then retrieve it
+        result = get_account_expire_cache(configuration, TEST_USER_DN)
+        self.assertEqual(result, TEST_EXPIRE_TIMESTAMP)
+
+    def test_get_account_expire_cache_with_missing_client_id(self):
+        """Test that get fails gracefully when client_id is missing."""
+        configuration = self.configuration
+
+        with self.assertLogs(level="ERROR") as log_capture:
+            result = get_account_expire_cache(configuration, "")
+            self.assertFalse(result)
+        self.assertTrue(
+            any("invalid client ID" in msg for msg in log_capture.output)
+        )
+
+
+class TestMigSharedAccountstate__reset_account_expire_cache(MigTestCase):
+    """Coverage of accountstate reset_account_expire_cache function."""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test environment for expire cache tests."""
+        configuration = self.configuration
+        # Ensure the mig_system_run sub directory exists for expire marks
+        marks_path = os.path.join(
+            configuration.mig_system_run, expire_marks_dir
+        )
+        ensure_dirs_exist(marks_path)
+
+        self.expire_base = os.path.join(
+            configuration.mig_system_run, expire_marks_dir
+        )
+
+    def test_reset_account_expire_cache_resets_all_marks(self):
+        """Test that reset_account_expire_cache resets all expire marks."""
+        configuration = self.configuration
+        # Create a couple of marks first
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": TEST_EXPIRE_TIMESTAMP,
+        }
+        update_account_expire_cache(configuration, user_dict)
+        cached_expire = get_account_expire_cache(configuration, TEST_USER_DN)
+        self.assertEqual(cached_expire, TEST_EXPIRE_TIMESTAMP)
+        user_dict = {
+            "distinguished_name": OTHER_USER_DN,
+            "expire": TEST_EXPIRE_TIMESTAMP + 42,
+        }
+        update_account_expire_cache(configuration, user_dict)
+        cached_expire = get_account_expire_cache(configuration, OTHER_USER_DN)
+        self.assertEqual(cached_expire, TEST_EXPIRE_TIMESTAMP + 42)
+
+        # Then reset all
+        result = reset_account_expire_cache(configuration)
+        self.assertTrue(result)
+
+        # Verify all marks were reset but not removed
+        marks_path = os.path.join(self.expire_base, TEST_USER_DIR)
+        self.assertTrue(os.path.exists(marks_path))
+        cached_expire = get_account_expire_cache(configuration, TEST_USER_DN)
+        self.assertEqual(cached_expire, 0.0)
+        marks_path = os.path.join(self.expire_base, OTHER_USER_DIR)
+        self.assertTrue(os.path.exists(marks_path))
+        cached_expire = get_account_expire_cache(configuration, OTHER_USER_DN)
+        self.assertEqual(cached_expire, 0.0)
+
+    def test_reset_account_expire_cache_resets_specific_mark(self):
+        """Test that reset_account_expire_cache resets given expire mark."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": TEST_EXPIRE_TIMESTAMP,
+        }
+
+        marks_path = os.path.join(self.expire_base, TEST_USER_DIR)
+        # Create the mark first
+        update_account_expire_cache(configuration, user_dict)
+        self.assertTrue(os.path.exists(marks_path))
+        cached_expire = get_account_expire_cache(configuration, TEST_USER_DN)
+        self.assertEqual(cached_expire, TEST_EXPIRE_TIMESTAMP)
+
+        # Then reset it
+        result = reset_account_expire_cache(configuration, TEST_USER_DN)
+        self.assertTrue(result)
+
+        # Verify the mark was reset but not removed
+        self.assertTrue(os.path.exists(marks_path))
+        cached_expire = get_account_expire_cache(configuration, TEST_USER_DN)
+        self.assertEqual(cached_expire, 0.0)
+
+
+class TestMigSharedAccountstate__update_account_status_cache(MigTestCase):
+    """Coverage of accountstate update_account_status_cache function."""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test environment for status cache tests."""
+        configuration = self.configuration
+        # Ensure the mig_system_run sub directory exists for status marks
+        marks_path = os.path.join(
+            configuration.mig_system_run, status_marks_dir
+        )
+        ensure_dirs_exist(marks_path)
+
+    def test_update_account_status_cache_creates_mark(self):
+        """Test that update_account_status_cache creates a status mark."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": TEST_STATUS_ACTIVE,
+        }
+
+        result = update_account_status_cache(configuration, user_dict)
+        self.assertTrue(result)
+
+        # Verify the mark was created
+        cached_status = get_account_status_cache(configuration, TEST_USER_DN)
+        self.assertEqual(cached_status, TEST_STATUS_ACTIVE)
+
+    def test_update_account_status_cache_with_different_status(self):
+        """Test that update_account_status_cache handles different status values."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": TEST_STATUS_LOCKED,
+        }
+
+        result = update_account_status_cache(configuration, user_dict)
+        self.assertTrue(result)
+
+        # Verify the mark was created with correct status
+        cached_status = get_account_status_cache(configuration, TEST_USER_DN)
+        self.assertEqual(cached_status, TEST_STATUS_LOCKED)
+
+    def test_update_account_status_cache_with_missing_client_id(self):
+        """Test that update fails gracefully when client_id is missing."""
+        configuration = self.configuration
+        user_dict = {
+            "status": TEST_STATUS_ACTIVE,
+        }
+
+        with self.assertLogs(level="ERROR") as log_capture:
+            result = update_account_status_cache(configuration, user_dict)
+            self.assertFalse(result)
+        self.assertTrue(
+            any("no client ID" in msg for msg in log_capture.output)
+        )
+
+    def test_update_account_status_cache_with_missing_status(self):
+        """Test that update returns True when status is missing."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+        }
+
+        with self.assertLogs(level="INFO") as log_capture:
+            result = update_account_status_cache(configuration, user_dict)
+            self.assertTrue(result)
+        self.assertTrue(
+            any("no status set" in msg for msg in log_capture.output)
+        )
+
+    def test_update_account_status_cache_with_invalid_status(self):
+        """Test that update fails when status is invalid."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": "invalid_status",
+        }
+
+        with self.assertLogs(level="ERROR") as log_capture:
+            result = update_account_status_cache(configuration, user_dict)
+            self.assertFalse(result)
+        self.assertTrue(
+            any("invalid account status" in msg for msg in log_capture.output)
+        )
+
+    def test_update_account_status_cache_with_delete(self):
+        """Test that delete=True removes the status mark."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": TEST_STATUS_ACTIVE,
+        }
+
+        # First create the mark
+        update_account_status_cache(configuration, user_dict)
+        cached_status = get_account_status_cache(configuration, TEST_USER_DN)
+        self.assertEqual(cached_status, TEST_STATUS_ACTIVE)
+
+        # Then delete it
+        result = update_account_status_cache(
+            configuration, user_dict, delete=True
+        )
+        self.assertTrue(result)
+
+        # Verify the mark was removed
+        cached_status = get_account_status_cache(configuration, TEST_USER_DN)
+        self.assertIsNone(cached_status)
+
+    def test_update_account_status_cache_with_invalid_user_dict(self):
+        """Test that update fails when user_dict is not a dictionary."""
+        configuration = self.configuration
+
+        with self.assertLogs(level="ERROR") as log_capture:
+            result = update_account_status_cache(configuration, "not_a_dict")
+            self.assertFalse(result)
+        self.assertTrue(
+            any("invalid user_dict" in msg for msg in log_capture.output)
+        )
+
+
+class TestMigSharedAccountstate__get_account_status_cache(MigTestCase):
+    """Coverage of accountstate get_account_status_cache function."""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test environment for status cache tests."""
+        configuration = self.configuration
+        # Ensure the mig_system_run sub directory exists for status marks
+        marks_path = os.path.join(
+            configuration.mig_system_run, status_marks_dir
+        )
+        ensure_dirs_exist(marks_path)
+
+    def test_get_account_status_cache_returns_cached_value(self):
+        """Test that get_account_status_cache returns cached status value."""
+        configuration = self.configuration
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "status": TEST_STATUS_ACTIVE,
+        }
+
+        # Create the mark first
+        update_account_status_cache(configuration, user_dict)
+
+        # Then retrieve it
+        result = get_account_status_cache(configuration, TEST_USER_DN)
+        self.assertEqual(result, TEST_STATUS_ACTIVE)
+
+    def test_get_account_status_cache_with_missing_client_id(self):
+        """Test that get fails gracefully when client_id is missing."""
+        configuration = self.configuration
+
+        with self.assertLogs(level="ERROR") as log_capture:
+            result = get_account_status_cache(configuration, "")
+            self.assertFalse(result)
+        self.assertTrue(
+            any("invalid client ID" in msg for msg in log_capture.output)
+        )
+
+    def test_get_account_status_cache_returns_none_when_not_set(self):
+        """Test that get_account_status_cache returns None when status not set."""
+        configuration = self.configuration
+
+        result = get_account_status_cache(configuration, TEST_USER_DN)
+        self.assertIsNone(result)
+
+
+class TestMigSharedAccountstate__check_account_expire(MigTestCase):
+    """Coverage of accountstate check_account_expire function."""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test environment for check_account_expire."""
+        configuration = self.configuration
+        # Ensure the mig_system_run directory exists for expire marks
+        marks_path = os.path.join(
+            configuration.mig_system_run, expire_marks_dir
+        )
+        ensure_dirs_exist(marks_path)
+
+        _ensure_dirs_needed_for_userdb(configuration)
+        self.expected_user_db_home = os.path.normpath(
+            configuration.user_db_home
+        )
+        self.expected_user_db_file = os.path.join(
+            self.expected_user_db_home, "MiG-users.db"
+        )
+        self._provision_test_user(self, TEST_USER_DN)
+
+    def test_check_account_expire_expired(self):
+        """Test that check_account_expire returns False for an expired account."""
+        configuration = self.configuration
+        logger = self.logger
+        # Expired account
+        account_expire = time.time() - 400 * 24 * 3600
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": account_expire,
+        }
+        # Update expire and delete cache for user
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict, delete=True)
+        pending, expire, _ = check_account_expire(configuration, TEST_USER_DN)
+        self.assertFalse(pending)
+        self.assertEqual(expire, account_expire)
+
+    def test_check_account_expire_active(self):
+        """Test that check_account_expire returns expire pending for an active account."""
+        configuration = self.configuration
+        logger = self.logger
+        # Active account
+        account_expire = time.time() + 42 * 24 * 3600
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": account_expire,
+        }
+        # Update expire and cache for user
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        pending, expire, _ = check_account_expire(configuration, TEST_USER_DN)
+        self.assertTrue(pending)
+        self.assertEqual(expire, account_expire)
+
+    @unittest.skip("TODO: init account without expire value and enable test?")
+    def test_check_account_expire_no_expire_field(self):
+        """Test that check_account_expire returns expire pending if expire is missing."""
+        configuration = self.configuration
+        logger = self.logger
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+        }
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict, delete=True)
+        pending, expire, _ = check_account_expire(configuration, TEST_USER_DN)
+        self.assertTrue(pending)
+        self.assertEqual(expire, -1)
+
+    def test_check_account_expire_invalid_expire_type(self):
+        """Test that check_account_expire returns expired if expire is not a number."""
+        configuration = self.configuration
+        logger = self.logger
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": "invalid",
+        }
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        with self.assertRaises(TypeError):
+            pending, expire, _ = check_account_expire(
+                configuration, TEST_USER_DN
+            )
+            self.assertFalse(pending)
+            self.assertEqual(expire, -42)
+
+    def test_check_account_expire_no_user_db_entry(self):
+        """Test that check_account_expire returns expired if user is not in the DB."""
+        configuration = self.configuration
+        with self.assertLogs(level="ERROR") as log_capture:
+            pending, expire, _ = check_account_expire(
+                configuration, "nosuchuser"
+            )
+            self.assertFalse(pending)
+            self.assertEqual(expire, -42)
+        self.assertTrue(
+            any("no such account:" in msg for msg in log_capture.output)
+        )
+
+    def test_check_account_expire_with_cache_miss(self):
+        """Test that check_account_expire updates the cache if not cached."""
+        configuration = self.configuration
+        logger = self.logger
+        # Active account
+        account_expire = time.time() + 42 * 24 * 3600
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": account_expire,
+        }
+        # Update user and delete cache
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict, delete=True)
+        pending, expire, _ = check_account_expire(configuration, TEST_USER_DN)
+        self.assertTrue(pending)
+        self.assertEqual(expire, account_expire)
+        cached_expire = get_account_expire_cache(configuration, TEST_USER_DN)
+        self.assertEqual(cached_expire, account_expire)
+
+    @unittest.skip("TODO: init account without expire value and enable test?")
+    def test_check_account_expire_with_current_time(self):
+        """Test that check_account_expire uses current time if expire is not set."""
+        configuration = self.configuration
+        logger = self.logger
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+        }
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        pending, expire, _ = check_account_expire(configuration, TEST_USER_DN)
+        now = time.time()
+        self.assertTrue(pending)
+        self.assertTrue(expire <= now - 3)
+
+    def test_check_account_expire_with_expired_account_and_cache(self):
+        """Test that check_account_expire works if the account is expired and cached."""
+        configuration = self.configuration
+        logger = self.logger
+        account_expire = time.time() - 400 * 24 * 3600
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": account_expire,
+        }
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        pending, expire, _ = check_account_expire(configuration, TEST_USER_DN)
+        self.assertFalse(pending)
+        self.assertEqual(expire, account_expire)
+
+
+class TestMigSharedAccountstate__account_expire_info(MigTestCase):
+    """Coverage of accountstate account_expire_info function."""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        """Set up test environment for account_expire_info."""
+        configuration = self.configuration
+        # Ensure the mig_system_run directory exists for expire and status marks
+        marks_path = os.path.join(
+            configuration.mig_system_run, expire_marks_dir)
+        ensure_dirs_exist(marks_path)
+        marks_path = os.path.join(
+            configuration.mig_system_run, status_marks_dir)
+        ensure_dirs_exist(marks_path)
+
+        _ensure_dirs_needed_for_userdb(configuration)
+        self.expected_user_db_home = os.path.normpath(
+            configuration.user_db_home
+        )
+        self.expected_user_db_file = os.path.join(
+            self.expected_user_db_home, "MiG-users.db"
+        )
+        self._provision_test_user(self, TEST_USER_DN)
+
+        # Set up configuration for auto-renew tests
+        configuration.auto_add_oid_user = True
+        configuration.auto_add_oidc_user = True
+        configuration.auto_add_cert_user = True
+        configuration.site_user_id_format = "X509"  # Default format
+
+    def test_account_expire_info_about_to_expire_oid(self):
+        """Test account_expire_info for OID user about to expire."""
+        configuration = self.configuration
+        logger = self.logger
+        # Set expire to be within min_days_left (14 days)
+        expect_expire = time.time() + (10 * 24 * 3600)  # 10 days from now
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": expect_expire,
+            "status": "active",
+        }
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        # Simulate OID login environment
+        environ = {
+            'REMOTE_ADDR': '127.0.0.1',  # Not localhost to allow renew
+            'HTTP_USER_AGENT': 'some agent',
+        }
+        base_url = "https://oid.example.com"
+        configuration.migserver_https_ext_oid_url = base_url
+        environ['SCRIPT_URI'] = '%s/wsgi-bin/something.py' % base_url
+
+        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+        self.assertTrue(expire_warn)
+        self.assertEqual(account_expire, expect_expire)
+        self.assertEqual(renew_days, configuration.oid_valid_days)
+        self.assertEqual(extend_days, oid_auto_extend_days)
+
+    def test_account_expire_info_not_about_to_expire(self):
+        """Test account_expire_info for user not about to expire."""
+        configuration = self.configuration
+        logger = self.logger
+        # Set expire to be beyond min_days_left (14 days)
+        expect_expire = time.time() + (20 * 24 * 3600)  # 20 days from now
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": expect_expire,
+            "status": "active",
+        }
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        environ = {
+            'REMOTE_ADDR': '127.0.0.1',
+            'HTTP_USER_AGENT': 'some agent',
+        }
+        base_url = "https://oid.example.com"
+        configuration.migserver_https_ext_oid_url = base_url
+        environ['SCRIPT_URI'] = '%s/wsgi-bin/something.py' % base_url
+
+        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+        self.assertFalse(expire_warn)
+        self.assertEqual(account_expire, expect_expire)
+        self.assertEqual(renew_days, 0)
+        self.assertEqual(extend_days, 0)
+
+    def test_account_expire_info_about_to_expire_oid_no_auto_renew(self):
+        """Test account_expire_info for OID user about to expire but auto-renew disabled."""
+        configuration = self.configuration
+        logger = self.logger
+        # Set expire to be within min_days_left (14 days)
+        expect_expire = time.time() + (10 * 24 * 3600)  # 10 days from now
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": expect_expire,
+            "status": "active",
+        }
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        # Disable auto-renew for OID
+        configuration.auto_add_oid_user = False
+
+        environ = {
+            'REMOTE_ADDR': '127.0.0.1',
+            'HTTP_USER_AGENT': 'some agent',
+        }
+        base_url = "https://oid.example.com"
+        configuration.migserver_https_ext_oid_url = base_url
+        environ['SCRIPT_URI'] = '%s/wsgi-bin/something.py' % base_url
+
+        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+        self.assertTrue(expire_warn)
+        self.assertEqual(account_expire, expect_expire)
+        self.assertEqual(renew_days, configuration.oid_valid_days)
+        self.assertEqual(extend_days, 0)  # Because auto-renew is disabled
+
+    def test_account_expire_info_about_to_expire_cert(self):
+        """Test account_expire_info for certificate user about to expire."""
+        configuration = self.configuration
+        logger = self.logger
+        # Set expire to be within min_days_left (14 days)
+        expect_expire = time.time() + (10 * 24 * 3600)  # 10 days from now
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": expect_expire,
+            "status": "active",
+        }
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        environ = {
+            'REMOTE_ADDR': '127.0.0.1',
+            'HTTP_USER_AGENT': 'some agent',
+        }
+        base_url = "https://cert.example.com"
+        configuration.migserver_https_ext_cert_url = base_url
+        environ['SCRIPT_URI'] = '%s/wsgi-bin/something.py' % base_url
+
+        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+        self.assertTrue(expire_warn)
+        self.assertEqual(account_expire, expect_expire)
+        self.assertEqual(renew_days, configuration.cert_valid_days)
+        self.assertEqual(extend_days, cert_auto_extend_days)
+
+    def test_account_expire_info_about_to_expire_oidc(self):
+        """Test account_expire_info for OIDC user about to expire."""
+        configuration = self.configuration
+        logger = self.logger
+        # Set expire to be within min_days_left (14 days)
+        expect_expire = time.time() + (10 * 24 * 3600)  # 10 days from now
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": expect_expire,
+            "status": "active",
+        }
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        environ = {
+            'REMOTE_ADDR': '127.0.0.1',
+            'HTTP_USER_AGENT': 'some agent',
+        }
+        base_url = "https://oidc.example.com"
+        configuration.migserver_https_ext_oidc_url = base_url
+        environ['SCRIPT_URI'] = '%s/wsgi-bin/something.py' % base_url
+
+        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
+            configuration, TEST_USER_DN, environ, min_days_left=14
+        )
+        self.assertTrue(expire_warn)
+        self.assertEqual(account_expire, expect_expire)
+        self.assertEqual(renew_days, configuration.oidc_valid_days)
+        self.assertEqual(extend_days, oidc_auto_extend_days)
+
+    def test_account_expire_info_with_different_min_days_left(self):
+        """Test account_expire_info with a custom min_days_left."""
+        configuration = self.configuration
+        logger = self.logger
+        # Set expire to be 10 days from now
+        expect_expire = time.time() + (10 * 24 * 3600)
+        user_dict = {
+            "distinguished_name": TEST_USER_DN,
+            "expire": expect_expire,
+            "status": "active",
+        }
+        update_user_dict(
+            logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
+        update_account_expire_cache(configuration, user_dict)
+        update_account_status_cache(configuration, user_dict)
+
+        environ = {
+            'REMOTE_ADDR': '127.0.0.1',
+            'HTTP_USER_AGENT': 'some agent',
+        }
+        base_url = "https://oid.example.com"
+        configuration.migserver_https_ext_oid_url = base_url
+        environ['SCRIPT_URI'] = '%s/wsgi-bin/something.py' % base_url
+
+        # Test with min_days_left=7 (so 10 days is beyond 7 -> not about to expire)
+        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
+            configuration, TEST_USER_DN, environ, min_days_left=7
+        )
+        self.assertFalse(expire_warn)
+        self.assertEqual(account_expire, expect_expire)
+        self.assertEqual(renew_days, 0)
+        self.assertEqual(extend_days, 0)
+
+        # Test with min_days_left=15 (so 10 days is within 15 -> about to expire)
+        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
+            configuration, TEST_USER_DN, environ, min_days_left=15
+        )
+        self.assertTrue(expire_warn)
+        self.assertEqual(account_expire, expect_expire)
+        self.assertEqual(renew_days, configuration.oid_valid_days)
+        self.assertEqual(extend_days, oid_auto_extend_days)
+
+
+class TestMigSharedAccountstate__detect_special_login(MigTestCase):
+    """Coverage of accountstate detect_special_login function."""
+
+    def _provide_configuration(self):
+        """Return a minimal configuration object for the test."""
+        return "testconfig"
+
+    def before_each(self):
+        """Create the directories that the function may touch."""
+        configuration = self.configuration
+        self.configuration.site_enable_jobs = True
+        self.configuration.site_enable_jupyter = True
+        # Ensure the home directories that the function may reference exist
+        ensure_dirs_exist(configuration.user_home)
+        ensure_dirs_exist(configuration.mrsl_files_dir)
+        ensure_dirs_exist(configuration.resource_pending)
+        ensure_dirs_exist(configuration.sessid_to_mrsl_link_home)
+        ensure_dirs_exist(configuration.sessid_to_jupyter_mount_link_home)
+        self._provision_test_user(self, TEST_USER_DN)
+
+    def test_special_login_sharelink_is_detected(self):
+        """Test that a sharelink ID is recognised as a special login."""
+        configuration = self.configuration
+        # Create a dummy RW sharelink to user home
+        sharelink_path = os.path.join(configuration.sharelink_home,
+                                      'read-write', TEST_RW_SHARE_ID)
+        sharelink_target = os.path.join(configuration.user_home, TEST_USER_DIR)
+        ensure_dirs_exist(sharelink_target)
+        ensure_dirs_exist(os.path.dirname(sharelink_path))
+        os.symlink(sharelink_target, sharelink_path)
+
+        # Call the function – it should return True for this special login
+        result = detect_special_login(configuration, TEST_RW_SHARE_ID, "sftp")
+        self.assertTrue(result)
+
+    def test_special_login_job_is_detected(self):
+        """Test that a job ID is recognised as a special login."""
+        configuration = self.configuration
+        # Create a dummy job link to mrsl files entry
+        job_target_path = os.path.join(configuration.mrsl_files_dir,
+                                       TEST_JOB_ID)
+        ensure_dirs_exist(job_target_path)
+        job_link_path = os.path.join(configuration.sessid_to_mrsl_link_home,
+                                     TEST_JOB_ID + ".mRSL")
+        ensure_dirs_exist(os.path.dirname(job_link_path))
+        os.symlink(job_target_path, job_link_path)
+
+        result = detect_special_login(configuration, TEST_JOB_ID, "sftp")
+        self.assertTrue(result)
+
+    def test_special_login_jupyter_mount_is_detected(self):
+        """Test that a jupyter‑mount ID is recognised as a special login."""
+        configuration = self.configuration
+        # Create a dummy jupyter‑mount link to user home
+        jupyter_link_path = os.path.join(
+            configuration.sessid_to_jupyter_mount_link_home, TEST_JUPYTER_SESSION_ID)
+        jupyter_target = os.path.join(configuration.user_home, TEST_USER_DIR)
+        ensure_dirs_exist(jupyter_target)
+        ensure_dirs_exist(os.path.dirname(jupyter_link_path))
+        os.symlink(jupyter_target, jupyter_link_path)
+
+        result = detect_special_login(configuration, TEST_JUPYTER_SESSION_ID,
+                                      "sftp")
+        self.assertTrue(result)
+
+    def test_special_login_normal_user_is_not_detected(self):
+        """Test that a normal user DN is *not* recognised as a special login."""
+        configuration = self.configuration
+        result = detect_special_login(configuration, TEST_USER_EMAIL, "sftp")
+        self.assertFalse(result)
+
+    def test_special_login_without_proto_is_not_detected(self):
+        """Test that a value without a recognised protocol is not detected."""
+        configuration = self.configuration
+        result = detect_special_login(configuration, TEST_USER_EMAIL, "")
+        self.assertFalse(result)
+
+    def test_special_login_with_unknown_proto_is_not_detected(self):
+        """Test that an unknown protocol string is not detected."""
+        configuration = self.configuration
+        result = detect_special_login(configuration, TEST_USER_EMAIL,
+                                      "unknown-proto")
+        self.assertFalse(result)
+
+    def test_special_login_with_empty_user_is_not_detected(self):
+        """Test that an empty user string is not detected."""
+        configuration = self.configuration
+        result = detect_special_login(configuration, "", "sftp")
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    testmain()

--- a/tests/test_mig_shared_accountstate.py
+++ b/tests/test_mig_shared_accountstate.py
@@ -53,11 +53,11 @@ from mig.shared.defaults import (
     AUTH_GENERIC,
     AUTH_OPENID_CONNECT,
     AUTH_OPENID_V2,
+    cert_auto_extend_days,
     expire_marks_dir,
-    status_marks_dir,
     oid_auto_extend_days,
     oidc_auto_extend_days,
-    cert_auto_extend_days,
+    status_marks_dir,
 )
 from mig.shared.useradm import _ensure_dirs_needed_for_userdb
 from mig.shared.userdb import update_user_dict
@@ -779,10 +779,12 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
         configuration = self.configuration
         # Ensure the mig_system_run directory exists for expire and status marks
         marks_path = os.path.join(
-            configuration.mig_system_run, expire_marks_dir)
+            configuration.mig_system_run, expire_marks_dir
+        )
         ensure_dirs_exist(marks_path)
         marks_path = os.path.join(
-            configuration.mig_system_run, status_marks_dir)
+            configuration.mig_system_run, status_marks_dir
+        )
         ensure_dirs_exist(marks_path)
 
         _ensure_dirs_needed_for_userdb(configuration)
@@ -819,15 +821,17 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
 
         # Simulate OID login environment
         environ = {
-            'REMOTE_ADDR': '127.0.0.1',  # Not localhost to allow renew
-            'HTTP_USER_AGENT': 'some agent',
+            "REMOTE_ADDR": "127.0.0.1",  # Not localhost to allow renew
+            "HTTP_USER_AGENT": "some agent",
         }
         base_url = "https://oid.example.com"
         configuration.migserver_https_ext_oid_url = base_url
-        environ['SCRIPT_URI'] = '%s/wsgi-bin/something.py' % base_url
+        environ["SCRIPT_URI"] = "%s/wsgi-bin/something.py" % base_url
 
-        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
-            configuration, TEST_USER_DN, environ, min_days_left=14
+        expire_warn, account_expire, renew_days, extend_days = (
+            account_expire_info(
+                configuration, TEST_USER_DN, environ, min_days_left=14
+            )
         )
         self.assertTrue(expire_warn)
         self.assertEqual(account_expire, expect_expire)
@@ -852,15 +856,17 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
         update_account_status_cache(configuration, user_dict)
 
         environ = {
-            'REMOTE_ADDR': '127.0.0.1',
-            'HTTP_USER_AGENT': 'some agent',
+            "REMOTE_ADDR": "127.0.0.1",
+            "HTTP_USER_AGENT": "some agent",
         }
         base_url = "https://oid.example.com"
         configuration.migserver_https_ext_oid_url = base_url
-        environ['SCRIPT_URI'] = '%s/wsgi-bin/something.py' % base_url
+        environ["SCRIPT_URI"] = "%s/wsgi-bin/something.py" % base_url
 
-        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
-            configuration, TEST_USER_DN, environ, min_days_left=14
+        expire_warn, account_expire, renew_days, extend_days = (
+            account_expire_info(
+                configuration, TEST_USER_DN, environ, min_days_left=14
+            )
         )
         self.assertFalse(expire_warn)
         self.assertEqual(account_expire, expect_expire)
@@ -888,15 +894,17 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
         configuration.auto_add_oid_user = False
 
         environ = {
-            'REMOTE_ADDR': '127.0.0.1',
-            'HTTP_USER_AGENT': 'some agent',
+            "REMOTE_ADDR": "127.0.0.1",
+            "HTTP_USER_AGENT": "some agent",
         }
         base_url = "https://oid.example.com"
         configuration.migserver_https_ext_oid_url = base_url
-        environ['SCRIPT_URI'] = '%s/wsgi-bin/something.py' % base_url
+        environ["SCRIPT_URI"] = "%s/wsgi-bin/something.py" % base_url
 
-        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
-            configuration, TEST_USER_DN, environ, min_days_left=14
+        expire_warn, account_expire, renew_days, extend_days = (
+            account_expire_info(
+                configuration, TEST_USER_DN, environ, min_days_left=14
+            )
         )
         self.assertTrue(expire_warn)
         self.assertEqual(account_expire, expect_expire)
@@ -921,15 +929,17 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
         update_account_status_cache(configuration, user_dict)
 
         environ = {
-            'REMOTE_ADDR': '127.0.0.1',
-            'HTTP_USER_AGENT': 'some agent',
+            "REMOTE_ADDR": "127.0.0.1",
+            "HTTP_USER_AGENT": "some agent",
         }
         base_url = "https://cert.example.com"
         configuration.migserver_https_ext_cert_url = base_url
-        environ['SCRIPT_URI'] = '%s/wsgi-bin/something.py' % base_url
+        environ["SCRIPT_URI"] = "%s/wsgi-bin/something.py" % base_url
 
-        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
-            configuration, TEST_USER_DN, environ, min_days_left=14
+        expire_warn, account_expire, renew_days, extend_days = (
+            account_expire_info(
+                configuration, TEST_USER_DN, environ, min_days_left=14
+            )
         )
         self.assertTrue(expire_warn)
         self.assertEqual(account_expire, expect_expire)
@@ -954,15 +964,17 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
         update_account_status_cache(configuration, user_dict)
 
         environ = {
-            'REMOTE_ADDR': '127.0.0.1',
-            'HTTP_USER_AGENT': 'some agent',
+            "REMOTE_ADDR": "127.0.0.1",
+            "HTTP_USER_AGENT": "some agent",
         }
         base_url = "https://oidc.example.com"
         configuration.migserver_https_ext_oidc_url = base_url
-        environ['SCRIPT_URI'] = '%s/wsgi-bin/something.py' % base_url
+        environ["SCRIPT_URI"] = "%s/wsgi-bin/something.py" % base_url
 
-        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
-            configuration, TEST_USER_DN, environ, min_days_left=14
+        expire_warn, account_expire, renew_days, extend_days = (
+            account_expire_info(
+                configuration, TEST_USER_DN, environ, min_days_left=14
+            )
         )
         self.assertTrue(expire_warn)
         self.assertEqual(account_expire, expect_expire)
@@ -987,16 +999,18 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
         update_account_status_cache(configuration, user_dict)
 
         environ = {
-            'REMOTE_ADDR': '127.0.0.1',
-            'HTTP_USER_AGENT': 'some agent',
+            "REMOTE_ADDR": "127.0.0.1",
+            "HTTP_USER_AGENT": "some agent",
         }
         base_url = "https://oid.example.com"
         configuration.migserver_https_ext_oid_url = base_url
-        environ['SCRIPT_URI'] = '%s/wsgi-bin/something.py' % base_url
+        environ["SCRIPT_URI"] = "%s/wsgi-bin/something.py" % base_url
 
         # Test with min_days_left=7 (so 10 days is beyond 7 -> not about to expire)
-        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
-            configuration, TEST_USER_DN, environ, min_days_left=7
+        expire_warn, account_expire, renew_days, extend_days = (
+            account_expire_info(
+                configuration, TEST_USER_DN, environ, min_days_left=7
+            )
         )
         self.assertFalse(expire_warn)
         self.assertEqual(account_expire, expect_expire)
@@ -1004,8 +1018,10 @@ class TestMigSharedAccountstate__account_expire_info(MigTestCase):
         self.assertEqual(extend_days, 0)
 
         # Test with min_days_left=15 (so 10 days is within 15 -> about to expire)
-        expire_warn, account_expire, renew_days, extend_days = account_expire_info(
-            configuration, TEST_USER_DN, environ, min_days_left=15
+        expire_warn, account_expire, renew_days, extend_days = (
+            account_expire_info(
+                configuration, TEST_USER_DN, environ, min_days_left=15
+            )
         )
         self.assertTrue(expire_warn)
         self.assertEqual(account_expire, expect_expire)
@@ -1037,8 +1053,9 @@ class TestMigSharedAccountstate__detect_special_login(MigTestCase):
         """Test that a sharelink ID is recognised as a special login."""
         configuration = self.configuration
         # Create a dummy RW sharelink to user home
-        sharelink_path = os.path.join(configuration.sharelink_home,
-                                      'read-write', TEST_RW_SHARE_ID)
+        sharelink_path = os.path.join(
+            configuration.sharelink_home, "read-write", TEST_RW_SHARE_ID
+        )
         sharelink_target = os.path.join(configuration.user_home, TEST_USER_DIR)
         ensure_dirs_exist(sharelink_target)
         ensure_dirs_exist(os.path.dirname(sharelink_path))
@@ -1052,11 +1069,13 @@ class TestMigSharedAccountstate__detect_special_login(MigTestCase):
         """Test that a job ID is recognised as a special login."""
         configuration = self.configuration
         # Create a dummy job link to mrsl files entry
-        job_target_path = os.path.join(configuration.mrsl_files_dir,
-                                       TEST_JOB_ID)
+        job_target_path = os.path.join(
+            configuration.mrsl_files_dir, TEST_JOB_ID
+        )
         ensure_dirs_exist(job_target_path)
-        job_link_path = os.path.join(configuration.sessid_to_mrsl_link_home,
-                                     TEST_JOB_ID + ".mRSL")
+        job_link_path = os.path.join(
+            configuration.sessid_to_mrsl_link_home, TEST_JOB_ID + ".mRSL"
+        )
         ensure_dirs_exist(os.path.dirname(job_link_path))
         os.symlink(job_target_path, job_link_path)
 
@@ -1068,14 +1087,17 @@ class TestMigSharedAccountstate__detect_special_login(MigTestCase):
         configuration = self.configuration
         # Create a dummy jupyter‑mount link to user home
         jupyter_link_path = os.path.join(
-            configuration.sessid_to_jupyter_mount_link_home, TEST_JUPYTER_SESSION_ID)
+            configuration.sessid_to_jupyter_mount_link_home,
+            TEST_JUPYTER_SESSION_ID,
+        )
         jupyter_target = os.path.join(configuration.user_home, TEST_USER_DIR)
         ensure_dirs_exist(jupyter_target)
         ensure_dirs_exist(os.path.dirname(jupyter_link_path))
         os.symlink(jupyter_target, jupyter_link_path)
 
-        result = detect_special_login(configuration, TEST_JUPYTER_SESSION_ID,
-                                      "sftp")
+        result = detect_special_login(
+            configuration, TEST_JUPYTER_SESSION_ID, "sftp"
+        )
         self.assertTrue(result)
 
     def test_special_login_normal_user_is_not_detected(self):
@@ -1093,8 +1115,9 @@ class TestMigSharedAccountstate__detect_special_login(MigTestCase):
     def test_special_login_with_unknown_proto_is_not_detected(self):
         """Test that an unknown protocol string is not detected."""
         configuration = self.configuration
-        result = detect_special_login(configuration, TEST_USER_EMAIL,
-                                      "unknown-proto")
+        result = detect_special_login(
+            configuration, TEST_USER_EMAIL, "unknown-proto"
+        )
         self.assertFalse(result)
 
     def test_special_login_with_empty_user_is_not_detected(self):
@@ -1122,7 +1145,8 @@ class TestMigSharedAccountstate__check_account_status(
         # Set up user DB and keep paths for later use
         _ensure_dirs_needed_for_userdb(configuration)
         self.expected_user_db_home = os.path.normpath(
-            configuration.user_db_home)
+            configuration.user_db_home
+        )
         self.expected_user_db_file = os.path.join(
             self.expected_user_db_home, "MiG-users.db"
         )
@@ -1138,13 +1162,15 @@ class TestMigSharedAccountstate__check_account_status(
             "status": "active",
         }
         # Create a DB entry for the user
-        update_user_dict(self.logger, TEST_USER_DN, user_dict,
-                         self.expected_user_db_file)
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
         # Populate the status cache
         update_account_status_cache(configuration, user_dict)
 
-        accessible, status, _ = check_account_status(configuration,
-                                                     TEST_USER_DN)
+        accessible, status, _ = check_account_status(
+            configuration, TEST_USER_DN
+        )
         self.assertTrue(accessible)
         self.assertEqual(status, "active")
 
@@ -1155,12 +1181,14 @@ class TestMigSharedAccountstate__check_account_status(
             "distinguished_name": TEST_USER_DN,
             "status": "locked",
         }
-        update_user_dict(self.logger, TEST_USER_DN, user_dict,
-                         self.expected_user_db_file)
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
         update_account_status_cache(configuration, user_dict)
 
-        accessible, status, _ = check_account_status(configuration,
-                                                     TEST_USER_DN)
+        accessible, status, _ = check_account_status(
+            configuration, TEST_USER_DN
+        )
         self.assertFalse(accessible)
         self.assertEqual(status, "locked")
 
@@ -1171,12 +1199,14 @@ class TestMigSharedAccountstate__check_account_status(
             "distinguished_name": TEST_USER_DN,
             "status": "suspended",
         }
-        update_user_dict(self.logger, TEST_USER_DN, user_dict,
-                         self.expected_user_db_file)
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
         update_account_status_cache(configuration, user_dict)
 
-        accessible, status, _ = check_account_status(configuration,
-                                                     TEST_USER_DN)
+        accessible, status, _ = check_account_status(
+            configuration, TEST_USER_DN
+        )
         self.assertFalse(accessible)
         self.assertEqual(status, "suspended")
 
@@ -1188,14 +1218,16 @@ class TestMigSharedAccountstate__check_account_status(
             "distinguished_name": TEST_USER_DN,
             "expire": expire_ts,
         }
-        update_user_dict(self.logger, TEST_USER_DN, user_dict,
-                         self.expected_user_db_file)
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
         update_account_status_cache(configuration, user_dict)
 
-        accessible, status, _ = check_account_status(configuration,
-                                                     TEST_USER_DN)
+        accessible, status, _ = check_account_status(
+            configuration, TEST_USER_DN
+        )
         self.assertTrue(accessible)
-        self.assertEqual(status, 'active')
+        self.assertEqual(status, "active")
 
     def test_check_account_status_unchanged_by_expire(self):
         """Test that account status itself remains unchanged after expire."""
@@ -1206,14 +1238,16 @@ class TestMigSharedAccountstate__check_account_status(
             "status": "active",
             "expire": expire_ts,
         }
-        update_user_dict(self.logger, TEST_USER_DN, user_dict,
-                         self.expected_user_db_file)
+        update_user_dict(
+            self.logger, TEST_USER_DN, user_dict, self.expected_user_db_file
+        )
         update_account_status_cache(configuration, user_dict)
 
-        accessible, status, _ = check_account_status(configuration,
-                                                     TEST_USER_DN)
+        accessible, status, _ = check_account_status(
+            configuration, TEST_USER_DN
+        )
         self.assertTrue(accessible)
-        self.assertEqual(status, 'active')
+        self.assertEqual(status, "active")
 
     def test_check_account_status_missing_user(self):
         """Test that check_account_status fails gracefully for a missing user."""


### PR DESCRIPTION
Implement fundamental unit test coverage of the `accountstate` module.
Fixes a corner-case bug in `reset_account_expire_cache` when called with a specific `client_id` rather than the default (`None`) to reset all expire marks. The specific `client_id` version is not yet used in any actual code, so it should be safe.

Originally developed for the UUID user format support work in #561 but this part makes for a stand-alone PR to first increase overall unit test coverage.