### PR TITLE
Adjust `migerrors` to filter expected recurring errors in recently added logs

### DIFF
--- a/mig/install/migerrors-template.sh.cronjob
+++ b/mig/install/migerrors-template.sh.cronjob
@@ -40,48 +40,48 @@ ENABLE_ACCOUNTING="__ENABLE_ACCOUNTING__"
 ENABLE_QUOTA="__ENABLE_QUOTA__"
 
 {
-[ "$ENABLE_DAVS" == "True" ] && grep -H "Internal Server Error" $LOGDIR/webdavs.out | tail -n $MAXLINES
-[ "$ENABLE_DAVS" == "True" ] && grep -H -A 12 "Traceback" $LOGDIR/webdavs.out | tail -n $MAXLINES
+[ "$ENABLE_DAVS" == "True" ] && grep -a -H "Internal Server Error" $LOGDIR/webdavs.out | tail -n $MAXLINES
+[ "$ENABLE_DAVS" == "True" ] && grep -a -H -A 12 "Traceback" $LOGDIR/webdavs.out | tail -n $MAXLINES
 
-[ "$ENABLE_FTPS" == "True" ] && grep -H " ERROR " $LOGDIR/ftps.log | \
+[ "$ENABLE_FTPS" == "True" ] && grep -a -H " ERROR " $LOGDIR/ftps.log | \
         grep -E -v "ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|: Invalid path characters" | tail -n $MAXLINES
 
 [[ "$ENABLE_SFTP" == "True" || "$ENABLE_SFTP_SUBSYS" == True ]]  \
-        && grep -H " ERROR " $LOGDIR/sftp*.log | \
+        && grep -a -H " ERROR " $LOGDIR/sftp*.log | \
 	grep -E -v "Password authentication failed for|Socket exception: Connection reset by peer|Error reading SSH protocol banner|check_banner|list_folder on missing path|chmod (292|365) rejected on path|symlink rejected on path|ERROR mkdir .* failed: \[Errno 17\] File exists|ERROR rmdir .* failed: \[Errno 39\] Directory not empty|ERROR (open|remove) .* failed: \[Errno 21\] Is a directory|ERROR open for modify on read-only path|ERROR open existing file on missing path |ERROR rmdir rejected on link path |ERROR Exception.*: Incompatible ssh|ERROR Exception.*: Incompatible version |Exception.*: Invalid SSH banner|ERROR Exception.*: no moduli available|ERROR Exception.*: Expecting packet from \(20,\), got 0|ERROR Socket exception: Connection timed out|ERROR Exception.*: Key-exchange timed out|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|ERROR Exception.*: Client kex .* is out of range|ERROR Exception.*: Expecting packet from .*|get_fs_path failed: Invalid path characters|ERROR $" | tail -n $MAXLINES
 
-[ "$ENABLE_DAVS" == "True" ] && grep -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES
+[ "$ENABLE_DAVS" == "True" ] && grep -a -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES
 
-[ "$ENABLE_OPENID" == "True" ] && grep -H " ERROR " $LOGDIR/openid.log | grep -E -v "crashed: Unexpected query variable|retry_url: shorter than minimum length|invalid retry_url: found invalid character|crashed: int\(\) argument must be a string|input: shorter than minimum length|input: found invalid character:" | tail -n $MAXLINES
+[ "$ENABLE_OPENID" == "True" ] && grep -a -H " ERROR " $LOGDIR/openid.log | grep -E -v "crashed: Unexpected query variable|retry_url: shorter than minimum length|invalid retry_url: found invalid character|crashed: int\(\) argument must be a string|input: shorter than minimum length|input: found invalid character:" | tail -n $MAXLINES
 
-[ "$ENABLE_CRONTAB" == "True" ] && grep -H " ERROR " $LOGDIR/cron.log | tail -n $MAXLINES
+[ "$ENABLE_CRONTAB" == "True" ] && grep -a -H " ERROR " $LOGDIR/cron.log | tail -n $MAXLINES
 
-[ "$ENABLE_EVENTS" == "True" ] && grep -H " ERROR " $LOGDIR/events.log | tail -n $MAXLINES
+[ "$ENABLE_EVENTS" == "True" ] && grep -a -H " ERROR " $LOGDIR/events.log | tail -n $MAXLINES
 
-[ "$ENABLE_TRANSFERS" == "True" ] && grep -H " ERROR " $LOGDIR/transfers.log | tail -n $MAXLINES
+[ "$ENABLE_TRANSFERS" == "True" ] && grep -a -H " ERROR " $LOGDIR/transfers.log | tail -n $MAXLINES
 
-[ "$ENABLE_NOTIFY" == "True" ] && grep -H " ERROR " $LOGDIR/notify.log | tail -n $MAXLINES
+[ "$ENABLE_NOTIFY" == "True" ] && grep -a -H " ERROR " $LOGDIR/notify.log | tail -n $MAXLINES
 
-[ "$ENABLE_JANITOR" == "True" ] && grep -H " ERROR " $LOGDIR/janitor.log | grep -E -v " expire [0-9:. -]+ vs [0-9:. -]+ prevents .+ as peer for " | tail -n $MAXLINES
+[ "$ENABLE_JANITOR" == "True" ] && grep -a -H " ERROR " $LOGDIR/janitor.log | grep -E -v " expire [0-9:. -]+ vs [0-9:. -]+ prevents .+ as peer for " | tail -n $MAXLINES
 
 # TODO: fix auto creation of freeze helper directory and skip partial archives without meta.pck then remove next ignores
-[ "$ENABLE_ACCOUNTING" == "True" ] && grep -H " ERROR " $LOGDIR/accounting.log | grep -E -v "Missing quota freeze path: ./.+/quota_home/lustre/freeze.|No such file or directory: ./.+/freeze_home/archive-.*/meta.pck." | tail -n $MAXLINES
+[ "$ENABLE_ACCOUNTING" == "True" ] && grep -a -H " ERROR " $LOGDIR/accounting.log | grep -E -v "Missing quota freeze path: ./.+/quota_home/lustre/freeze.|No such file or directory: ./.+/freeze_home/archive-.*/meta.pck." | tail -n $MAXLINES
 
 # TODO: fix quota handling of old-style vgrids and remove next ignore
-[ "$ENABLE_QUOTA" == "True" ] && grep -H " ERROR " $LOGDIR/quota.log | grep -E -v "skipping entry: .*, no lustre data path:"  | tail -n $MAXLINES
+[ "$ENABLE_QUOTA" == "True" ] && grep -a -H " ERROR " $LOGDIR/quota.log | grep -E -v "skipping entry: .*, no lustre data path:"  | tail -n $MAXLINES
 
-grep -H " ERROR " $LOGDIR/chkchroot.log | grep -E -v " from ${SECSCANIP} "| \
+grep -a -H " ERROR " $LOGDIR/chkchroot.log | grep -E -v " from ${SECSCANIP} "| \
         grep -E -v "__CRACK_WEB_REGEX__" | \
         grep -E -v "/index\.html.$|/state/webserver_home/share_redirect.$" | \
         tail -n $MAXLINES
 
 # NOTE: we ignore script crashed errors here and treat specifically next
-grep -H " ERROR " $LOGDIR/mig.log | \
+grep -a -H " ERROR " $LOGDIR/mig.log | \
 	grep -E -v "problems importing arclib|disabled in configuration|(settings|userprofile) could not be opened/unpickled|load (ssh|ftps|davs|seafile) publickeys failed|is not a valid openid provider|script crashed:|INFO Content-Length missing or zero|${SECSCANIP} (refused to|could not) import .*shared\.functionality\.|INFO Not available on this site.*Replied .ERROR.|: failed on .*: .*\[Errno 2\] No such file or directory: |: failed on .*: .*\[Errno 17\] File exists: |ERROR could not delete .*: \[Errno 2\] No such file or directory: |ERROR could not read .*: \[Errno 21\] Is a directory: |ERROR cat: failed on .*: could not read file|create directory failed: .*\[Errno 17\] File exists: |ERROR Unpack called on unsupported archive: |ERROR .* uploadchunked .* request data read error: |ERROR rm: refusing rm home dir: |refusing rm link: .*/user_home/.*/Trash|ERROR .* could not import .*: No module named "| tail -n $MAXLINES
 # Extract variable length script crash tracebacks terminated with a blank line
 sed -n "/ERROR.* script crashed:/""{ :a; $p; N; /\n$/!ba; p; }" $LOGDIR/mig.log | tail -n $MAXLINES
 
-grep -H "CSRF check failed" $LOGDIR/mig.log | tail -n $MAXLINES
+grep -a -H "CSRF check failed" $LOGDIR/mig.log | tail -n $MAXLINES
 } | grep -E "${YESTERDAY}|${TODAY}|^[^0-9/]"'
 
 exit 0

--- a/mig/install/migerrors-template.sh.cronjob
+++ b/mig/install/migerrors-template.sh.cronjob
@@ -62,11 +62,13 @@ ENABLE_QUOTA="__ENABLE_QUOTA__"
 
 [ "$ENABLE_NOTIFY" == "True" ] && grep -H " ERROR " $LOGDIR/notify.log | tail -n $MAXLINES
 
-[ "$ENABLE_JANITOR" == "True" ] && grep -H " ERROR " $LOGDIR/janitor.log | tail -n $MAXLINES
+[ "$ENABLE_JANITOR" == "True" ] && grep -H " ERROR " $LOGDIR/janitor.log | grep -E -v " expire [0-9:. -]+ vs [0-9:. -]+ prevents .+ as peer for " | tail -n $MAXLINES
 
-[ "$ENABLE_ACCOUNTING" == "True" ] && grep -H " ERROR " $LOGDIR/accounting.log | tail -n $MAXLINES
+# TODO: fix auto creation of freeze helper directory and skip partial archives without meta.pck then remove next ignores
+[ "$ENABLE_ACCOUNTING" == "True" ] && grep -H " ERROR " $LOGDIR/accounting.log | grep -E -v "Missing quota freeze path: ./.+/quota_home/lustre/freeze.|No such file or directory: ./.+/freeze_home/archive-.*/meta.pck." | tail -n $MAXLINES
 
-[ "$ENABLE_QUOTA" == "True" ] && grep -H " ERROR " $LOGDIR/quota.log | tail -n $MAXLINES
+# TODO: fix quota handling of old-style vgrids and remove next ignore
+[ "$ENABLE_QUOTA" == "True" ] && grep -H " ERROR " $LOGDIR/quota.log | grep -E -v "skipping entry: .*, no lustre data path:"  | tail -n $MAXLINES
 
 grep -H " ERROR " $LOGDIR/chkchroot.log | grep -E -v " from ${SECSCANIP} "| \
         grep -E -v "__CRACK_WEB_REGEX__" | \

--- a/mig/install/migerrors-template.sh.cronjob
+++ b/mig/install/migerrors-template.sh.cronjob
@@ -62,10 +62,10 @@ ENABLE_QUOTA="__ENABLE_QUOTA__"
 
 [ "$ENABLE_NOTIFY" == "True" ] && grep -a -H " ERROR " $LOGDIR/notify.log | tail -n $MAXLINES
 
-[ "$ENABLE_JANITOR" == "True" ] && grep -a -H " ERROR " $LOGDIR/janitor.log | grep -E -v " expire [0-9:. -]+ vs [0-9:. -]+ prevents .+ as peer for " | tail -n $MAXLINES
+[ "$ENABLE_JANITOR" == "True" ] && grep -a -H " ERROR " $LOGDIR/janitor.log | grep -E -v " expire [0-9:. -]+ .+ prevents .+ as peer for " | tail -n $MAXLINES
 
-# TODO: fix auto creation of freeze helper directory and skip partial archives without meta.pck then remove next ignores
-[ "$ENABLE_ACCOUNTING" == "True" ] && grep -a -H " ERROR " $LOGDIR/accounting.log | grep -E -v "Missing quota freeze path: ./.+/quota_home/lustre/freeze.|No such file or directory: ./.+/freeze_home/archive-.*/meta.pck." | tail -n $MAXLINES
+# TODO: skip or fix auto creation of missing freeze helper paths and skip partial archives without meta.pck and missing quota ID.json then remove next ignores
+[ "$ENABLE_ACCOUNTING" == "True" ] && grep -a -H " ERROR " $LOGDIR/accounting.log | grep -E -v "Missing quota freeze path: ./.+/quota_home/.+/freeze.|Failed to fetch freeze quota: ./.+/quota_home/.+/freeze/.+\.json.|No such file or directory: ./.+/freeze_home/archive-.*/meta\.pck.|No such file or directory: ./.+/quota_home/.+/freeze/.+\.json." | tail -n $MAXLINES
 
 # TODO: fix quota handling of old-style vgrids and remove next ignore
 [ "$ENABLE_QUOTA" == "True" ] && grep -a -H " ERROR " $LOGDIR/quota.log | grep -E -v "skipping entry: .*, no lustre data path:"  | tail -n $MAXLINES

--- a/tests/fixture/confs-stdlocal/migerrors
+++ b/tests/fixture/confs-stdlocal/migerrors
@@ -40,48 +40,48 @@ ENABLE_ACCOUNTING="False"
 ENABLE_QUOTA="False"
 
 {
-[ "$ENABLE_DAVS" == "True" ] && grep -H "Internal Server Error" $LOGDIR/webdavs.out | tail -n $MAXLINES
-[ "$ENABLE_DAVS" == "True" ] && grep -H -A 12 "Traceback" $LOGDIR/webdavs.out | tail -n $MAXLINES
+[ "$ENABLE_DAVS" == "True" ] && grep -a -H "Internal Server Error" $LOGDIR/webdavs.out | tail -n $MAXLINES
+[ "$ENABLE_DAVS" == "True" ] && grep -a -H -A 12 "Traceback" $LOGDIR/webdavs.out | tail -n $MAXLINES
 
-[ "$ENABLE_FTPS" == "True" ] && grep -H " ERROR " $LOGDIR/ftps.log | \
+[ "$ENABLE_FTPS" == "True" ] && grep -a -H " ERROR " $LOGDIR/ftps.log | \
         grep -E -v "ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|: Invalid path characters" | tail -n $MAXLINES
 
 [[ "$ENABLE_SFTP" == "True" || "$ENABLE_SFTP_SUBSYS" == True ]]  \
-        && grep -H " ERROR " $LOGDIR/sftp*.log | \
+        && grep -a -H " ERROR " $LOGDIR/sftp*.log | \
 	grep -E -v "Password authentication failed for|Socket exception: Connection reset by peer|Error reading SSH protocol banner|check_banner|list_folder on missing path|chmod (292|365) rejected on path|symlink rejected on path|ERROR mkdir .* failed: \[Errno 17\] File exists|ERROR rmdir .* failed: \[Errno 39\] Directory not empty|ERROR (open|remove) .* failed: \[Errno 21\] Is a directory|ERROR open for modify on read-only path|ERROR open existing file on missing path |ERROR rmdir rejected on link path |ERROR Exception.*: Incompatible ssh|ERROR Exception.*: Incompatible version |Exception.*: Invalid SSH banner|ERROR Exception.*: no moduli available|ERROR Exception.*: Expecting packet from \(20,\), got 0|ERROR Socket exception: Connection timed out|ERROR Exception.*: Key-exchange timed out|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|ERROR Exception.*: Client kex .* is out of range|ERROR Exception.*: Expecting packet from .*|get_fs_path failed: Invalid path characters|ERROR $" | tail -n $MAXLINES
 
-[ "$ENABLE_DAVS" == "True" ] && grep -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES
+[ "$ENABLE_DAVS" == "True" ] && grep -a -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES
 
-[ "$ENABLE_OPENID" == "True" ] && grep -H " ERROR " $LOGDIR/openid.log | grep -E -v "crashed: Unexpected query variable|retry_url: shorter than minimum length|invalid retry_url: found invalid character|crashed: int\(\) argument must be a string|input: shorter than minimum length|input: found invalid character:" | tail -n $MAXLINES
+[ "$ENABLE_OPENID" == "True" ] && grep -a -H " ERROR " $LOGDIR/openid.log | grep -E -v "crashed: Unexpected query variable|retry_url: shorter than minimum length|invalid retry_url: found invalid character|crashed: int\(\) argument must be a string|input: shorter than minimum length|input: found invalid character:" | tail -n $MAXLINES
 
-[ "$ENABLE_CRONTAB" == "True" ] && grep -H " ERROR " $LOGDIR/cron.log | tail -n $MAXLINES
+[ "$ENABLE_CRONTAB" == "True" ] && grep -a -H " ERROR " $LOGDIR/cron.log | tail -n $MAXLINES
 
-[ "$ENABLE_EVENTS" == "True" ] && grep -H " ERROR " $LOGDIR/events.log | tail -n $MAXLINES
+[ "$ENABLE_EVENTS" == "True" ] && grep -a -H " ERROR " $LOGDIR/events.log | tail -n $MAXLINES
 
-[ "$ENABLE_TRANSFERS" == "True" ] && grep -H " ERROR " $LOGDIR/transfers.log | tail -n $MAXLINES
+[ "$ENABLE_TRANSFERS" == "True" ] && grep -a -H " ERROR " $LOGDIR/transfers.log | tail -n $MAXLINES
 
-[ "$ENABLE_NOTIFY" == "True" ] && grep -H " ERROR " $LOGDIR/notify.log | tail -n $MAXLINES
+[ "$ENABLE_NOTIFY" == "True" ] && grep -a -H " ERROR " $LOGDIR/notify.log | tail -n $MAXLINES
 
-[ "$ENABLE_JANITOR" == "True" ] && grep -H " ERROR " $LOGDIR/janitor.log | grep -E -v " expire [0-9:. -]+ vs [0-9:. -]+ prevents .+ as peer for " | tail -n $MAXLINES
+[ "$ENABLE_JANITOR" == "True" ] && grep -a -H " ERROR " $LOGDIR/janitor.log | grep -E -v " expire [0-9:. -]+ vs [0-9:. -]+ prevents .+ as peer for " | tail -n $MAXLINES
 
 # TODO: fix auto creation of freeze helper directory and skip partial archives without meta.pck then remove next ignores
-[ "$ENABLE_ACCOUNTING" == "True" ] && grep -H " ERROR " $LOGDIR/accounting.log | grep -E -v "Missing quota freeze path: ./.+/quota_home/lustre/freeze.|No such file or directory: ./.+/freeze_home/archive-.*/meta.pck." | tail -n $MAXLINES
+[ "$ENABLE_ACCOUNTING" == "True" ] && grep -a -H " ERROR " $LOGDIR/accounting.log | grep -E -v "Missing quota freeze path: ./.+/quota_home/lustre/freeze.|No such file or directory: ./.+/freeze_home/archive-.*/meta.pck." | tail -n $MAXLINES
 
 # TODO: fix quota handling of old-style vgrids and remove next ignore
-[ "$ENABLE_QUOTA" == "True" ] && grep -H " ERROR " $LOGDIR/quota.log | grep -E -v "skipping entry: .*, no lustre data path:"  | tail -n $MAXLINES
+[ "$ENABLE_QUOTA" == "True" ] && grep -a -H " ERROR " $LOGDIR/quota.log | grep -E -v "skipping entry: .*, no lustre data path:"  | tail -n $MAXLINES
 
-grep -H " ERROR " $LOGDIR/chkchroot.log | grep -E -v " from ${SECSCANIP} "| \
+grep -a -H " ERROR " $LOGDIR/chkchroot.log | grep -E -v " from ${SECSCANIP} "| \
         grep -E -v "((HNAP1|GponForm|provisioning|provision|prov|polycom|yealink|CertProv|phpmyadmin|admin|cfg|wp|wordpress|cms|blog|old|new|test|dev|tmp|temp|remote|mgmt|properties|authenticate|tmui|ddem|a2billing|vtigercrm|secure|rpc|recordings|dana-na)(/.*|)|.*(Login|login|logon|configuration|header|admin|index)\.(php|jsp|asp)|(api/v1/pods|Telerik.Web.UI.WebResource.axd))" | \
         grep -E -v "/index\.html.$|/state/webserver_home/share_redirect.$" | \
         tail -n $MAXLINES
 
 # NOTE: we ignore script crashed errors here and treat specifically next
-grep -H " ERROR " $LOGDIR/mig.log | \
+grep -a -H " ERROR " $LOGDIR/mig.log | \
 	grep -E -v "problems importing arclib|disabled in configuration|(settings|userprofile) could not be opened/unpickled|load (ssh|ftps|davs|seafile) publickeys failed|is not a valid openid provider|script crashed:|INFO Content-Length missing or zero|${SECSCANIP} (refused to|could not) import .*shared\.functionality\.|INFO Not available on this site.*Replied .ERROR.|: failed on .*: .*\[Errno 2\] No such file or directory: |: failed on .*: .*\[Errno 17\] File exists: |ERROR could not delete .*: \[Errno 2\] No such file or directory: |ERROR could not read .*: \[Errno 21\] Is a directory: |ERROR cat: failed on .*: could not read file|create directory failed: .*\[Errno 17\] File exists: |ERROR Unpack called on unsupported archive: |ERROR .* uploadchunked .* request data read error: |ERROR rm: refusing rm home dir: |refusing rm link: .*/user_home/.*/Trash|ERROR .* could not import .*: No module named "| tail -n $MAXLINES
 # Extract variable length script crash tracebacks terminated with a blank line
 sed -n "/ERROR.* script crashed:/""{ :a; $p; N; /\n$/!ba; p; }" $LOGDIR/mig.log | tail -n $MAXLINES
 
-grep -H "CSRF check failed" $LOGDIR/mig.log | tail -n $MAXLINES
+grep -a -H "CSRF check failed" $LOGDIR/mig.log | tail -n $MAXLINES
 } | grep -E "${YESTERDAY}|${TODAY}|^[^0-9/]"'
 
 exit 0

--- a/tests/fixture/confs-stdlocal/migerrors
+++ b/tests/fixture/confs-stdlocal/migerrors
@@ -62,11 +62,13 @@ ENABLE_QUOTA="False"
 
 [ "$ENABLE_NOTIFY" == "True" ] && grep -H " ERROR " $LOGDIR/notify.log | tail -n $MAXLINES
 
-[ "$ENABLE_JANITOR" == "True" ] && grep -H " ERROR " $LOGDIR/janitor.log | tail -n $MAXLINES
+[ "$ENABLE_JANITOR" == "True" ] && grep -H " ERROR " $LOGDIR/janitor.log | grep -E -v " expire [0-9:. -]+ vs [0-9:. -]+ prevents .+ as peer for " | tail -n $MAXLINES
 
-[ "$ENABLE_ACCOUNTING" == "True" ] && grep -H " ERROR " $LOGDIR/accounting.log | tail -n $MAXLINES
+# TODO: fix auto creation of freeze helper directory and skip partial archives without meta.pck then remove next ignores
+[ "$ENABLE_ACCOUNTING" == "True" ] && grep -H " ERROR " $LOGDIR/accounting.log | grep -E -v "Missing quota freeze path: ./.+/quota_home/lustre/freeze.|No such file or directory: ./.+/freeze_home/archive-.*/meta.pck." | tail -n $MAXLINES
 
-[ "$ENABLE_QUOTA" == "True" ] && grep -H " ERROR " $LOGDIR/quota.log | tail -n $MAXLINES
+# TODO: fix quota handling of old-style vgrids and remove next ignore
+[ "$ENABLE_QUOTA" == "True" ] && grep -H " ERROR " $LOGDIR/quota.log | grep -E -v "skipping entry: .*, no lustre data path:"  | tail -n $MAXLINES
 
 grep -H " ERROR " $LOGDIR/chkchroot.log | grep -E -v " from ${SECSCANIP} "| \
         grep -E -v "((HNAP1|GponForm|provisioning|provision|prov|polycom|yealink|CertProv|phpmyadmin|admin|cfg|wp|wordpress|cms|blog|old|new|test|dev|tmp|temp|remote|mgmt|properties|authenticate|tmui|ddem|a2billing|vtigercrm|secure|rpc|recordings|dana-na)(/.*|)|.*(Login|login|logon|configuration|header|admin|index)\.(php|jsp|asp)|(api/v1/pods|Telerik.Web.UI.WebResource.axd))" | \

--- a/tests/fixture/confs-stdlocal/migerrors
+++ b/tests/fixture/confs-stdlocal/migerrors
@@ -62,10 +62,10 @@ ENABLE_QUOTA="False"
 
 [ "$ENABLE_NOTIFY" == "True" ] && grep -a -H " ERROR " $LOGDIR/notify.log | tail -n $MAXLINES
 
-[ "$ENABLE_JANITOR" == "True" ] && grep -a -H " ERROR " $LOGDIR/janitor.log | grep -E -v " expire [0-9:. -]+ vs [0-9:. -]+ prevents .+ as peer for " | tail -n $MAXLINES
+[ "$ENABLE_JANITOR" == "True" ] && grep -a -H " ERROR " $LOGDIR/janitor.log | grep -E -v " expire [0-9:. -]+ .+ prevents .+ as peer for " | tail -n $MAXLINES
 
-# TODO: fix auto creation of freeze helper directory and skip partial archives without meta.pck then remove next ignores
-[ "$ENABLE_ACCOUNTING" == "True" ] && grep -a -H " ERROR " $LOGDIR/accounting.log | grep -E -v "Missing quota freeze path: ./.+/quota_home/lustre/freeze.|No such file or directory: ./.+/freeze_home/archive-.*/meta.pck." | tail -n $MAXLINES
+# TODO: skip or fix auto creation of missing freeze helper paths and skip partial archives without meta.pck and missing quota ID.json then remove next ignores
+[ "$ENABLE_ACCOUNTING" == "True" ] && grep -a -H " ERROR " $LOGDIR/accounting.log | grep -E -v "Missing quota freeze path: ./.+/quota_home/.+/freeze.|Failed to fetch freeze quota: ./.+/quota_home/.+/freeze/.+\.json.|No such file or directory: ./.+/freeze_home/archive-.*/meta\.pck.|No such file or directory: ./.+/quota_home/.+/freeze/.+\.json." | tail -n $MAXLINES
 
 # TODO: fix quota handling of old-style vgrids and remove next ignore
 [ "$ENABLE_QUOTA" == "True" ] && grep -a -H " ERROR " $LOGDIR/quota.log | grep -E -v "skipping entry: .*, no lustre data path:"  | tail -n $MAXLINES


### PR DESCRIPTION
Adjust `migerrors` to filter some recurring log errors in the recently added `janitor`, `quota` and `accounting` log monitoring in #574. The latter two should really be fixed in the daemons and the temporary filters then disabled again.
In the janitor case we may want to adjust the retry rate for external account renewals when the employee account is expired and therefore won't work as peer. Still, it should be retried regularly because a single employee account login will renew and allow it to succeed.

Tweaks the grep commands to force text mode to remove occasional messages about binary file matching when mixed content is encountered.