### PR TITLE
Address openid session crashes on invalid input

### DIFF
--- a/mig/server/grid_openid.py
+++ b/mig/server/grid_openid.py
@@ -211,7 +211,11 @@ def filter_why_pw(configuration, why):
         text = why.response.encodeToKVForm()
         return strip_password(configuration, text)
     elif isinstance(why, server.ProtocolError):
-        text = why.message
+        # NOTE: UntrustedReturnURL does not have message - fallback to str
+        if hasattr(why, 'message'):
+            text = why.message
+        else:
+            text = str(why)
         return strip_password(configuration, text)
     else:
         # IMPORTANT: do NOT log or show raw why as it may contain credentials
@@ -513,17 +517,17 @@ class ServerHandler(BaseHTTPRequestHandler):
 
         except (KeyboardInterrupt, SystemExit):
             raise
-        except InputException as err:
-            logger.error("Invalid %r input: %s" % (key, err))
-            logger.debug("*** Begin Trace ***\n%s\n*** End trace ***" %
-                         cgitb.text(sys.exc_info(), context=10))
+        except (InputException, ValueError) as err:
+            logger.warning("Invalid %r input: %s" % (key, err))
             err_msg = """<p class='leftpad'>
 Invalid '%s' input: %s
+
+Please contact the site support %s if this persistently happens for valid use.
 </p>
 <p>
 <a href='javascript:history.back(-1);'>Back</a>
-</p>""" % (key, err)
-            self.showErrorPage(err_msg)
+</p>""" % (key, err, configuration.support_email)
+            self.showErrorPage(err_msg, error_code=400)
         except Exception as exc:
             error_ref = time.time()
             logger.error("do_GET with ref %d crashed: %s" % (error_ref, exc))
@@ -583,17 +587,17 @@ Internal error while handling your request - please contact the site support
 
         except (KeyboardInterrupt, SystemExit):
             raise
-        except InputException as err:
-            logger.error("Invalid %r input: %s" % (key, err))
-            logger.debug("*** Begin Trace ***\n%s\n*** End trace ***" %
-                         cgitb.text(sys.exc_info(), context=10))
+        except (InputException, ValueError) as err:
+            logger.warning("Invalid %r input: %s" % (key, err))
             err_msg = """<p class='leftpad'>
 Invalid '%s' input: %s
+
+Please contact the site support %s if this persistently happens for valid use.
 </p>
 <p>
 <a href='javascript:history.back(-1);'>Back</a>
-</p>""" % (key, err)
-            self.showErrorPage(err_msg)
+</p>""" % (key, err, configuration.support_email)
+            self.showErrorPage(err_msg, error_code=400)
         except Exception as exc:
             error_ref = time.time()
             logger.error("do_POST with ref %d crashed: %s" % (error_ref, exc))
@@ -643,6 +647,10 @@ Internal error while handling your request - please contact the site support
         if not request:
             try:
                 request = self.server.openid.decodeRequest(query)
+                if request is None:
+                    # Display text indicating that this is an endpoint.
+                    self.showAboutPage()
+                    return
             except server.ProtocolError as why:
                 # IMPORTANT: NEVER log or show raw why or query with password!
                 safe_query = strip_password(configuration, query)
@@ -815,9 +823,13 @@ inconsistent session state.
         """End-point handler"""
         try:
             request = self.server.openid.decodeRequest(query)
+            if request is None:
+                # Display text indicating that this is an endpoint.
+                self.showAboutPage()
+                return
             # Pass any errors from previous login attempts on for display
             request.error = query.get('err', '')
-        except server.ProtocolError as why:
+        except (ValueError, server.ProtocolError) as why:
             # IMPORTANT: NEVER log or show raw why or query with password!
             safe_query = strip_password(configuration, query)
             safe_why = filter_why_pw(configuration, why)
@@ -834,11 +846,6 @@ inconsistent session state.
 <h3>Error details:</h3>
 <pre>%s</pre>
 ''' % (configuration.short_title, html_escape(safe_why)))
-            return
-
-        if request is None:
-            # Display text indicating that this is an endpoint.
-            self.showAboutPage()
             return
 
         if request.mode in ["checkid_immediate", "checkid_setup"]:

--- a/mig/server/grid_openid.py
+++ b/mig/server/grid_openid.py
@@ -205,8 +205,11 @@ def filter_why_pw(configuration, why):
         text = why.response.encodeToKVForm()
         return strip_password(configuration, text)
     elif isinstance(why, server.ProtocolError):
-        # NOTE: UntrustedReturnURL does not have message - fallback to str
-        if hasattr(why, 'message'):
+        # NOTE: UntrustedReturnURL does not have message but it may have been
+        #       renamed to openid_message - fallback to str
+        if hasattr(why, 'openid_message'):
+            text = why.openid_message
+        elif hasattr(why, 'message'):
             text = why.message
         else:
             text = str(why)

--- a/mig/server/grid_openid.py
+++ b/mig/server/grid_openid.py
@@ -68,7 +68,7 @@ try:
     import http.cookies
     from http.server import HTTPServer, BaseHTTPRequestHandler
     from socketserver import ThreadingMixIn
-except Exception as exc:
+except Exception:
     print("ERROR: failed to init py 2/3 compatibility")
     exit(1)
 
@@ -83,18 +83,12 @@ import types
 
 
 try:
-    import openid
-except ImportError:
-    print("ERROR: the python openid module is required for this daemon")
-    sys.exit(1)
-
-try:
     from openid.consumer import discover
     from openid.extensions import sreg
     from openid.server import server
     from openid.store.filestore import FileOpenIDStore
 except ImportError:
-    print("ERROR: one or more python openid modules missing")
+    print("ERROR: one or more required python openid modules missing")
     sys.exit(1)
 
 try:
@@ -160,7 +154,7 @@ def valid_cert_dir(arg):
 def valid_cert_fields(arg):
     """Make sure only valid cert field names are allowed"""
     valid_job_id(arg, extra_chars=',')
-    if [i for i in arg.split(',') if not i in cert_field_names]:
+    if [i for i in arg.split(',') if i not in cert_field_names]:
         invalid_argument(arg)
 
 
@@ -309,7 +303,7 @@ class OpenIDHTTPServer(HTTPServer):
 
         # Add our own SReg fields to list of valid fields from sreg 1.1 spec
         for (key, val) in cert_field_map.items():
-            if not key in sreg.data_fields:
+            if key not in sreg.data_fields:
                 sreg.data_fields[key] = key.replace('_', ' ').title()
         # print "DEBUG: sreg fields: %s" % sreg.data_fields
         for name in cert_field_names:
@@ -481,7 +475,7 @@ class ServerHandler(BaseHTTPRequestHandler):
             # Resolve retry url, strip password and err
 
             retry_query = {key: val for (key, val) in self.query.items()
-                           if not key in ['password', 'err']}
+                           if key not in ['password', 'err']}
             self.retry_url = "%s?%s" \
                 % (self.parsed_uri[2], urlencode(retry_query))
 
@@ -677,7 +671,7 @@ inconsistent session state.
         # Old IE 8 does not send contents of submit buttons thus only the
         # fields login_as and password are set with the allow requests. We
         # manually add a yes here if so to avoid the else case.
-        if not 'yes' in query and not 'no' in query:
+        if 'yes' not in query and 'no' not in query:
             query['yes'] = 'yes'
 
         if 'yes' in query:
@@ -764,7 +758,6 @@ inconsistent session state.
                 logger.warning("handleAllow rejected login %s" % identity)
                 # logger.debug("full query: %s" % self.query)
                 # logger.debug("full headers: %s" % self.headers)
-                fail_user, fail_pw = self.user, self.password
                 self.clearUser()
                 # Login failed - return to refering page to let user try again
                 retry_url = self.__retry_url_from_cookie()
@@ -1095,7 +1088,7 @@ inconsistent session state.
                 logger.debug("full query: %s" % self.query)
                 self.clearUser()
                 # Login failed - return to refering page to let user try again
-                cookies = self.headers.get('Cookie')
+                # cookies = self.headers.get('Cookie')
                 # print "found cookies: %s" % cookies
                 retry_url = self.__retry_url_from_cookie()
                 if retry_url:

--- a/mig/server/grid_openid.py
+++ b/mig/server/grid_openid.py
@@ -516,11 +516,11 @@ class ServerHandler(BaseHTTPRequestHandler):
             err_msg = """<p class='leftpad'>
 Invalid '%s' input: %s
 
-Please contact the site support %s if this persistently happens for valid use.
+Please contact %s if this persistently happens for valid use.
 </p>
 <p>
 <a href='javascript:history.back(-1);'>Back</a>
-</p>""" % (key, err, configuration.support_email)
+</p>""" % (key, err, html_escape(configuration.support_email))
             self.showErrorPage(err_msg, error_code=400)
         except Exception as exc:
             error_ref = time.time()
@@ -532,12 +532,12 @@ Please contact the site support %s if this persistently happens for valid use.
             filtered_exc = filtered_exc.replace(pw, '*' * len(pw))
             logger.debug("Traceback %s: %s" % (error_ref, filtered_exc))
             err_msg = """<p class='leftpad'>
-Internal error while handling your request - please contact the site support
-%s if this persistently happens and include the error reference %d.
+Internal error while handling your request - please contact %s
+and include the error reference %d if this persistently happens for valid use.
 </p>
 <p>
 <a href='javascript:history.back(-1);'>Back</a>
-</p>""" % (configuration.support_email, error_ref)
+</p>""" % (html_escape(configuration.support_email), error_ref)
             self.showErrorPage(err_msg, error_code=500)
 
     def do_POST(self):
@@ -586,11 +586,11 @@ Internal error while handling your request - please contact the site support
             err_msg = """<p class='leftpad'>
 Invalid '%s' input: %s
 
-Please contact the site support %s if this persistently happens for valid use.
+Please contact %s if this persistently happens for valid use.
 </p>
 <p>
 <a href='javascript:history.back(-1);'>Back</a>
-</p>""" % (key, err, configuration.support_email)
+</p>""" % (key, err, html_escape(configuration.support_email))
             self.showErrorPage(err_msg, error_code=400)
         except Exception as exc:
             error_ref = time.time()
@@ -605,12 +605,12 @@ Please contact the site support %s if this persistently happens for valid use.
             self.send_header('Content-type', 'text/html')
             self.end_headers()
             err_msg = """<p class='leftpad'>
-Internal error while handling your request - please contact the site support
-%s if this persistently happens and include the error reference %d.
+Internal error while handling your request - please contact %s
+and include the error reference %d if this persistently happens for valid use.
 </p>
 <p>
 <a href='javascript:history.back(-1);'>Back</a>
-</p>""" % (configuration.support_email, error_ref)
+</p>""" % (html_escape(configuration.support_email), error_ref)
             # NOTE: socket write expects byte strings
             self.wfile.write(force_utf8(err_msg))
 


### PR DESCRIPTION
Attempt to address #589 with more robust handling of various errors and especially the input validation ones. Show a generic error page and only write log warnings rather than errors in that case.
Check the openid library could in fact decode user query to a request before using the result in order to avoid some NoneType object attribute errors when it couldn't.

Some generic lint fixes and polish of error messages to properly show support email.