### PR TITLE
Auto-format code in tests/support for style compliance

### DIFF
--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -28,8 +28,6 @@
 
 """Supporting functions for the unit test framework"""
 
-from collections import defaultdict
-from configparser import ConfigParser
 import difflib
 import errno
 import io
@@ -40,35 +38,41 @@ import pickle
 import shutil
 import stat
 import sys
+from collections import defaultdict
+from configparser import ConfigParser
 from types import SimpleNamespace
-from unittest import TestCase, main as testmain
+from unittest import TestCase
+from unittest import main as testmain
 
+import tests.support.fakes as fakes
+from tests.support._env import MIG_ENV, PY2
 from tests.support.configsupp import FakeConfiguration
 from tests.support.fixturesupp import _PreparedFixture
-from tests.support.suppconst import MIG_BASE, TEST_BASE, \
-    TEST_DATA_DIR, TEST_OUTPUT_DIR, ENVHELP_OUTPUT_DIR
+from tests.support.suppconst import (
+    ENVHELP_OUTPUT_DIR,
+    MIG_BASE,
+    TEST_BASE,
+    TEST_DATA_DIR,
+    TEST_OUTPUT_DIR,
+)
 from tests.support.usersupp import UserAssertMixin
-import tests.support.fakes as fakes
-
-from tests.support._env import MIG_ENV, PY2
-
 
 # Provide access to a configuration file for the active environment.
 
-if MIG_ENV in ('local', 'docker'):
+if MIG_ENV in ("local", "docker"):
     # force local testconfig
-    _output_dir = os.path.join(MIG_BASE, 'envhelp/output')
+    _output_dir = os.path.join(MIG_BASE, "envhelp/output")
     _conf_dir_name = "testconfs-%s" % (MIG_ENV,)
     _conf_dir = os.path.join(_output_dir, _conf_dir_name)
-    _local_conf = os.path.join(_conf_dir, 'MiGserver.conf')
-    _config_file = os.getenv('MIG_CONF', None)
+    _local_conf = os.path.join(_conf_dir, "MiGserver.conf")
+    _config_file = os.getenv("MIG_CONF", None)
     if _config_file is None:
-        os.environ['MIG_CONF'] = _local_conf
+        os.environ["MIG_CONF"] = _local_conf
 
     # adjust the link through which confs are accessed to suit the environment
-    _conf_link = os.path.join(_output_dir, 'testconfs')
+    _conf_link = os.path.join(_output_dir, "testconfs")
     assert os.path.lexists(_conf_link)  # it must already exist
-    os.remove(_conf_link)              # blow it away
+    os.remove(_conf_link)  # blow it away
     os.symlink(_conf_dir, _conf_link)  # recreate it using the active MIG_BASE
 else:
     raise NotImplementedError()
@@ -97,7 +101,6 @@ from tests.support.assertover import AssertOver
 from tests.support.configsupp import FakeConfiguration
 from tests.support.loggersupp import FakeLogger, FakeLoggerChecker
 from tests.support.serversupp import make_wrapped_server
-
 
 # Basic global logging configuration for testing
 
@@ -182,7 +185,7 @@ class MigTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if MIG_ENV == 'docker':
+        if MIG_ENV == "docker":
             # the permissions story wrt running inside docker containers is
             # such that we can end up with files from previous test runs left
             # around that might subsequently cause spurious permissions errors
@@ -210,22 +213,27 @@ class MigTestCase(TestCase):
 
     @staticmethod
     def _make_configuration_instance(testcase, configuration_to_make):
-        if configuration_to_make == 'fakeconfig':
+        if configuration_to_make == "fakeconfig":
             fake_configuration = FakeConfiguration(logger=testcase.logger)
             from mig.shared.conf import RuntimeConfiguration
+
             return RuntimeConfiguration(fake_configuration)
-        elif configuration_to_make == 'testconfig':
+        elif configuration_to_make == "testconfig":
             from mig.shared.conf import get_configuration_object
-            configuration = get_configuration_object(skip_log=True,
-                                                     disable_auth_log=True)
+
+            configuration = get_configuration_object(
+                skip_log=True, disable_auth_log=True
+            )
             configuration.logger = testcase.logger
             return configuration
         else:
             raise AssertionError(
-                "MigTestCase: unknown configuration %r" % (configuration_to_make,))
+                "MigTestCase: unknown configuration %r"
+                % (configuration_to_make,)
+            )
 
     def _provide_configuration(self):
-        return 'unspecified'
+        return "unspecified"
 
     @property
     def configuration(self):
@@ -236,14 +244,16 @@ class MigTestCase(TestCase):
 
         configuration_to_make = self._provide_configuration()
 
-        if configuration_to_make == 'unspecified':
+        if configuration_to_make == "unspecified":
             raise AssertionError(
-                "configuration access but testcase did not request it")
+                "configuration access but testcase did not request it"
+            )
 
         configuration_instance = self._make_configuration_instance(
-            self, configuration_to_make)
+            self, configuration_to_make
+        )
 
-        if configuration_to_make == 'testconfig':
+        if configuration_to_make == "testconfig":
             # use the paths defined by the loaded configuration to create
             # the directories which are expected to be present by the code
             os.mkdir(configuration_instance.certs_path)
@@ -279,16 +289,20 @@ class MigTestCase(TestCase):
         """Make sure the supplied path is an empty directory"""
         path_kind = self.assertPathExists(relative_path)
         assert path_kind == "dir", "expected a directory but found %s" % (
-            path_kind, )
+            path_kind,
+        )
         absolute_path = os.path.join(TEST_OUTPUT_DIR, relative_path)
         entries = os.listdir(absolute_path)
         assert not entries, "directory is not empty"
 
     def assertDirNotEmpty(self, relative_path, allow_anypath=False):
         """Make sure the supplied path is a non-empty directory"""
-        path_kind = self.assertPathExists(relative_path, allow_anypath=allow_anypath)
+        path_kind = self.assertPathExists(
+            relative_path, allow_anypath=allow_anypath
+        )
         assert path_kind == "dir", "expected a directory but found %s" % (
-            path_kind, )
+            path_kind,
+        )
         absolute_path = os.path.join(TEST_OUTPUT_DIR, relative_path)
         entries = os.listdir(absolute_path)
         assert entries, "directory is empty"
@@ -296,28 +310,35 @@ class MigTestCase(TestCase):
 
     def assertFileContentIdentical(self, file_actual, file_expected):
         """Make sure file_actual and file_expected are identical"""
-        with io.open(file_actual) as f_actual, io.open(file_expected) as f_expected:
+        with io.open(file_actual) as f_actual, io.open(
+            file_expected
+        ) as f_expected:
             lhs = f_actual.readlines()
             rhs = f_expected.readlines()
             different_lines = list(difflib.unified_diff(rhs, lhs))
             try:
                 self.assertEqual(len(different_lines), 0)
             except AssertionError:
-                raise AssertionError("""differences found between files
+                raise AssertionError(
+                    """differences found between files
 * %s
 * %s
 included:
 %s
-                    """ % (
-                    os.path.relpath(file_expected, MIG_BASE),
-                    os.path.relpath(file_actual, MIG_BASE),
-                    ''.join(different_lines)))
+                    """
+                    % (
+                        os.path.relpath(file_expected, MIG_BASE),
+                        os.path.relpath(file_actual, MIG_BASE),
+                        "".join(different_lines),
+                    )
+                )
 
     def assertFileExists(self, relative_path):
         """Make sure relative_path exists and is a file"""
         path_kind = self.assertPathExists(relative_path)
         assert path_kind == "file", "expected a file but found %s" % (
-            path_kind, )
+            path_kind,
+        )
         return os.path.join(TEST_OUTPUT_DIR, relative_path)
 
     def assertPathExists(self, relative_path, allow_anypath=False):
@@ -349,13 +370,14 @@ included:
         """Make sure path is within start directory"""
         if not is_path_within(path, start=start):
             raise AssertionError(
-                "path %s is not within directory %s" % (path, start))
+                "path %s is not within directory %s" % (path, start)
+            )
 
     @staticmethod
     def pretty_display_path(absolute_path):
         assert os.path.isabs(absolute_path)
         relative_path = os.path.relpath(absolute_path, start=MIG_BASE)
-        assert not relative_path.startswith('..')
+        assert not relative_path.startswith("..")
         return relative_path
 
     @staticmethod
@@ -366,7 +388,9 @@ included:
         Note that this method, along with a number of others, are defined in
         the user portion of the test support libraries.
         """
-        return UserAssertMixin._provision_test_user(testcase, distinguished_name)
+        return UserAssertMixin._provision_test_user(
+            testcase, distinguished_name
+        )
 
 
 def is_path_within(path, start=None, _msg=None):
@@ -376,7 +400,7 @@ def is_path_within(path, start=None, _msg=None):
         relative = os.path.relpath(path, start=start)
     except:
         return False
-    return not relative.startswith('..')
+    return not relative.startswith("..")
 
 
 def ensure_dirs_exist(absolute_dir):
@@ -407,7 +431,7 @@ def temppath(relative_path, test_case, ensure_dir=False):
 
     # failsafe path checking that supplied paths are rooted within valid paths
     is_tmp_path_within_safe_dir = False
-    for start in (ENVHELP_OUTPUT_DIR):
+    for start in ENVHELP_OUTPUT_DIR:
         is_tmp_path_within_safe_dir = is_path_within(tmp_path, start=start)
         if is_tmp_path_within_safe_dir:
             break
@@ -420,7 +444,8 @@ def temppath(relative_path, test_case, ensure_dir=False):
         except OSError as oserr:
             if oserr.errno == errno.EEXIST:
                 raise AssertionError(
-                    "ABORT: use of unclean output path: %s" % tmp_path)
+                    "ABORT: use of unclean output path: %s" % tmp_path
+                )
     return tmp_path
 
 

--- a/tests/support/_env.py
+++ b/tests/support/_env.py
@@ -2,10 +2,10 @@ import os
 import sys
 
 # expose the configured environment as a constant
-MIG_ENV = os.environ.get('MIG_ENV', 'local')
+MIG_ENV = os.environ.get("MIG_ENV", "local")
 
 # force the chosen environment globally
-os.environ['MIG_ENV'] = MIG_ENV
+os.environ["MIG_ENV"] = MIG_ENV
 
 # expose a boolean indicating whether we are executing on Python 2
-PY2 = (sys.version_info[0] == 2)
+PY2 = sys.version_info[0] == 2

--- a/tests/support/assertover.py
+++ b/tests/support/assertover.py
@@ -29,11 +29,13 @@
 
 class NoBlockError(AssertionError):
     """Decorate AssertionError for our own convenience"""
+
     pass
 
 
 class NoCasesError(AssertionError):
     """Decorate AssertionError for our own convenience"""
+
     pass
 
 
@@ -76,10 +78,15 @@ class AssertOver:
         if not any(self._attempts):
             return True
 
-        value_lines = ["- <%r> : %s" % (attempt[0], str(attempt[1])) for
-                       attempt in self._attempts if attempt]
-        raise AssertionError("assertions raised for the following values:\n%s"
-                             % '\n'.join(value_lines))
+        value_lines = [
+            "- <%r> : %s" % (attempt[0], str(attempt[1]))
+            for attempt in self._attempts
+            if attempt
+        ]
+        raise AssertionError(
+            "assertions raised for the following values:\n%s"
+            % "\n".join(value_lines)
+        )
 
     def record_attempt(self, attempt_info):
         """Record the result of a test attempt"""
@@ -89,7 +96,9 @@ class AssertOver:
         def raise_unless_consulted():
             if not self._consulted:
                 raise AssertionError(
-                    "no examiniation made of assertion of multiple values")
+                    "no examiniation made of assertion of multiple values"
+                )
+
         return raise_unless_consulted
 
     def assert_success(self):
@@ -103,4 +112,7 @@ class AssertOver:
             block.__call__(block_value)
             return None
         except Exception as blockexc:
-            return (block_value, blockexc,)
+            return (
+                block_value,
+                blockexc,
+            )

--- a/tests/support/configsupp.py
+++ b/tests/support/configsupp.py
@@ -27,20 +27,21 @@
 
 """Configuration related details within the test support library."""
 
-from tests.support.loggersupp import FakeLogger
-
 from mig.shared.compat import SimpleNamespace
-from mig.shared.configuration import \
-    _CONFIGURATION_ARGUMENTS, _CONFIGURATION_PROPERTIES
+from mig.shared.configuration import (
+    _CONFIGURATION_ARGUMENTS,
+    _CONFIGURATION_PROPERTIES,
+)
+from tests.support.loggersupp import FakeLogger
 
 
 def _ensure_only_configuration_keys(thedict):
-    """Check a dictionary contains only keys valid as Configuration properties.
-    """
+    """Check a dictionary contains only keys valid as Configuration properties."""
 
     unknown_keys = set(thedict.keys()) - set(_CONFIGURATION_ARGUMENTS)
-    assert len(unknown_keys) == 0, \
-        "non-Configuration keys: %s" % (', '.join(unknown_keys),)
+    assert len(unknown_keys) == 0, "non-Configuration keys: %s" % (
+        ", ".join(unknown_keys),
+    )
 
 
 def _generate_namespace_kwargs():
@@ -49,7 +50,7 @@ def _generate_namespace_kwargs():
     """
 
     properties_and_defaults = dict(_CONFIGURATION_PROPERTIES)
-    properties_and_defaults['logger'] = None
+    properties_and_defaults["logger"] = None
     return properties_and_defaults
 
 

--- a/tests/support/fixturesupp.py
+++ b/tests/support/fixturesupp.py
@@ -27,12 +27,12 @@
 
 """Fixture related details within the test support library."""
 
-from configparser import ConfigParser
-from datetime import date, timedelta
 import json
 import os
 import pickle
 import shutil
+from configparser import ConfigParser
+from datetime import date, timedelta
 from time import mktime
 from types import SimpleNamespace
 
@@ -51,30 +51,35 @@ def _fixturefile_loadrelative(fixture_name, fixture_format=None):
     assert fixture_format is not None, "fixture format must be specified"
     relative_path_with_ext = "%s.%s" % (fixture_name, fixture_format)
     tmp_path = os.path.join(TEST_FIXTURE_DIR, relative_path_with_ext)
-    assert os.path.isfile(tmp_path), \
-        'fixture named "%s" with format %s is not present: %s' % \
-        (fixture_name, fixture_format, relative_path_with_ext)
+    assert os.path.isfile(
+        tmp_path
+    ), 'fixture named "%s" with format %s is not present: %s' % (
+        fixture_name,
+        fixture_format,
+        relative_path_with_ext,
+    )
 
     data = None
 
-    if fixture_format == 'binary':
-        with open(tmp_path, 'rb') as binfile:
+    if fixture_format == "binary":
+        with open(tmp_path, "rb") as binfile:
             data = binfile.read()
-    elif fixture_format == 'json':
+    elif fixture_format == "json":
         with open(tmp_path) as jsonfile:
             data = json.load(jsonfile, object_hook=_FixtureHint.object_hook)
             _hints_apply_from_instances_if_present(data)
             _hints_apply_from_fixture_ini_if_present(fixture_name, data)
     else:
         raise AssertionError(
-            "unsupported fixture format: %s" % (fixture_format,))
+            "unsupported fixture format: %s" % (fixture_format,)
+        )
 
     return data, tmp_path
 
 
-def _fixturefile_normname(relative_path, prefix=''):
+def _fixturefile_normname(relative_path, prefix=""):
     """Grab normname from relative_path and optionally add a path prefix"""
-    normname, _ = relative_path.split('--')
+    normname, _ = relative_path.split("--")
     if prefix:
         return os.path.join(prefix, normname)
     return normname
@@ -96,6 +101,7 @@ def _fixturefile_normname(relative_path, prefix=''):
 #
 # <hints>
 
+
 def _hints_apply_array_of_tuples(value, modifier):
     """
     Convert list of lists such that its values are instead tuples.
@@ -109,7 +115,7 @@ def _hints_apply_today_relative(value, modifier):
     Geneate a time value by applying a declared delta to today's date.
     """
 
-    kind, delta = modifier.split('|')
+    kind, delta = modifier.split("|")
     if kind == "days":
         time_delta = timedelta(days=int(delta))
         adjusted_datetime = date.today() + time_delta
@@ -131,15 +137,17 @@ def _hints_apply_dict_bytes_to_strings_kv(input_dict, modifier):
     for k, v in input_dict.items():
         key_to_use = k
         if isinstance(k, bytes):
-            key_to_use = str(k, 'utf8')
+            key_to_use = str(k, "utf8")
 
         if isinstance(v, dict):
-            output_dict[key_to_use] = _hints_apply_dict_bytes_to_strings_kv(v, modifier)
+            output_dict[key_to_use] = _hints_apply_dict_bytes_to_strings_kv(
+                v, modifier
+            )
             continue
 
         val_to_use = v
         if isinstance(v, bytes):
-            val_to_use = str(v, 'utf8')
+            val_to_use = str(v, "utf8")
 
         output_dict[key_to_use] = val_to_use
 
@@ -159,15 +167,17 @@ def _hints_apply_dict_strings_to_bytes_kv(input_dict, modifier):
     for k, v in input_dict.items():
         key_to_use = k
         if isinstance(k, str):
-            key_to_use = bytes(k, 'utf8')
+            key_to_use = bytes(k, "utf8")
 
         if isinstance(v, dict):
-            output_dict[key_to_use] = _hints_apply_dict_strings_to_bytes_kv(v, modifier)
+            output_dict[key_to_use] = _hints_apply_dict_strings_to_bytes_kv(
+                v, modifier
+            )
             continue
 
         val_to_use = v
         if isinstance(v, str):
-            val_to_use = bytes(v, 'utf8')
+            val_to_use = bytes(v, "utf8")
 
         output_dict[key_to_use] = val_to_use
 
@@ -176,21 +186,21 @@ def _hints_apply_dict_strings_to_bytes_kv(input_dict, modifier):
 
 # hints that can be aplied without an additional modifier argument
 _HINTS_APPLIERS_ARGLESS = {
-    'array_of_tuples': _hints_apply_array_of_tuples,
-    'today_relative': _hints_apply_today_relative,
-    'convert_dict_bytes_to_strings_kv': _hints_apply_dict_bytes_to_strings_kv,
-    'convert_dict_strings_to_bytes_kv': _hints_apply_dict_strings_to_bytes_kv,
+    "array_of_tuples": _hints_apply_array_of_tuples,
+    "today_relative": _hints_apply_today_relative,
+    "convert_dict_bytes_to_strings_kv": _hints_apply_dict_bytes_to_strings_kv,
+    "convert_dict_strings_to_bytes_kv": _hints_apply_dict_strings_to_bytes_kv,
 }
 
 # hints applicable to the conversion of attributes during fixture loading
 _FIXTUREFILE_APPLIERS_ATTRIBUTES = {
-    'array_of_tuples': _hints_apply_array_of_tuples,
-    'today_relative': _hints_apply_today_relative,
+    "array_of_tuples": _hints_apply_array_of_tuples,
+    "today_relative": _hints_apply_today_relative,
 }
 
 # hints applied when writing the contents of a fixture as a temporary file
 _FIXTUREFILE_APPLIERS_ONWRITE = {
-    'convert_dict_strings_to_bytes_kv': _hints_apply_dict_strings_to_bytes_kv,
+    "convert_dict_strings_to_bytes_kv": _hints_apply_dict_strings_to_bytes_kv,
 }
 
 
@@ -222,7 +232,7 @@ def _load_hints_ini_for_fixture_if_present(fixture_name):
         pass
 
     # ensure empty required fixture to avoid extra conditionals later
-    for required_section in ['ATTRIBUTES']:
+    for required_section in ["ATTRIBUTES"]:
         if not hints.has_section(required_section):
             hints.add_section(required_section)
 
@@ -239,10 +249,10 @@ def _hints_apply_from_fixture_ini_if_present(fixture_name, json_object):
 
     # apply any attriutes hints ahead of specified conversions such that any
     # key can be specified matching what is visible within the loaded fixture
-    for item_name, item_hint_unparsed in hints['ATTRIBUTES'].items():
+    for item_name, item_hint_unparsed in hints["ATTRIBUTES"].items():
         loaded_value = json_object[item_name]
 
-        item_hint_and_maybe_modifier = item_hint_unparsed.split('--')
+        item_hint_and_maybe_modifier = item_hint_unparsed.split("--")
         item_hint = item_hint_and_maybe_modifier[0]
         if len(item_hint_and_maybe_modifier) == 2:
             modifier = item_hint_and_maybe_modifier[1]
@@ -267,7 +277,9 @@ class _FixtureHint:
     def decode_hint(hint_obj):
         """Produce a value based on the properties of a hint instance."""
         assert isinstance(hint_obj, _FixtureHint)
-        value_from_loaded_value = _FIXTUREFILE_APPLIERS_ATTRIBUTES[hint_obj.hint]
+        value_from_loaded_value = _FIXTUREFILE_APPLIERS_ATTRIBUTES[
+            hint_obj.hint
+        ]
         return value_from_loaded_value(hint_obj.value, hint_obj.modifier)
 
     @staticmethod
@@ -278,10 +290,13 @@ class _FixtureHint:
         """
 
         if "_FixtureHint" in decoded_object:
-            fixture_hint = _FixtureHint(decoded_object["hint"], decoded_object["modifier"])
+            fixture_hint = _FixtureHint(
+                decoded_object["hint"], decoded_object["modifier"]
+            )
             return _FixtureHint.decode_hint(fixture_hint)
 
         return decoded_object
+
 
 # </hints>
 
@@ -295,7 +310,7 @@ def fixturepath(relative_path):
 def _to_display_path(value):
     """Convert an absolute path to one to be shown as part of test output."""
     display_path = os.path.relpath(value, MIG_BASE)
-    if not display_path.startswith('.'):
+    if not display_path.startswith("."):
         return "./" + display_path
     return display_path
 
@@ -307,10 +322,9 @@ class _PreparedFixture:
 
     NO_DATA = object()
 
-    def __init__(self, testcase,
-                 fixture_name,
-                 fixture_format='',
-                 fixture_data=NO_DATA):
+    def __init__(
+        self, testcase, fixture_name, fixture_format="", fixture_data=NO_DATA
+    ):
         self.testcase = testcase
         self.fixture_name = fixture_name
         self.fixture_format = fixture_format
@@ -336,9 +350,12 @@ class _PreparedFixture:
             if self.fixture_format:
                 message_infix = " with format %s" % (self.fixture_format,)
             else:
-                message_infix = ''
+                message_infix = ""
             message = "value differed from fixture named %s%s\n\n%s" % (
-                self.fixture_name, message_infix, raised_exception)
+                self.fixture_name,
+                message_infix,
+                raised_exception,
+            )
             raise AssertionError(message)
 
     def write_to_dir(self, target_dir, output_format=None):
@@ -347,42 +364,47 @@ class _PreparedFixture:
         directory applying any onwrite hints that may be specified.
         """
 
-        assert self.fixture_data is not self.NO_DATA, \
-                "fixture is not populated with data"
+        assert (
+            self.fixture_data is not self.NO_DATA
+        ), "fixture is not populated with data"
 
         assert os.path.isabs(target_dir)
 
         # convert fixture name (which includes the varaint) to the target file
-        fixture_file_target = _fixturefile_normname(self.fixture_name, prefix=target_dir)
+        fixture_file_target = _fixturefile_normname(
+            self.fixture_name, prefix=target_dir
+        )
 
         output_data = self.fixture_data
 
         # now apply any onwrite conversions
         hints = _load_hints_ini_for_fixture_if_present(self.fixture_name)
-        for item_name in hints['ONWRITE']:
+        for item_name in hints["ONWRITE"]:
             if item_name not in _FIXTUREFILE_APPLIERS_ONWRITE:
                 raise AssertionError(
-                    "unsupported fixture conversion: %s" % (item_name,))
+                    "unsupported fixture conversion: %s" % (item_name,)
+                )
 
-            enabled = hints.getboolean('ONWRITE', item_name)
+            enabled = hints.getboolean("ONWRITE", item_name)
             if not enabled:
                 continue
 
             hint_fn = _FIXTUREFILE_APPLIERS_ONWRITE[item_name]
             output_data = hint_fn(output_data, None)
 
-        if output_format == 'binary':
-            with open(fixture_file_target, 'wb') as fixture_outputfile:
+        if output_format == "binary":
+            with open(fixture_file_target, "wb") as fixture_outputfile:
                 fixture_outputfile.write(output_data)
-        elif output_format == 'json':
-            with open(fixture_file_target, 'w') as fixture_outputfile:
+        elif output_format == "json":
+            with open(fixture_file_target, "w") as fixture_outputfile:
                 json.dump(output_data, fixture_outputfile)
-        elif output_format == 'pickle':
-            with open(fixture_file_target, 'wb') as fixture_outputfile:
+        elif output_format == "pickle":
+            with open(fixture_file_target, "wb") as fixture_outputfile:
                 pickle.dump(output_data, fixture_outputfile)
         else:
             raise AssertionError(
-                "unsupported fixture format: %s" % (output_format,))
+                "unsupported fixture format: %s" % (output_format,)
+            )
 
     @staticmethod
     def from_relpath(testcase, fixture_name, fixture_format):
@@ -392,11 +414,16 @@ class _PreparedFixture:
         """
 
         fixture_data, fixture_path = _fixturefile_loadrelative(
-            fixture_name, fixture_format)
-        return _PreparedFixture(testcase, fixture_name, fixture_format, fixture_data)
+            fixture_name, fixture_format
+        )
+        return _PreparedFixture(
+            testcase, fixture_name, fixture_format, fixture_data
+        )
 
 
 class FixtureAssertMixin:
     def prepareFixtureAssert(self, fixture_relpath, fixture_format=None):
         """Prepare to assert a value against a fixture."""
-        return _PreparedFixture.from_relpath(self, fixture_relpath, fixture_format)
+        return _PreparedFixture.from_relpath(
+            self, fixture_relpath, fixture_format
+        )

--- a/tests/support/loggersupp.py
+++ b/tests/support/loggersupp.py
@@ -28,9 +28,9 @@
 
 """Logger related details within the test support library."""
 
-from collections import defaultdict
 import os
 import re
+from collections import defaultdict
 
 from tests.support.suppconst import MIG_BASE, TEST_BASE
 
@@ -47,7 +47,8 @@ class FakeLogger:
     """
 
     RE_UNCLOSEDFILE = re.compile(
-        'unclosed file <.*? name=\'(?P<location>.*?)\'( .*?)?>')
+        "unclosed file <.*? name='(?P<location>.*?)'( .*?)?>"
+    )
 
     def __init__(self):
         self.channels_dict = defaultdict(list)
@@ -70,13 +71,19 @@ class FakeLogger:
 
         # complain loudly (and in detail) in the case of unclosed files
         if len(unclosed_by_file) > 0:
-            messages = '\n'.join({' --> %s: line=%s, file=%s' % (fname, lineno, outname)
-                                  for fname, (lineno, outname) in unclosed_by_file.items()})
-            raise RuntimeError('unclosed files encountered:\n%s' % (messages,))
+            messages = "\n".join(
+                {
+                    " --> %s: line=%s, file=%s" % (fname, lineno, outname)
+                    for fname, (lineno, outname) in unclosed_by_file.items()
+                }
+            )
+            raise RuntimeError("unclosed files encountered:\n%s" % (messages,))
 
-        if channels_dict['error'] and not forgive_by_channel['error']:
-            raise RuntimeError('errors reported to logger:\n%s' %
-                               '\n'.join(channels_dict['error']))
+        if channels_dict["error"] and not forgive_by_channel["error"]:
+            raise RuntimeError(
+                "errors reported to logger:\n%s"
+                % "\n".join(channels_dict["error"])
+            )
 
     def forgive_errors(self):
         """Allow log errors for cases where they are expected"""
@@ -90,26 +97,26 @@ class FakeLogger:
 
     def debug(self, line):
         """Mock log action of same name"""
-        self._append_as('debug', line)
+        self._append_as("debug", line)
 
     def error(self, line):
         """Mock log action of same name"""
-        self._append_as('error', line)
+        self._append_as("error", line)
 
     def info(self, line):
         """Mock log action of same name"""
-        self._append_as('info', line)
+        self._append_as("info", line)
 
     def warning(self, line):
         """Mock log action of same name"""
-        self._append_as('warning', line)
+        self._append_as("warning", line)
 
     def write(self, message):
         """Actual write handler"""
-        channel, namespace, specifics = message.split(':', 2)
+        channel, namespace, specifics = message.split(":", 2)
 
         # ignore everything except warnings sent by the python runtime
-        if not (channel == 'WARNING' and namespace == 'py.warnings'):
+        if not (channel == "WARNING" and namespace == "py.warnings"):
             return
 
         filename_and_datatuple = FakeLogger.identify_unclosed_file(specifics)
@@ -119,10 +126,10 @@ class FakeLogger:
     @staticmethod
     def identify_unclosed_file(specifics):
         """Warn about unclosed files"""
-        filename, lineno, exc_name, message = specifics.split(':', 3)
+        filename, lineno, exc_name, message = specifics.split(":", 3)
 
         exc_name = exc_name.lstrip()
-        if exc_name != 'ResourceWarning':
+        if exc_name != "ResourceWarning":
             return
 
         matched = FakeLogger.RE_UNCLOSEDFILE.match(message.lstrip())
@@ -131,7 +138,8 @@ class FakeLogger:
 
         relative_testfile = os.path.relpath(filename, start=MIG_BASE)
         relative_outputfile = os.path.relpath(
-            matched.groups('location')[0], start=TEST_BASE)
+            matched.groups("location")[0], start=TEST_BASE
+        )
         return (relative_testfile, (lineno, relative_outputfile))
 
 

--- a/tests/support/picklesupp.py
+++ b/tests/support/picklesupp.py
@@ -29,8 +29,8 @@
 
 import pickle
 
-from tests.support.suppconst import TEST_OUTPUT_DIR
 from tests.support.fixturesupp import _HINTS_APPLIERS_ARGLESS
+from tests.support.suppconst import TEST_OUTPUT_DIR
 
 
 class PickleAssertMixin:
@@ -44,7 +44,7 @@ class PickleAssertMixin:
         having been optionally transformed as requested by hints.
         """
 
-        with open(pickle_file_path, 'rb') as picklefile:
+        with open(pickle_file_path, "rb") as picklefile:
             pickled = pickle.load(picklefile)
 
         if not apply_hints:

--- a/tests/support/serversupp.py
+++ b/tests/support/serversupp.py
@@ -27,7 +27,8 @@
 
 """Server threading related details within the test support library"""
 
-from threading import Thread, Event as ThreadEvent
+from threading import Event as ThreadEvent
+from threading import Thread
 
 
 class ServerWithinThreadExecutor:
@@ -50,7 +51,7 @@ class ServerWithinThreadExecutor:
         """Mimic the same method from the standard thread API"""
         server_args, server_kwargs = self._arguments
 
-        server_kwargs['on_start'] = lambda _: self._started.set()
+        server_kwargs["on_start"] = lambda _: self._started.set()
 
         self._wrapped = self._serverclass(*server_args, **server_kwargs)
 

--- a/tests/support/snapshotsupp.py
+++ b/tests/support/snapshotsupp.py
@@ -28,14 +28,14 @@
 
 import difflib
 import errno
-import re
 import os
+import re
 
 from tests.support.suppconst import TEST_BASE
 
-HTML_TAG = '<html>'
-MARKER_CONTENT_BEGIN = '<!-- Begin UI container -->'
-MARKER_CONTENT_END = '<!-- End UI container -->'
+HTML_TAG = "<html>"
+MARKER_CONTENT_BEGIN = "<!-- Begin UI container -->"
+MARKER_CONTENT_END = "<!-- End UI container -->"
 TEST_SNAPSHOTS_DIR = os.path.join(TEST_BASE, "snapshots")
 
 try:
@@ -57,9 +57,9 @@ def _html_content_only(value):
     # set the index after the content marker
     content_start_index += len(MARKER_CONTENT_BEGIN)
     # we now need to remove the container div inside it ..first find it
-    content_start_inner_div = value.find('<div', content_start_index)
+    content_start_inner_div = value.find("<div", content_start_index)
     # reset the content start to exclude up the end of the container div
-    content_start_index = value.find('>', content_start_inner_div) + 1
+    content_start_index = value.find(">", content_start_inner_div) + 1
 
     content_end_index = value.find(MARKER_CONTENT_END)
     assert content_end_index > -1, "unable to locate end of content"
@@ -75,31 +75,37 @@ def _html_fragment_only(value):
 
     content_length = len(value)
 
-    first_tag_index = value.find('<')
+    first_tag_index = value.find("<")
 
     first_tag_name = ""
     first_tag_index_close = first_tag_index + 1
     while first_tag_index_close < content_length:
         character = value[first_tag_index_close]
-        if character == '>':
+        if character == ">":
             break
         first_tag_name += character
         first_tag_index_close += 1
 
     # remove any attributes from the first found tag
     try:
-        first_tag_name = first_tag_name[0:first_tag_name.index(' ')]
+        first_tag_name = first_tag_name[0 : first_tag_name.index(" ")]
     except ValueError:
         pass
     assert first_tag_name, "fragment did not begin with a valid tag"
     assert first_tag_index_close != content_length, "fragment is unclosed"
 
     first_tag_closing = "</%s>" % (first_tag_name,)
-    after_first_tag_closing_index = value.rfind(first_tag_closing) + len(first_tag_closing)
+    after_first_tag_closing_index = value.rfind(first_tag_closing) + len(
+        first_tag_closing
+    )
 
-    trailing_characters_if_any = value[after_first_tag_closing_index:content_length]
+    trailing_characters_if_any = value[
+        after_first_tag_closing_index:content_length
+    ]
 
-    assert trailing_characters_if_any.rstrip() == '', "fragment did not end with its opening tag"
+    assert (
+        trailing_characters_if_any.rstrip() == ""
+    ), "fragment did not end with its opening tag"
 
     return value
 
@@ -114,7 +120,7 @@ def _delimited_lines(value):
     lines = []
 
     while from_index < last_index:
-        found_index = value.find('\n', from_index)
+        found_index = value.find("\n", from_index)
         if found_index == -1:
             break
         found_index += 1
@@ -130,8 +136,8 @@ def _delimited_lines(value):
 def _force_refresh_snapshots():
     """Check whether the environment specifies snapshots should be refreshed."""
 
-    env_refresh_snapshots = os.environ.get('REFRESH_SNAPSHOTS', 'no').lower()
-    return env_refresh_snapshots in ('true', 'yes', '1')
+    env_refresh_snapshots = os.environ.get("REFRESH_SNAPSHOTS", "no").lower()
+    return env_refresh_snapshots in ("true", "yes", "1")
 
 
 class SnapshotAssertMixin:
@@ -144,7 +150,7 @@ class SnapshotAssertMixin:
         In the case a snapshot does not exist it is saved on first invocation.
         """
 
-        file_name = ''.join([self._testMethodName, ".", extension])
+        file_name = "".join([self._testMethodName, ".", extension])
         file_path = os.path.join(TEST_SNAPSHOTS_DIR, file_name)
 
         if not os.path.isfile(file_path) or _force_refresh_snapshots():
@@ -163,13 +169,18 @@ class SnapshotAssertMixin:
         udiff = difflib.unified_diff(
             _delimited_lines(expected_content),
             _delimited_lines(actual_content),
-            'expected',
-            'actual'
+            "expected",
+            "actual",
         )
 
         display_snapshot_file = os.path.relpath(file_path, TEST_SNAPSHOTS_DIR)
         raise AssertionError(
-            "content did not match snapshot file: %s\n\n%s" % (display_snapshot_file, ''.join(udiff),))
+            "content did not match snapshot file: %s\n\n%s"
+            % (
+                display_snapshot_file,
+                "".join(udiff),
+            )
+        )
 
     def assertSnapshot(self, actual_content, extension=None):
         """Load a snapshot corresponding to the named test and check that what
@@ -190,4 +201,4 @@ class SnapshotAssertMixin:
             actual_content = _html_fragment_only(actual_content)
         else:
             actual_content = _html_content_only(actual_content)
-        self._snapshotsupp_compare_snapshot('html', actual_content)
+        self._snapshotsupp_compare_snapshot("html", actual_content)

--- a/tests/support/suppconst.py
+++ b/tests/support/suppconst.py
@@ -29,11 +29,11 @@ import os
 
 from tests.support._env import MIG_ENV
 
-if MIG_ENV == 'local':
+if MIG_ENV == "local":
     # Use abspath for __file__ on Py2
     _SUPPORT_DIR = os.path.dirname(os.path.abspath(__file__))
-elif MIG_ENV == 'docker':
-    _SUPPORT_DIR = '/usr/src/app/tests/support'
+elif MIG_ENV == "docker":
+    _SUPPORT_DIR = "/usr/src/app/tests/support"
 else:
     raise NotImplementedError("ABORT: unsupported environment: %s" % (MIG_ENV,))
 
@@ -46,7 +46,8 @@ ENVHELP_DIR = os.path.join(MIG_BASE, "envhelp")
 ENVHELP_OUTPUT_DIR = os.path.join(ENVHELP_DIR, "output")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
+
     def print_root_relative(prefix, path):
         print("%s = <root>/%s" % (prefix, os.path.relpath(path, MIG_BASE)))
 

--- a/tests/support/usersupp.py
+++ b/tests/support/usersupp.py
@@ -33,17 +33,13 @@ import os
 import pickle
 
 from mig.shared.base import client_id_dir
-
 from tests.support.fixturesupp import _PreparedFixture
 
+TEST_USER_DN = "/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com"
+OTHER_USER_DN = "/C=DK/ST=NA/L=NA/O=Other Org/OU=NA/CN=Other User/emailAddress=other@example.com"
+NO_SUCH_USER_DN = "/C=DK/ST=NA/L=NA/O=No Such Org/OU=NA/CN=No Such User/emailAddress=nosuchuser@example.com"
 
-TEST_USER_DN = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com'
-OTHER_USER_DN = '/C=DK/ST=NA/L=NA/O=Other Org/OU=NA/CN=Other User/emailAddress=other@example.com'
-NO_SUCH_USER_DN = '/C=DK/ST=NA/L=NA/O=No Such Org/OU=NA/CN=No Such User/emailAddress=nosuchuser@example.com'
-
-_FIXTURE_NAME_BY_USER_DN = {
-    TEST_USER_DN: 'MiG-users.db--example'
-}
+_FIXTURE_NAME_BY_USER_DN = {TEST_USER_DN: "MiG-users.db--example"}
 
 
 class UserAssertMixin:
@@ -61,9 +57,9 @@ class UserAssertMixin:
         conf_user_db_home = testcase.configuration.user_db_home
         os.makedirs(conf_user_db_home, exist_ok=True)
 
-        user_db_file = os.path.join(conf_user_db_home, 'MiG-users.db')
+        user_db_file = os.path.join(conf_user_db_home, "MiG-users.db")
         if os.path.exists(user_db_file):
-            raise AssertionError('a user database file already exists')
+            raise AssertionError("a user database file already exists")
 
         return conf_user_db_home
 
@@ -81,21 +77,19 @@ class UserAssertMixin:
         try:
             fixture_relpath = _FIXTURE_NAME_BY_USER_DN[distinguished_name]
         except KeyError:
-            raise AssertionError(
-                'supplied test user is not known as a fixture')
+            raise AssertionError("supplied test user is not known as a fixture")
 
         # note: this is a non-standard direct use of fixture preparation due
         #       to this being bootstrap code and should not be used elsewhere
-        prepared_fixture = _PreparedFixture.from_relpath(testcase,
-                                                         fixture_relpath,
-                                                         fixture_format='json'
-                                                         )
+        prepared_fixture = _PreparedFixture.from_relpath(
+            testcase, fixture_relpath, fixture_format="json"
+        )
         # write out the user database fixture containing the user
-        prepared_fixture.write_to_dir(conf_user_db_home,
-                                      output_format='pickle')
+        prepared_fixture.write_to_dir(conf_user_db_home, output_format="pickle")
 
         test_user_dir = UserAssertMixin._provision_test_user_dirs(
-            testcase, distinguished_name)
+            testcase, distinguished_name
+        )
 
         return test_user_dir
 
@@ -117,24 +111,29 @@ class UserAssertMixin:
 
         # create the test user settings directory
         conf_user_settings = os.path.normpath(self.configuration.user_settings)
-        test_user_settings_dir = os.path.join(conf_user_settings,
-                                              test_client_dir_name)
+        test_user_settings_dir = os.path.join(
+            conf_user_settings, test_client_dir_name
+        )
         os.makedirs(test_user_settings_dir)
 
         # create an empty user settings file
-        test_user_settings_file = os.path.join(test_user_settings_dir,
-                                               'settings')
-        with open(test_user_settings_file, 'wb') as outfile:
+        test_user_settings_file = os.path.join(
+            test_user_settings_dir, "settings"
+        )
+        with open(test_user_settings_file, "wb") as outfile:
             pickle.dump({}, outfile)
 
         # TODO: clean up old _ensure_dirs_exist calls in tests to create these.
         # create the test user cache, resource pending and mrsl files sub dirs
-        for sub in (self.configuration.user_cache,
-                    self.configuration.resource_pending,
-                    self.configuration.mrsl_files_dir):
+        for sub in (
+            self.configuration.user_cache,
+            self.configuration.resource_pending,
+            self.configuration.mrsl_files_dir,
+        ):
             conf_user_sub = os.path.normpath(sub)
-            test_user_sub_dir = os.path.join(conf_user_sub,
-                                             test_client_dir_name)
+            test_user_sub_dir = os.path.join(
+                conf_user_sub, test_client_dir_name
+            )
             os.makedirs(test_user_sub_dir)
 
         return test_user_dir
@@ -171,11 +170,11 @@ class UserAssertMixin:
         # write out all the users we have assembled by populating an empty
         # fixture with their data but using a known fixture name and thus one
         # suitably hinted so a production format pickle file ends up on-disk
-        prepared_fixture = _PreparedFixture(testcase, 'MiG-users.db--example')
+        prepared_fixture = _PreparedFixture(testcase, "MiG-users.db--example")
         prepared_fixture.fixture_data = users_by_dn
-        prepared_fixture.write_to_dir(conf_user_db_home,
-                                      output_format='pickle')
+        prepared_fixture.write_to_dir(conf_user_db_home, output_format="pickle")
 
         for distinguished_name in distinguished_names:
-            UserAssertMixin._provision_test_user_dirs(testcase,
-                                                      distinguished_name)
+            UserAssertMixin._provision_test_user_dirs(
+                testcase, distinguished_name
+            )

--- a/tests/support/wsgisupp.py
+++ b/tests/support/wsgisupp.py
@@ -27,22 +27,21 @@
 
 """Test support library for WSGI."""
 
-from collections import namedtuple
 import codecs
+from collections import namedtuple
 from io import BytesIO
 from urllib.parse import urlencode, urlparse
 
 from werkzeug.datastructures import MultiDict
 
-
 # named type representing the tuple that is passed to WSGI handlers
-_PreparedWsgi = namedtuple('_PreparedWsgi', ['environ', 'start_response'])
+_PreparedWsgi = namedtuple("_PreparedWsgi", ["environ", "start_response"])
 
 
 class FakeWsgiStartResponse:
     """Glue object that conforms to the same interface as the start_response()
-       in the WSGI specs but records the calls to it such that they can be
-       inspected and, for our purposes, asserted against."""
+    in the WSGI specs but records the calls to it such that they can be
+    inspected and, for our purposes, asserted against."""
 
     def __init__(self):
         self.calls = []
@@ -51,7 +50,9 @@ class FakeWsgiStartResponse:
         self.calls.append((status, headers, exc))
 
 
-def create_wsgi_environ(configuration, wsgi_url, method='GET', query=None, headers=None, form=None):
+def create_wsgi_environ(
+    configuration, wsgi_url, method="GET", query=None, headers=None, form=None
+):
     """Populate the necessary variables that will constitute a valid WSGI
     environment given a URL to which we will make a requests under test and
     various other options that set up the nature of that request."""
@@ -59,21 +60,21 @@ def create_wsgi_environ(configuration, wsgi_url, method='GET', query=None, heade
     parsed_url = urlparse(wsgi_url)
 
     if query:
-        method = 'GET'
+        method = "GET"
 
         request_query = urlencode(query)
         wsgi_input = ()
     elif form:
-        method = 'POST'
-        request_query = ''
+        method = "POST"
+        request_query = ""
 
-        body = urlencode(MultiDict(form)).encode('ascii')
+        body = urlencode(MultiDict(form)).encode("ascii")
 
         headers = headers or {}
-        if not 'Content-Type' in headers:
-            headers['Content-Type'] = 'application/x-www-form-urlencoded'
+        if not "Content-Type" in headers:
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
 
-        headers['Content-Length'] = str(len(body))
+        headers["Content-Length"] = str(len(body))
         wsgi_input = BytesIO(body)
     else:
         request_query = parsed_url.query
@@ -83,26 +84,27 @@ def create_wsgi_environ(configuration, wsgi_url, method='GET', query=None, heade
         """Internal helper to ignore wsgi.errors close method calls"""
 
         def close(self, *ars, **kwargs):
-            """"Simply ignore"""
+            """ "Simply ignore"""
             pass
 
     environ = {}
-    environ['wsgi.errors'] = _errors()
-    environ['wsgi.input'] = wsgi_input
-    environ['wsgi.url_scheme'] = parsed_url.scheme
-    environ['wsgi.version'] = (1, 0)
-    environ['MIG_CONF'] = configuration.config_file
-    environ['HTTP_HOST'] = parsed_url.netloc
-    environ['PATH_INFO'] = parsed_url.path
-    environ['QUERY_STRING'] = request_query
-    environ['REQUEST_METHOD'] = method
-    environ['SCRIPT_URI'] = ''.join(
-        ('http://', environ['HTTP_HOST'], environ['PATH_INFO']))
+    environ["wsgi.errors"] = _errors()
+    environ["wsgi.input"] = wsgi_input
+    environ["wsgi.url_scheme"] = parsed_url.scheme
+    environ["wsgi.version"] = (1, 0)
+    environ["MIG_CONF"] = configuration.config_file
+    environ["HTTP_HOST"] = parsed_url.netloc
+    environ["PATH_INFO"] = parsed_url.path
+    environ["QUERY_STRING"] = request_query
+    environ["REQUEST_METHOD"] = method
+    environ["SCRIPT_URI"] = "".join(
+        ("http://", environ["HTTP_HOST"], environ["PATH_INFO"])
+    )
 
     if headers:
         for k, v in headers.items():
-            header_key = k.replace('-', '_').upper()
-            if header_key.startswith('CONTENT'):
+            header_key = k.replace("-", "_").upper()
+            if header_key.startswith("CONTENT"):
                 # Content-* headers must not be prefixed in WSGI
                 pass
             else:
@@ -119,15 +121,15 @@ def create_wsgi_start_response():
 def prepare_wsgi(configuration, url, **kwargs):
     return _PreparedWsgi(
         create_wsgi_environ(configuration, url, **kwargs),
-        create_wsgi_start_response()
+        create_wsgi_start_response(),
     )
 
 
 def _trigger_and_unpack_result(wsgi_result):
     chunks = list(wsgi_result)
     assert len(chunks) > 0, "invocation returned no output"
-    complete_value = b''.join(chunks)
-    decoded_value = codecs.decode(complete_value, 'utf8')
+    complete_value = b"".join(chunks)
+    decoded_value = codecs.decode(complete_value, "utf8")
     return decoded_value
 
 
@@ -140,7 +142,7 @@ class WsgiAssertMixin:
         content = _trigger_and_unpack_result(wsgi_result)
 
         def called_once(fake):
-            assert hasattr(fake, 'calls')
+            assert hasattr(fake, "calls")
             return len(fake.calls) == 1
 
         fake_start_response = fake_wsgi.start_response


### PR DESCRIPTION
Simply applied formatting rules to `tests/support/` code with a
`make format-python LINT_ENFORCE_DIRS=tests/support`
run.

Should be followed by same to `tests/test*`, `mig/lib` and all proper files in `bin` and `sbin` folders.