### PR TITLE
xmlrpc client and server updates to make examples functional again

### DIFF
--- a/mig/shared/rpcfunctions.py
+++ b/mig/shared/rpcfunctions.py
@@ -36,7 +36,6 @@ import os
 import time
 
 from mig.shared import returnvalues
-from mig.shared.base import force_utf8_rec
 from mig.shared.conf import get_configuration_object
 from mig.shared.httpsclient import extract_client_id
 from mig.shared.objecttypes import get_object_type_info
@@ -51,7 +50,7 @@ def system_method_signature(method_name):
         exec(compile('from mig.shared.functionality.%s import signature'
                      % method_name, '', 'single'))
         signature_string = "%s" % signature()
-    except:
+    except Exception:
         signature_string = 'none, array'
     return signature_string
 
@@ -64,13 +63,13 @@ def system_method_help(method_name):
         exec(compile('from mig.shared.functionality.%s import usage'
                      % method_name, '', 'single'))
         help_string = "%s" % usage()
-    except:
+    except Exception:
         try:
             exec(compile(
                 'from mig.shared.functionality.%s import __doc__ as method_help' %
                 method_name, '', 'single'))
             help_string = "%s" % method_help
-        except:
+        except Exception:
             help_string = ''
     return help_string
 
@@ -133,7 +132,10 @@ def stub(function, user_arguments_dict, environ=None,
         _logger.error("%s main failed: %s" % (function, err))
         import traceback
         _logger.debug("%s main trace:" % traceback.format_exc())
-        return ('Error calling function: %s' % err, returnvalues.ERROR)
+        output_objects.extend([
+            {'object_type': 'error_text', 'text':
+             'Error calling function: %s' % err}])
+        return (output_objects, returnvalues.ERROR)
 
     (val_ret, val_msg) = validate(output_objects)
     if not val_ret:

--- a/mig/shared/rpcfunctions.py
+++ b/mig/shared/rpcfunctions.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # rpcfunctions - Backend for XMLRPC and JSONRPC interfaces over CGI
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -149,716 +149,716 @@ def stub(function, user_arguments_dict):
 def ls(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.ls', user_arguments_dict)
+    return stub('mig.shared.functionality.ls', user_arguments_dict)
 
 
 def tail(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.tail', user_arguments_dict)
+    return stub('mig.shared.functionality.tail', user_arguments_dict)
 
 
 def head(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.head', user_arguments_dict)
+    return stub('mig.shared.functionality.head', user_arguments_dict)
 
 
 def find(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.find', user_arguments_dict)
+    return stub('mig.shared.functionality.find', user_arguments_dict)
 
 
 def grep(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.grep', user_arguments_dict)
+    return stub('mig.shared.functionality.grep', user_arguments_dict)
 
 
 def wc(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.wc', user_arguments_dict)
+    return stub('mig.shared.functionality.wc', user_arguments_dict)
 
 
 def docs(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.docs', user_arguments_dict)
+    return stub('mig.shared.functionality.docs', user_arguments_dict)
 
 
 def spell(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.spell', user_arguments_dict)
+    return stub('mig.shared.functionality.spell', user_arguments_dict)
 
 
 def editfile(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.editfile', user_arguments_dict)
+    return stub('mig.shared.functionality.editfile', user_arguments_dict)
 
 
 def editor(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.editor', user_arguments_dict)
+    return stub('mig.shared.functionality.editor', user_arguments_dict)
 
 
 def rmdir(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmdir', user_arguments_dict)
+    return stub('mig.shared.functionality.rmdir', user_arguments_dict)
 
 
 def zip(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.zip', user_arguments_dict)
+    return stub('mig.shared.functionality.zip', user_arguments_dict)
 
 
 def unzip(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.unzip', user_arguments_dict)
+    return stub('mig.shared.functionality.unzip', user_arguments_dict)
 
 
 def tar(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.tar', user_arguments_dict)
+    return stub('mig.shared.functionality.tar', user_arguments_dict)
 
 
 def untar(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.untar', user_arguments_dict)
+    return stub('mig.shared.functionality.untar', user_arguments_dict)
 
 
 def pack(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.pack', user_arguments_dict)
+    return stub('mig.shared.functionality.pack', user_arguments_dict)
 
 
 def unpack(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.unpack', user_arguments_dict)
+    return stub('mig.shared.functionality.unpack', user_arguments_dict)
 
 
 def chksum(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.chksum', user_arguments_dict)
+    return stub('mig.shared.functionality.chksum', user_arguments_dict)
 
 
 def mv(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.mv', user_arguments_dict)
+    return stub('mig.shared.functionality.mv', user_arguments_dict)
 
 
 def mkdir(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.mkdir', user_arguments_dict)
+    return stub('mig.shared.functionality.mkdir', user_arguments_dict)
 
 
 def touch(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.touch', user_arguments_dict)
+    return stub('mig.shared.functionality.touch', user_arguments_dict)
 
 
 def cat(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cat', user_arguments_dict)
+    return stub('mig.shared.functionality.cat', user_arguments_dict)
 
 
 def cp(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cp', user_arguments_dict)
+    return stub('mig.shared.functionality.cp', user_arguments_dict)
 
 
 def stat(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.statpath', user_arguments_dict)
+    return stub('mig.shared.functionality.statpath', user_arguments_dict)
 
 
 def truncate(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.truncate', user_arguments_dict)
+    return stub('mig.shared.functionality.truncate', user_arguments_dict)
 
 
 def rm(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rm', user_arguments_dict)
+    return stub('mig.shared.functionality.rm', user_arguments_dict)
 
 
 def mrslview(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.mrslview', user_arguments_dict)
+    return stub('mig.shared.functionality.mrslview', user_arguments_dict)
 
 
 def jobstatus(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.jobstatus', user_arguments_dict)
+    return stub('mig.shared.functionality.jobstatus', user_arguments_dict)
 
 
 def jobaction(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.jobaction', user_arguments_dict)
+    return stub('mig.shared.functionality.jobaction', user_arguments_dict)
 
 
 def jobfeasible(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.jobfeasible', user_arguments_dict)
+    return stub('mig.shared.functionality.jobfeasible', user_arguments_dict)
 
 
 def jobschedule(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.jobschedule', user_arguments_dict)
+    return stub('mig.shared.functionality.jobschedule', user_arguments_dict)
 
 
 def canceljob(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.canceljob', user_arguments_dict)
+    return stub('mig.shared.functionality.canceljob', user_arguments_dict)
 
 
 def submit(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.submit', user_arguments_dict)
+    return stub('mig.shared.functionality.submit', user_arguments_dict)
 
 
 def resubmit(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.resubmit', user_arguments_dict)
+    return stub('mig.shared.functionality.resubmit', user_arguments_dict)
 
 
 def jobobjsubmit(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.jobobjsubmit',
+    return stub('mig.shared.functionality.jobobjsubmit',
                 user_arguments_dict)
 
 
 def getjobobj(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.getjobobj', user_arguments_dict)
+    return stub('mig.shared.functionality.getjobobj', user_arguments_dict)
 
 
 def scripts(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.scripts', user_arguments_dict)
+    return stub('mig.shared.functionality.scripts', user_arguments_dict)
 
 
 def liveio(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.liveio', user_arguments_dict)
+    return stub('mig.shared.functionality.liveio', user_arguments_dict)
 
 
 def mqueue(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.mqueue', user_arguments_dict)
+    return stub('mig.shared.functionality.mqueue', user_arguments_dict)
 
 
 def datatransfer(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.datatransfer', user_arguments_dict)
+    return stub('mig.shared.functionality.datatransfer', user_arguments_dict)
 
 
 def sharelink(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.sharelink', user_arguments_dict)
+    return stub('mig.shared.functionality.sharelink', user_arguments_dict)
 
 
 def crontab(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.crontab', user_arguments_dict)
+    return stub('mig.shared.functionality.crontab', user_arguments_dict)
 
 
 def lscrontab(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.lscrontab', user_arguments_dict)
+    return stub('mig.shared.functionality.lscrontab', user_arguments_dict)
 
 
 def addcrontab(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.addcrontab', user_arguments_dict)
+    return stub('mig.shared.functionality.addcrontab', user_arguments_dict)
 
 
 def rmcrontab(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmcrontab', user_arguments_dict)
+    return stub('mig.shared.functionality.rmcrontab', user_arguments_dict)
 
 
 def textarea(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.textarea', user_arguments_dict)
+    return stub('mig.shared.functionality.textarea', user_arguments_dict)
 
 
 def updateresconfig(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.updateresconfig',
+    return stub('mig.shared.functionality.updateresconfig',
                 user_arguments_dict)
 
 
 def addresowner(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.addresowner', user_arguments_dict)
+    return stub('mig.shared.functionality.addresowner', user_arguments_dict)
 
 
 def rmresowner(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmresowner', user_arguments_dict)
+    return stub('mig.shared.functionality.rmresowner', user_arguments_dict)
 
 
 def lsresowners(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.lsresowners', user_arguments_dict)
+    return stub('mig.shared.functionality.lsresowners', user_arguments_dict)
 
 
 def delres(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.delres', user_arguments_dict)
+    return stub('mig.shared.functionality.delres', user_arguments_dict)
 
 
 def restartfe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.restartfe', user_arguments_dict)
+    return stub('mig.shared.functionality.restartfe', user_arguments_dict)
 
 
 def startfe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.startfe', user_arguments_dict)
+    return stub('mig.shared.functionality.startfe', user_arguments_dict)
 
 
 def statusfe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.statusfe', user_arguments_dict)
+    return stub('mig.shared.functionality.statusfe', user_arguments_dict)
 
 
 def stopfe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.stopfe', user_arguments_dict)
+    return stub('mig.shared.functionality.stopfe', user_arguments_dict)
 
 
 def cleanfe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cleanfe', user_arguments_dict)
+    return stub('mig.shared.functionality.cleanfe', user_arguments_dict)
 
 
 def restartallexes(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.restartallexes', user_arguments_dict)
+    return stub('mig.shared.functionality.restartallexes', user_arguments_dict)
 
 
 def restartexe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.restartexe', user_arguments_dict)
+    return stub('mig.shared.functionality.restartexe', user_arguments_dict)
 
 
 def startallexes(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.startallexes', user_arguments_dict)
+    return stub('mig.shared.functionality.startallexes', user_arguments_dict)
 
 
 def startexe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.startexe', user_arguments_dict)
+    return stub('mig.shared.functionality.startexe', user_arguments_dict)
 
 
 def statusallexes(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.statusallexes', user_arguments_dict)
+    return stub('mig.shared.functionality.statusallexes', user_arguments_dict)
 
 
 def statusexe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.statusexe', user_arguments_dict)
+    return stub('mig.shared.functionality.statusexe', user_arguments_dict)
 
 
 def stopallexes(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.stopallexes', user_arguments_dict)
+    return stub('mig.shared.functionality.stopallexes', user_arguments_dict)
 
 
 def stopexe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.stopexe', user_arguments_dict)
+    return stub('mig.shared.functionality.stopexe', user_arguments_dict)
 
 
 def cleanallexes(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cleanallexes', user_arguments_dict)
+    return stub('mig.shared.functionality.cleanallexes', user_arguments_dict)
 
 
 def cleanexe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cleanexe', user_arguments_dict)
+    return stub('mig.shared.functionality.cleanexe', user_arguments_dict)
 
 
 def restartallstores(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.restartallstores', user_arguments_dict)
+    return stub('mig.shared.functionality.restartallstores', user_arguments_dict)
 
 
 def restartstore(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.restartstore', user_arguments_dict)
+    return stub('mig.shared.functionality.restartstore', user_arguments_dict)
 
 
 def startallstores(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.startallstores', user_arguments_dict)
+    return stub('mig.shared.functionality.startallstores', user_arguments_dict)
 
 
 def startstore(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.startstore', user_arguments_dict)
+    return stub('mig.shared.functionality.startstore', user_arguments_dict)
 
 
 def statusallstores(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.statusallstores', user_arguments_dict)
+    return stub('mig.shared.functionality.statusallstores', user_arguments_dict)
 
 
 def statusstore(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.statusstore', user_arguments_dict)
+    return stub('mig.shared.functionality.statusstore', user_arguments_dict)
 
 
 def stopallstores(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.stopallstores', user_arguments_dict)
+    return stub('mig.shared.functionality.stopallstores', user_arguments_dict)
 
 
 def stopstore(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.stopstore', user_arguments_dict)
+    return stub('mig.shared.functionality.stopstore', user_arguments_dict)
 
 
 def cleanallstores(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cleanallstores', user_arguments_dict)
+    return stub('mig.shared.functionality.cleanallstores', user_arguments_dict)
 
 
 def cleanstore(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cleanstore', user_arguments_dict)
+    return stub('mig.shared.functionality.cleanstore', user_arguments_dict)
 
 
 def vgridmemberrequest(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.vgridmemberrequest',
+    return stub('mig.shared.functionality.vgridmemberrequest',
                 user_arguments_dict)
 
 
 def vgridmemberrequestaction(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.vgridmemberrequestaction',
+    return stub('mig.shared.functionality.vgridmemberrequestaction',
                 user_arguments_dict)
 
 
 def createvgrid(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.createvgrid', user_arguments_dict)
+    return stub('mig.shared.functionality.createvgrid', user_arguments_dict)
 
 
 def rmvgridowner(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmvgridowner',
+    return stub('mig.shared.functionality.rmvgridowner',
                 user_arguments_dict)
 
 
 def rmvgridmember(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmvgridmember',
+    return stub('mig.shared.functionality.rmvgridmember',
                 user_arguments_dict)
 
 
 def addvgridmember(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.addvgridmember',
+    return stub('mig.shared.functionality.addvgridmember',
                 user_arguments_dict)
 
 
 def addvgridowner(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.addvgridowner',
+    return stub('mig.shared.functionality.addvgridowner',
                 user_arguments_dict)
 
 
 def lsvgridowners(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.lsvgridowners',
+    return stub('mig.shared.functionality.lsvgridowners',
                 user_arguments_dict)
 
 
 def lsvgridmembers(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.lsvgridmembers',
+    return stub('mig.shared.functionality.lsvgridmembers',
                 user_arguments_dict)
 
 
 def lsvgridres(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.lsvgridres', user_arguments_dict)
+    return stub('mig.shared.functionality.lsvgridres', user_arguments_dict)
 
 
 def addvgridres(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.addvgridres', user_arguments_dict)
+    return stub('mig.shared.functionality.addvgridres', user_arguments_dict)
 
 
 def rmvgridres(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmvgridres', user_arguments_dict)
+    return stub('mig.shared.functionality.rmvgridres', user_arguments_dict)
 
 
 def lsvgridtriggers(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.lsvgridtriggers', user_arguments_dict)
+    return stub('mig.shared.functionality.lsvgridtriggers', user_arguments_dict)
 
 
 def addvgridtrigger(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.addvgridtrigger', user_arguments_dict)
+    return stub('mig.shared.functionality.addvgridtrigger', user_arguments_dict)
 
 
 def rmvgridtrigger(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmvgridtrigger', user_arguments_dict)
+    return stub('mig.shared.functionality.rmvgridtrigger', user_arguments_dict)
 
 
 def vgridworkflows(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.vgridworkflows', user_arguments_dict)
+    return stub('mig.shared.functionality.vgridworkflows', user_arguments_dict)
 
 
 def vgridsettings(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.vgridsettings', user_arguments_dict)
+    return stub('mig.shared.functionality.vgridsettings', user_arguments_dict)
 
 
 def viewvgrid(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.viewvgrid', user_arguments_dict)
+    return stub('mig.shared.functionality.viewvgrid', user_arguments_dict)
 
 
 def showvgridmonitor(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.showvgridmonitor',
+    return stub('mig.shared.functionality.showvgridmonitor',
                 user_arguments_dict)
 
 
 def showvgridprivatefile(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.showvgridprivatefile',
+    return stub('mig.shared.functionality.showvgridprivatefile',
                 user_arguments_dict)
 
 
 def adminvgrid(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.adminvgrid', user_arguments_dict)
+    return stub('mig.shared.functionality.adminvgrid', user_arguments_dict)
 
 
 def createre(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.createre', user_arguments_dict)
+    return stub('mig.shared.functionality.createre', user_arguments_dict)
 
 
 def deletere(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.deletere', user_arguments_dict)
+    return stub('mig.shared.functionality.deletere', user_arguments_dict)
 
 
 def showre(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.showre', user_arguments_dict)
+    return stub('mig.shared.functionality.showre', user_arguments_dict)
 
 
 def redb(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.redb', user_arguments_dict)
+    return stub('mig.shared.functionality.redb', user_arguments_dict)
 
 
 def adminre(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.adminre', user_arguments_dict)
+    return stub('mig.shared.functionality.adminre', user_arguments_dict)
 
 
 def createbackup(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.createbackup', user_arguments_dict)
+    return stub('mig.shared.functionality.createbackup', user_arguments_dict)
 
 
 def deletebackup(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.deletebackup', user_arguments_dict)
+    return stub('mig.shared.functionality.deletebackup', user_arguments_dict)
 
 
 def showbackup(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.showbackup', user_arguments_dict)
+    return stub('mig.shared.functionality.showbackup', user_arguments_dict)
 
 
 def createfreeze(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.createfreeze', user_arguments_dict)
+    return stub('mig.shared.functionality.createfreeze', user_arguments_dict)
 
 
 def deletefreeze(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.deletefreeze', user_arguments_dict)
+    return stub('mig.shared.functionality.deletefreeze', user_arguments_dict)
 
 
 def adminfreeze(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.adminfreeze', user_arguments_dict)
+    return stub('mig.shared.functionality.adminfreeze', user_arguments_dict)
 
 
 def showfreeze(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.showfreeze', user_arguments_dict)
+    return stub('mig.shared.functionality.showfreeze', user_arguments_dict)
 
 
 def freezedb(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.freezedb', user_arguments_dict)
+    return stub('mig.shared.functionality.freezedb', user_arguments_dict)
 
 
 def settings(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.settings', user_arguments_dict)
+    return stub('mig.shared.functionality.settings', user_arguments_dict)
 
 
 def settingsaction(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.settingsaction', user_arguments_dict)
+    return stub('mig.shared.functionality.settingsaction', user_arguments_dict)
 
 
 def sendrequest(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.sendrequest', user_arguments_dict)
+    return stub('mig.shared.functionality.sendrequest', user_arguments_dict)
 
 
 def sendrequestaction(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.sendrequestaction', user_arguments_dict)
+    return stub('mig.shared.functionality.sendrequestaction', user_arguments_dict)
 
 
 def pubvgridprojects(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.pubvgridprojects',
+    return stub('mig.shared.functionality.pubvgridprojects',
                 user_arguments_dict)
 
 
 def people(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.people', user_arguments_dict)
+    return stub('mig.shared.functionality.people', user_arguments_dict)
 
 
 def signature(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.signature', user_arguments_dict)
+    return stub('mig.shared.functionality.signature', user_arguments_dict)
 
 
 # IMPORTANT: List of all functions to expose both in XMLRPC and JSONRPC

--- a/mig/shared/rpcfunctions.py
+++ b/mig/shared/rpcfunctions.py
@@ -31,6 +31,7 @@ methods through platform-independent Remote Procedure Calls.
 
 from __future__ import absolute_import
 
+import importlib
 import os
 import time
 
@@ -39,7 +40,7 @@ from mig.shared.base import force_utf8_rec
 from mig.shared.conf import get_configuration_object
 from mig.shared.httpsclient import extract_client_id
 from mig.shared.objecttypes import get_object_type_info
-from mig.shared.output import validate
+from mig.shared.output import validate, kwargs_for_functionality, dummy_main
 
 
 def system_method_signature(method_name):
@@ -80,27 +81,32 @@ def object_type_info(object_type):
     return get_object_type_info(object_type)
 
 
-def stub(function, user_arguments_dict):
+def stub(function, user_arguments_dict, environ=None,
+         _import_module=importlib.import_module):
     """Run backend function with supplied arguments"""
 
     before_time = time.time()
 
-    environ = os.environ
+    if environ is None:
+        environ = os.environ
     configuration = get_configuration_object()
     _logger = configuration.logger
 
     # get ID of user currently logged in
 
-    main = id
     client_id = extract_client_id(configuration, environ)
     output_objects = []
+    main = dummy_main
     _logger.debug("import main for function: %s" % function)
     try:
-        exec('from %s import main' % function)
+        # NOTE: dynamic module loading to find corresponding main function
+        module_handle = _import_module(function)
+        main = module_handle.main
     except Exception as err:
+        _logger.warning("import main for %s failed: %s" % (function, err))
         output_objects.extend([
             {'object_type': 'error_text', 'text':
-             'Could not import module! %s: %s' % (function, err)}])
+             'Could not load %r backend!' % function}])
         return (output_objects, returnvalues.SYSTEM_ERROR)
 
     # Save actual functionality backend for initialize_main_variables to expose
@@ -117,11 +123,13 @@ def stub(function, user_arguments_dict):
 
     _logger.debug("run %s.main(%s)" % (function, user_arguments_dict))
     try:
-
-        # TODO: add environ arg support to all main backends and use here
+        main_kwargs = kwargs_for_functionality(main,
+                                               configuration=configuration,
+                                               environ=environ)
 
         (output_objects, (ret_code, ret_msg)) = main(client_id,
-                                                     user_arguments_dict)
+                                                     user_arguments_dict,
+                                                     **main_kwargs)
     except Exception as err:
         _logger.error("%s main failed: %s" % (function, err))
         import traceback

--- a/mig/shared/rpcfunctions.py
+++ b/mig/shared/rpcfunctions.py
@@ -117,9 +117,8 @@ def stub(function, user_arguments_dict, environ=None,
              'user_arguments_dict is not a dictionary/struct type!'}])
         return (output_objects, returnvalues.INVALID_ARGUMENT)
 
-    # NOTE: Force to UTF-8 - JSONRPC dict is unicode while XMLRPC is UTF-8
-    if user_arguments_dict:
-        user_arguments_dict = force_utf8_rec(user_arguments_dict)
+    # TODO: Force to unicode now with py3?
+    # NOTE: on py2 JSONRPC dict was unicode and XMLRPC UTF-8 so we forced utf8
 
     _logger.debug("run %s.main(%s)" % (function, user_arguments_dict))
     try:

--- a/mig/user/xmlrpcbackup.py
+++ b/mig/user/xmlrpcbackup.py
@@ -34,7 +34,7 @@ from future import standard_library
 standard_library.install_aliases()
 import os
 import sys
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qs
 
 from xmlrpcsslclient import xmlrpcgetserver, read_user_conf
 

--- a/mig/user/xmlrpcbackup.py
+++ b/mig/user/xmlrpcbackup.py
@@ -36,7 +36,7 @@ import os
 import sys
 from urllib.parse import urlparse, parse_qs
 
-from xmlrpcsslclient import xmlrpcgetserver, read_user_conf
+from mig.user.xmlrpcsslclient import xmlrpcgetserver, read_user_conf
 
 
 if '__main__' == __name__:

--- a/mig/user/xmlrpcbackup.py
+++ b/mig/user/xmlrpcbackup.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # xmlrpcsbackup - backup files with XMLRPC and user certificate
-# Copyright (C) 2003-2012  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,169 +20,23 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
 
-"""XMLRPC backuphelper with support for HTTPS using client certificates"""
+"""XMLRPC backup helper with support for HTTPS using client certificates"""
 
 from __future__ import print_function
 
 from future import standard_library
 standard_library.install_aliases()
-from builtins import range
-import http.client
 import os
-import ssl
 import sys
-import time
-import xmlrpc.client
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse
 
-
-def read_user_conf():
-    """Read and parse 'KEY VAL' formatted user conf file"""
-    user_conf = {}
-    conf_path = os.path.expanduser(os.path.join('~', '.mig',
-                                                'miguser.conf'))
-    if not os.path.exists(conf_path):
-        print('mig user configuration not found, %s does not exist'
-              % conf_path)
-        sys.exit(1)
-
-    needed_settings = ['migserver', 'certfile', 'keyfile']
-    optional_settings = ['password', 'cacertfile', 'connect_timeout']
-    expand_paths = ['certfile', 'keyfile', 'cacertfile']
-    try:
-        conf_fd = open(conf_path, 'r')
-        for thisline in conf_fd:
-
-            # ignore comments
-
-            comment_start = thisline.find('#')
-            if comment_start > -1:
-                thisline = thisline[:comment_start]
-            thisline = thisline.rstrip()
-            if not thisline:
-                continue
-            parts = thisline.split(None)
-            (key, val) = parts[:2]
-            (key, val) = key.strip(), val.strip()
-            if not key in needed_settings + optional_settings:
-                continue
-            if key in expand_paths:
-                val = os.path.expandvars(os.path.expanduser(val))
-            user_conf[key] = val
-        conf_fd.close()
-    except IOError as exc:
-        print('Could not read miguser conf: %s, %s' % (conf_path, exc))
-        sys.exit(1)
-    for needed_key in needed_settings:
-        if needed_key not in user_conf:
-            print('Needed setting %s not found in %s' % (needed_key,
-                                                         conf_path))
-            sys.exit(1)
-    return user_conf
-
-
-class SafeCertTransport(xmlrpc.client.SafeTransport):
-
-    """HTTPS with user certificate"""
-
-    host = None
-    conf = {}
-
-    def __init__(self, use_datetime=0, conf={}):
-        """For backward compatibility with python < 2.7 . Call parent
-        constructor and check if the new _connection attribute is set.
-        If not we must switch to compatibility mode where the request
-        method needs to be overridden.
-        """
-        xmlrpc.client.SafeTransport.__init__(self, use_datetime)
-        self.conf.update(conf)
-
-        if not hasattr(self, '_connection'):
-            # print "DEBUG: switch to compat mode"
-            self._connection = (None, None)
-            self.request = self._compat_request
-
-    def _compat_request(self, host, handler, request_body, verbose=0):
-        """For backward compatibility with < 2.7 : must override connection
-        calls to fit older httplib API.
-
-        Reuse existing connections to avoid repeating passphrase every single
-        time.
-        """
-
-        # issue XML-RPC request
-
-        if not self.host:
-            self.host = self.make_connection(host)
-        if verbose:
-            self.host.set_debuglevel(1)
-
-        self.send_request(self.host, handler, request_body)
-
-        self.send_user_agent(self.host)
-        self.send_content(self.host, request_body)
-
-        resp = self.host.getresponse()
-        errcode = resp.status
-        errmsg = resp.reason
-        headers = resp.getheaders()
-
-        if errcode != 200:
-            raise xmlrpc.client.ProtocolError(host + handler, errcode,
-                                          errmsg, headers)
-
-        self.verbose = verbose
-
-        try:
-            sock = self.host._conn.sock
-        except AttributeError:
-            sock = None
-
-        return self._parse_response(resp, sock)
-
-    def make_connection(self, host):
-        """Override default HTTPS Transport to include key/cert support. This
-        is the python 2.7 version which changed internals and broke
-        backward compatibility. We use the exact same structure and do the
-        plumbing for backward compatibility in the constructor instead.
-
-        Reuses connections if possible to support HTTP/1.1 keep-alive.
-
-        Finally allows non-interactive use with password from conf file.
-        """
-        if self._connection and host == self._connection[0]:
-            return self._connection[1]
-        try:
-            HTTPS = http.client.HTTPSConnection
-        except AttributeError:
-            raise NotImplementedError(
-                "your version of httplib doesn't support HTTPS")
-
-        key_pw = self.conf.get('password', None)
-        cacert = None
-        if conf['cacertfile'] and conf['cacertfile'] != 'AUTO':
-            cacert = self.conf['cacertfile']
-        ssl_ctx = ssl.create_default_context(cafile=cacert)
-        ssl_ctx.load_cert_chain(self.conf['certfile'],
-                                keyfile=self.conf['keyfile'], password=key_pw)
-        self._connection = host, HTTPS(self.conf['host'],
-                                       port=self.conf['port'], context=ssl_ctx)
-        return self._connection[1]
-
-
-def xmlrpcgetserver(conf):
-    cert_transport = SafeCertTransport(conf=conf)
-    server = xmlrpc.client.ServerProxy('https://%(host)s:%(port)s%(script)s' %
-                                   conf, transport=cert_transport,
-                                   # encoding='utf-8',
-                                   # verbose=True
-                                   )
-    return server
+from xmlrpcsslclient import xmlrpcgetserver, read_user_conf
 
 
 if '__main__' == __name__:

--- a/mig/user/xmlrpcbackup.py
+++ b/mig/user/xmlrpcbackup.py
@@ -67,8 +67,7 @@ if '__main__' == __name__:
     host_port = url_tuple[1].split(':', 1)
     if len(host_port) < 2:
         host_port.append('443')
-    host_port[1] = int(host_port[1])
-    conf['host'], conf['port'] = host_port
+    conf['host'], conf['port'] = host_port[0], int(host_port[1])
 
     print('''Running XMLRPC backup script against %(migserver)s with user certificate
 from %(certfile)s , key from %(keyfile)s and

--- a/mig/user/xmlrpcbackuplocation.py
+++ b/mig/user/xmlrpcbackuplocation.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # xmlrpcsbackuplocation - show freeze backup location with XMLRPC and user certificate
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -32,156 +33,11 @@ from __future__ import print_function
 
 from future import standard_library
 standard_library.install_aliases()
-import http.client
 import os
-import ssl
 import sys
-import time
-import xmlrpc.client
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse
 
-
-def read_user_conf():
-    """Read and parse 'KEY VAL' formatted user conf file"""
-    user_conf = {}
-    conf_path = os.path.expanduser(os.path.join('~', '.mig',
-                                                'miguser.conf'))
-    if not os.path.exists(conf_path):
-        print('mig user configuration not found, %s does not exist'
-              % conf_path)
-        sys.exit(1)
-
-    needed_settings = ['migserver', 'certfile', 'keyfile']
-    optional_settings = ['password', 'cacertfile', 'connect_timeout']
-    expand_paths = ['certfile', 'keyfile', 'cacertfile']
-    try:
-        conf_fd = open(conf_path, 'r')
-        for thisline in conf_fd:
-
-            # ignore comments
-
-            comment_start = thisline.find('#')
-            if comment_start > -1:
-                thisline = thisline[:comment_start]
-            thisline = thisline.rstrip()
-            if not thisline:
-                continue
-            parts = thisline.split(None)
-            (key, val) = parts[:2]
-            (key, val) = key.strip(), val.strip()
-            if not key in needed_settings + optional_settings:
-                continue
-            if key in expand_paths:
-                val = os.path.expandvars(os.path.expanduser(val))
-            user_conf[key] = val
-        conf_fd.close()
-    except IOError as exc:
-        print('Could not read miguser conf: %s, %s' % (conf_path, exc))
-        sys.exit(1)
-    for needed_key in needed_settings:
-        if needed_key not in user_conf:
-            print('Needed setting %s not found in %s' % (needed_key,
-                                                         conf_path))
-            sys.exit(1)
-    return user_conf
-
-
-class SafeCertTransport(xmlrpc.client.SafeTransport):
-    """HTTPS with user certificate"""
-
-    host = None
-    conf = {}
-
-    def __init__(self, use_datetime=0, conf={}):
-        """For backward compatibility with python < 2.7 . Call parent
-        constructor and check if the new _connection attribute is set.
-        If not we must switch to compatibility mode where the request
-        method needs to be overridden.
-        """
-        xmlrpc.client.SafeTransport.__init__(self, use_datetime)
-        self.conf.update(conf)
-
-        if not hasattr(self, '_connection'):
-            # print "DEBUG: switch to compat mode"
-            self._connection = (None, None)
-            self.request = self._compat_request
-
-    def _compat_request(self, host, handler, request_body, verbose=0):
-        """For backward compatibility with < 2.7 : must override connection
-        calls to fit older httplib API.
-
-        Reuse existing connections to avoid repeating passphrase every single
-        time.
-        """
-
-        # issue XML-RPC request
-
-        if not self.host:
-            self.host = self.make_connection(host)
-        if verbose:
-            self.host.set_debuglevel(1)
-
-        self.send_request(self.host, handler, request_body)
-
-        self.send_user_agent(self.host)
-        self.send_content(self.host, request_body)
-
-        resp = self.host.getresponse()
-        errcode = resp.status
-        errmsg = resp.reason
-        headers = resp.getheaders()
-
-        if errcode != 200:
-            raise xmlrpc.client.ProtocolError(host + handler, errcode,
-                                          errmsg, headers)
-
-        self.verbose = verbose
-
-        try:
-            sock = self.host._conn.sock
-        except AttributeError:
-            sock = None
-
-        return self._parse_response(resp, sock)
-
-    def make_connection(self, host):
-        """Override default HTTPS Transport to include key/cert support. This
-        is the python 2.7 version which changed internals and broke
-        backward compatibility. We use the exact same structure and do the
-        plumbing for backward compatibility in the constructor instead.
-
-        Reuses connections if possible to support HTTP/1.1 keep-alive.
-
-        Finally allows non-interactive use with password from conf file.
-        """
-        if self._connection and host == self._connection[0]:
-            return self._connection[1]
-        try:
-            HTTPS = http.client.HTTPSConnection
-        except AttributeError:
-            raise NotImplementedError(
-                "your version of httplib doesn't support HTTPS")
-
-        key_pw = self.conf.get('password', None)
-        cacert = None
-        if conf['cacertfile'] and conf['cacertfile'] != 'AUTO':
-            cacert = self.conf['cacertfile']
-        ssl_ctx = ssl.create_default_context(cafile=cacert)
-        ssl_ctx.load_cert_chain(self.conf['certfile'],
-                                keyfile=self.conf['keyfile'], password=key_pw)
-        self._connection = host, HTTPS(self.conf['host'],
-                                       port=self.conf['port'], context=ssl_ctx)
-        return self._connection[1]
-
-
-def xmlrpcgetserver(conf):
-    cert_transport = SafeCertTransport(conf=conf)
-    server = xmlrpc.client.ServerProxy('https://%(host)s:%(port)s%(script)s' %
-                                   conf, transport=cert_transport,
-                                   # encoding='utf-8',
-                                   # verbose=True
-                                   )
-    return server
+from xmlrpcsslclient import xmlrpcgetserver, read_user_conf
 
 
 if '__main__' == __name__:

--- a/mig/user/xmlrpcbackuplocation.py
+++ b/mig/user/xmlrpcbackuplocation.py
@@ -67,8 +67,7 @@ if '__main__' == __name__:
     host_port = url_tuple[1].split(':', 1)
     if len(host_port) < 2:
         host_port.append('443')
-    host_port[1] = int(host_port[1])
-    conf['host'], conf['port'] = host_port
+    conf['host'], conf['port'] = host_port[0], int(host_port[1])
 
     print('''Running XMLRPC freeze backup location script against %(migserver)s
 with user certificate from %(certfile)s , key from %(keyfile)s and
@@ -78,7 +77,7 @@ key/certificate passphrase before you can continue.
     server = xmlrpcgetserver(conf)
 
     # Switch to display inline docs for showfreeze call
-    #show_docs = ['showfreeze']
+    # show_docs = ['showfreeze']
     show_docs = []
     for method in show_docs:
         print('%s() signature: %s' % (method,

--- a/mig/user/xmlrpcbackuplocation.py
+++ b/mig/user/xmlrpcbackuplocation.py
@@ -37,7 +37,7 @@ import os
 import sys
 from urllib.parse import urlparse
 
-from xmlrpcsslclient import xmlrpcgetserver, read_user_conf
+from mig.user.xmlrpcsslclient import xmlrpcgetserver, read_user_conf
 
 
 if '__main__' == __name__:

--- a/mig/user/xmlrpccron.py
+++ b/mig/user/xmlrpccron.py
@@ -67,8 +67,7 @@ if '__main__' == __name__:
     host_port = url_tuple[1].split(':', 1)
     if len(host_port) < 2:
         host_port.append('443')
-    host_port[1] = int(host_port[1])
-    conf['host'], conf['port'] = host_port
+    conf['host'], conf['port'] = host_port[0], int(host_port[1])
 
     print('''Running XMLRPC cron script against %(migserver)s with user certificate
 from %(certfile)s , key from %(keyfile)s and
@@ -131,8 +130,8 @@ key/certificate passphrase before you can continue.
     # for i in xrange(len(path_list)):
     #    create_args['freeze_copy_%d' % i] = [path_list[i]]
 
-    #(outlist, retval) = server.crontab(crontab_args)
-    #(returnval, returnmsg) = retval
+    # (outlist, retval) = server.crontab(crontab_args)
+    # (returnval, returnmsg) = retval
     # if returnval != 0:
     #    print 'Error %s:%s ' % (returnval, returnmsg)
     #    sys.exit(1)
@@ -148,7 +147,7 @@ key/certificate passphrase before you can continue.
 
     # Dummy jobs for testing add and remove
     cron_jobs = ['49 13 * * * touch add-cron-job-test.txt']
-    at_jobs = ['2019-12-24 12:13:14 touch Christmas-test-+SCHEDYEAR+.txt']
+    at_jobs = ['2042-12-24 12:13:14 touch Christmas-test-+SCHEDYEAR+.txt']
 
     print('Running addcrontab method:')
     addcrontab_args = {'crontab': cron_jobs, 'atjobs': at_jobs,

--- a/mig/user/xmlrpccron.py
+++ b/mig/user/xmlrpccron.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # xmlrpcscron - cron manipulation with XMLRPC and user certificate
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -31,157 +32,11 @@ from __future__ import print_function
 
 from future import standard_library
 standard_library.install_aliases()
-import http.client
 import os
-import ssl
 import sys
-import time
-import xmlrpc.client
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse
 
-
-def read_user_conf():
-    """Read and parse 'KEY VAL' formatted user conf file"""
-    user_conf = {}
-    conf_path = os.path.expanduser(os.path.join('~', '.mig',
-                                                'miguser.conf'))
-    if not os.path.exists(conf_path):
-        print('mig user configuration not found, %s does not exist'
-              % conf_path)
-        sys.exit(1)
-
-    needed_settings = ['migserver', 'certfile', 'keyfile']
-    optional_settings = ['password', 'cacertfile', 'connect_timeout']
-    expand_paths = ['certfile', 'keyfile', 'cacertfile']
-    try:
-        conf_fd = open(conf_path, 'r')
-        for thisline in conf_fd:
-
-            # ignore comments
-
-            comment_start = thisline.find('#')
-            if comment_start > -1:
-                thisline = thisline[:comment_start]
-            thisline = thisline.rstrip()
-            if not thisline:
-                continue
-            parts = thisline.split(None)
-            (key, val) = parts[:2]
-            (key, val) = key.strip(), val.strip()
-            if not key in needed_settings + optional_settings:
-                continue
-            if key in expand_paths:
-                val = os.path.expandvars(os.path.expanduser(val))
-            user_conf[key] = val
-        conf_fd.close()
-    except IOError as exc:
-        print('Could not read miguser conf: %s, %s' % (conf_path, exc))
-        sys.exit(1)
-    for needed_key in needed_settings:
-        if needed_key not in user_conf:
-            print('Needed setting %s not found in %s' % (needed_key,
-                                                         conf_path))
-            sys.exit(1)
-    return user_conf
-
-
-class SafeCertTransport(xmlrpc.client.SafeTransport):
-
-    """HTTPS with user certificate"""
-
-    host = None
-    conf = {}
-
-    def __init__(self, use_datetime=0, conf={}):
-        """For backward compatibility with python < 2.7 . Call parent
-        constructor and check if the new _connection attribute is set.
-        If not we must switch to compatibility mode where the request
-        method needs to be overridden.
-        """
-        xmlrpc.client.SafeTransport.__init__(self, use_datetime)
-        self.conf.update(conf)
-
-        if not hasattr(self, '_connection'):
-            # print "DEBUG: switch to compat mode"
-            self._connection = (None, None)
-            self.request = self._compat_request
-
-    def _compat_request(self, host, handler, request_body, verbose=0):
-        """For backward compatibility with < 2.7 : must override connection
-        calls to fit older httplib API.
-
-        Reuse existing connections to avoid repeating passphrase every single
-        time.
-        """
-
-        # issue XML-RPC request
-
-        if not self.host:
-            self.host = self.make_connection(host)
-        if verbose:
-            self.host.set_debuglevel(1)
-
-        self.send_request(self.host, handler, request_body)
-
-        self.send_user_agent(self.host)
-        self.send_content(self.host, request_body)
-
-        resp = self.host.getresponse()
-        errcode = resp.status
-        errmsg = resp.reason
-        headers = resp.getheaders()
-
-        if errcode != 200:
-            raise xmlrpc.client.ProtocolError(host + handler, errcode,
-                                          errmsg, headers)
-
-        self.verbose = verbose
-
-        try:
-            sock = self.host._conn.sock
-        except AttributeError:
-            sock = None
-
-        return self._parse_response(resp, sock)
-
-    def make_connection(self, host):
-        """Override default HTTPS Transport to include key/cert support. This
-        is the python 2.7 version which changed internals and broke
-        backward compatibility. We use the exact same structure and do the
-        plumbing for backward compatibility in the constructor instead.
-
-        Reuses connections if possible to support HTTP/1.1 keep-alive.
-
-        Finally allows non-interactive use with password from conf file.
-        """
-        if self._connection and host == self._connection[0]:
-            return self._connection[1]
-        try:
-            HTTPS = http.client.HTTPSConnection
-        except AttributeError:
-            raise NotImplementedError(
-                "your version of httplib doesn't support HTTPS")
-
-        key_pw = self.conf.get('password', None)
-        cacert = None
-        if conf['cacertfile'] and conf['cacertfile'] != 'AUTO':
-            cacert = self.conf['cacertfile']
-        ssl_ctx = ssl.create_default_context(cafile=cacert)
-        ssl_ctx.load_cert_chain(self.conf['certfile'],
-                                keyfile=self.conf['keyfile'], password=key_pw)
-        self._connection = host, HTTPS(self.conf['host'],
-                                       port=self.conf['port'], context=ssl_ctx)
-        return self._connection[1]
-
-
-def xmlrpcgetserver(conf):
-    cert_transport = SafeCertTransport(conf=conf)
-    server = xmlrpc.client.ServerProxy('https://%(host)s:%(port)s%(script)s' %
-                                   conf, transport=cert_transport,
-                                   # encoding='utf-8',
-                                   # verbose=True
-                                   )
-    return server
+from xmlrpcsslclient import xmlrpcgetserver, read_user_conf
 
 
 if '__main__' == __name__:
@@ -316,7 +171,7 @@ key/certificate passphrase before you can continue.
     (outlist, retval) = server.lscrontab(lscrontab_args)
     (returnval, returnmsg) = retval
     if returnval != 0:
-        print('Error %s:%s ' % (returnval, returnmsg))
+        print('Error %s:%s' % (returnval, returnmsg))
         print(outlist)
         sys.exit(1)
 

--- a/mig/user/xmlrpccron.py
+++ b/mig/user/xmlrpccron.py
@@ -36,7 +36,7 @@ import os
 import sys
 from urllib.parse import urlparse
 
-from xmlrpcsslclient import xmlrpcgetserver, read_user_conf
+from mig.user.xmlrpcsslclient import xmlrpcgetserver, read_user_conf
 
 
 if '__main__' == __name__:

--- a/mig/user/xmlrpcsslclient.py
+++ b/mig/user/xmlrpcsslclient.py
@@ -219,8 +219,7 @@ if '__main__' == __name__:
     host_port = url_tuple[1].split(':', 1)
     if len(host_port) < 2:
         host_port.append('443')
-    host_port[1] = int(host_port[1])
-    conf['host'], conf['port'] = host_port
+    conf['host'], conf['port'] = host_port[0], int(host_port[1])
 
     print('''Testing XMLRPC client against %(migserver)s with user certificate
 from %(certfile)s , key from %(keyfile)s and

--- a/mig/user/xmlrpcsslclient.py
+++ b/mig/user/xmlrpcsslclient.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # xmlrpcsslclient - XMLRPC client with HTTPS user certificate support
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -92,14 +93,18 @@ class SafeCertTransport(xmlrpc.client.SafeTransport):
     host = None
     conf = {}
 
-    def __init__(self, use_datetime=0, conf={}):
+    def __init__(self, use_datetime=False, use_builtin_types=False, headers=(),
+                 context=None, conf=None):
         """For backward compatibility with python < 2.7 . Call parent
         constructor and check if the new _connection attribute is set.
         If not we must switch to compatibility mode where the request
         method needs to be overridden.
         """
-        xmlrpc.client.SafeTransport.__init__(self, use_datetime)
-        self.conf.update(conf)
+        xmlrpc.client.SafeTransport.__init__(self, use_datetime=use_datetime,
+                                             use_builtin_types=use_builtin_types,
+                                             headers=headers, context=context)
+        if conf:
+            self.conf.update(conf)
 
         if not hasattr(self, '_connection'):
             # print "DEBUG: switch to compat mode"
@@ -133,7 +138,7 @@ class SafeCertTransport(xmlrpc.client.SafeTransport):
 
         if errcode != 200:
             raise xmlrpc.client.ProtocolError(host + handler, errcode,
-                                          errmsg, headers)
+                                              errmsg, headers)
 
         self.verbose = verbose
 
@@ -164,7 +169,7 @@ class SafeCertTransport(xmlrpc.client.SafeTransport):
 
         key_pw = self.conf.get('password', None)
         cacert = None
-        if conf['cacertfile'] and conf['cacertfile'] != 'AUTO':
+        if self.conf['cacertfile'] and self.conf['cacertfile'] != 'AUTO':
             cacert = self.conf['cacertfile']
         ssl_ctx = ssl.create_default_context(cafile=cacert)
         ssl_ctx.load_cert_chain(self.conf['certfile'],
@@ -176,11 +181,14 @@ class SafeCertTransport(xmlrpc.client.SafeTransport):
 
 def xmlrpcgetserver(conf):
     cert_transport = SafeCertTransport(conf=conf)
+    # TODO: extract ssl_ctx from cert_transport?
+    ssl_ctx = None
     server = xmlrpc.client.ServerProxy('https://%(host)s:%(port)s%(script)s' %
-                                   conf, transport=cert_transport,
-                                   # encoding='utf-8',
-                                   # verbose=True
-                                   )
+                                       conf, transport=cert_transport,
+                                       # encoding='utf-8',
+                                       # verbose=True
+                                       context=ssl_ctx
+                                       )
     return server
 
 

--- a/mig/user/xmlrpcsslclient.py
+++ b/mig/user/xmlrpcsslclient.py
@@ -399,6 +399,7 @@ vgrid=Generic
     print("cat as text file")
     (inlist, retval) = server.cat({"path": path_list, "flags": "v"})
     print('cat status: %s' % retval)
+    (returnval, returnmsg) = retval
     if returnval != 0:
         print('Error %s:%s' % (returnval, returnmsg))
     for ele in inlist:
@@ -411,6 +412,7 @@ vgrid=Generic
     try:
         (inlist, retval) = server.cat({"path": path_list, "flags": "vb"})
         print('cat status: %s' % retval)
+        (returnval, returnmsg) = retval
         if returnval != 0:
             print('Error %s:%s' % (returnval, returnmsg))
         for ele in inlist:

--- a/mig/user/xmlrpcsslclient.py
+++ b/mig/user/xmlrpcsslclient.py
@@ -111,10 +111,11 @@ class SafeCertTransport(xmlrpc.client.SafeTransport):
     def __init_ssl_ctx(self):
         """Helper to set up an ssl_ctx with client key and cert plus optional
         reading of the key passphrase from conf to enable non-interactive use.
+        Uses any configured CA certificate, too, but defaults to system ones.
         """
         key_pw = self.conf.get('password', None)
         cacert = None
-        if self.conf['cacertfile'] and self.conf['cacertfile'] != 'AUTO':
+        if self.conf.get('cacertfile', None) and self.conf['cacertfile'] != 'AUTO':
             cacert = self.conf['cacertfile']
         ssl_ctx = ssl.create_default_context(cafile=cacert)
         ssl_ctx.load_cert_chain(self.conf['certfile'],

--- a/mig/user/xmlrpcsslclient.py
+++ b/mig/user/xmlrpcsslclient.py
@@ -268,7 +268,10 @@ key/certificate passphrase before you can continue.
         {'job_id': job_id_list, 'flags': 'vs', 'max_jobs': '5'})
     (returnval, returnmsg) = retval
     if returnval != 0:
-        print('Error %s:%s ' % (returnval, returnmsg))
+        print('Error %s:%s' % (returnval, returnmsg))
+        for ele in inlist:
+            if ele['object_type'] == 'error_text':
+                print(ele['text'])
 
     for ele in inlist:
         if ele['object_type'] == 'job_list':
@@ -431,13 +434,29 @@ vgrid=Generic
     # (inlist, retval) = server.editfile({"path":["/m2"], "submitjob":["True"], "editarea":["%s" % mrsl]})
     # (inlist, retval) = server.canceljob({"job_id":["%s" % sys.argv[1]]})
 
+    print("cat as text file")
+    (inlist, retval) = server.cat({"path": path_list, "flags": "v"})
+    print('cat status: %s' % retval)
+    if returnval != 0:
+        print('Error %s:%s' % (returnval, returnmsg))
+    for ele in inlist:
+        if ele['object_type'] == 'error_text':
+            print(ele['text'])
+        elif 'file_output' == ele['object_type']:
+            print(''.join(ele['lines']))
+
+    print("cat as binary file")
     try:
-        print("cat as binary file")
         (inlist, retval) = server.cat({"path": path_list, "flags": "vb"})
-        for entry in inlist:
-            if 'file_output' == entry['object_type']:
+        print('cat status: %s' % retval)
+        if returnval != 0:
+            print('Error %s:%s' % (returnval, returnmsg))
+        for ele in inlist:
+            if ele['object_type'] == 'error_text':
+                print(ele['text'])
+            elif 'file_output' == ele['object_type']:
                 # NOTE: xmlrpc wraps in object with contents in data attribute
-                print(''.join([i.data for i in entry['lines']]))
+                print([i.data for i in ele['lines']])
     except Exception as exc:
         print("Error: could not cat as binary file: %s" % exc)
 
@@ -461,9 +480,14 @@ ANY
         "jobname_0_0_0": "abc", "fileupload_0_0_0filename": "newfile.txt",
         "submitmrsl_0": ["OFF"], "fileupload_0_0_0": ["%s" % mrsl]
     })
-    print(inlist)
-
-    # print "DEBUG: %s\n%s" % (inlist, retval)
+    print('upload status: %s' % retval)
+    # print(inlist)
+    for entry in inlist:
+        if 'text' == entry['object_type']:
+            print('upload status: %s' % entry['text'])
+        elif 'fileuploadobjs' == entry['object_type']:
+            for obj in entry["fileuploadobjs"]:
+                print('uploaded %(name)s of %(size)db' % obj)
 
     print('submit job description in %s' % mrsl_path)
     (inlist, retval) = server.submit({'path': [mrsl_path]})

--- a/mig/user/xmlrpcsslclient.py
+++ b/mig/user/xmlrpcsslclient.py
@@ -69,7 +69,7 @@ def read_user_conf():
             parts = thisline.split(None)
             (key, val) = parts[:2]
             (key, val) = key.strip(), val.strip()
-            if not key in needed_settings + optional_settings:
+            if key not in needed_settings + optional_settings:
                 continue
             if key in expand_paths:
                 val = os.path.expandvars(os.path.expanduser(val))
@@ -87,7 +87,6 @@ def read_user_conf():
 
 
 class SafeCertTransport(xmlrpc.client.SafeTransport):
-
     """HTTPS with user certificate"""
 
     host = None
@@ -95,65 +94,15 @@ class SafeCertTransport(xmlrpc.client.SafeTransport):
 
     def __init__(self, use_datetime=False, use_builtin_types=False, headers=(),
                  context=None, conf=None):
-        """For backward compatibility with python < 2.7 . Call parent
-        constructor and check if the new _connection attribute is set.
-        If not we must switch to compatibility mode where the request
-        method needs to be overridden.
-        """
+        """Simply wrap parent constructor with our own conf added"""
         xmlrpc.client.SafeTransport.__init__(self, use_datetime=use_datetime,
                                              use_builtin_types=use_builtin_types,
                                              headers=headers, context=context)
         if conf:
             self.conf.update(conf)
 
-        if not hasattr(self, '_connection'):
-            # print "DEBUG: switch to compat mode"
-            self._connection = (None, None)
-            self.request = self._compat_request
-
-    def _compat_request(self, host, handler, request_body, verbose=0):
-        """For backward compatibility with < 2.7 : must override connection
-        calls to fit older httplib API.
-
-        Reuse existing connections to avoid repeating passphrase every single
-        time.
-        """
-
-        # issue XML-RPC request
-
-        if not self.host:
-            self.host = self.make_connection(host)
-        if verbose:
-            self.host.set_debuglevel(1)
-
-        self.send_request(self.host, handler, request_body)
-
-        self.send_user_agent(self.host)
-        self.send_content(self.host, request_body)
-
-        resp = self.host.getresponse()
-        errcode = resp.status
-        errmsg = resp.reason
-        headers = resp.getheaders()
-
-        if errcode != 200:
-            raise xmlrpc.client.ProtocolError(host + handler, errcode,
-                                              errmsg, headers)
-
-        self.verbose = verbose
-
-        try:
-            sock = self.host._conn.sock
-        except AttributeError:
-            sock = None
-
-        return self._parse_response(resp, sock)
-
     def make_connection(self, host):
-        """Override default HTTPS Transport to include key/cert support. This
-        is the python 2.7 version which changed internals and broke
-        backward compatibility. We use the exact same structure and do the
-        plumbing for backward compatibility in the constructor instead.
+        """Override default HTTPS Transport to include key/cert support.
 
         Reuses connections if possible to support HTTP/1.1 keep-alive.
 

--- a/mig/user/xmlrpcsslclient.py
+++ b/mig/user/xmlrpcsslclient.py
@@ -91,6 +91,7 @@ class SafeCertTransport(xmlrpc.client.SafeTransport):
 
     host = None
     ssl_ctx = None
+    _connection = None
     conf = {}
 
     def __init__(self, use_datetime=False, use_builtin_types=False, headers=(),

--- a/mig/user/xmlrpcsslclient.py
+++ b/mig/user/xmlrpcsslclient.py
@@ -115,7 +115,8 @@ class SafeCertTransport(xmlrpc.client.SafeTransport):
         """
         key_pw = self.conf.get('password', None)
         cacert = None
-        if self.conf.get('cacertfile', None) and self.conf['cacertfile'] != 'AUTO':
+        if self.conf.get('cacertfile', None) \
+                and self.conf['cacertfile'] != 'AUTO':
             cacert = self.conf['cacertfile']
         ssl_ctx = ssl.create_default_context(cafile=cacert)
         ssl_ctx.load_cert_chain(self.conf['certfile'],

--- a/mig/user/xmlrpcsslclient.py
+++ b/mig/user/xmlrpcsslclient.py
@@ -90,16 +90,36 @@ class SafeCertTransport(xmlrpc.client.SafeTransport):
     """HTTPS with user certificate"""
 
     host = None
+    ssl_ctx = None
     conf = {}
 
     def __init__(self, use_datetime=False, use_builtin_types=False, headers=(),
                  context=None, conf=None):
-        """Simply wrap parent constructor with our own conf added"""
+        """Wrap parent constructor with our conf and optional ssl_ctx init"""
         xmlrpc.client.SafeTransport.__init__(self, use_datetime=use_datetime,
                                              use_builtin_types=use_builtin_types,
                                              headers=headers, context=context)
         if conf:
             self.conf.update(conf)
+
+        if context is None:
+            self.ssl_ctx = self.__init_ssl_ctx()
+        else:
+            self.ssl_ctx = context
+
+    def __init_ssl_ctx(self):
+        """Helper to set up an ssl_ctx with client key and cert plus optional
+        reading of the key passphrase from conf to enable non-interactive use.
+        """
+        key_pw = self.conf.get('password', None)
+        cacert = None
+        if self.conf['cacertfile'] and self.conf['cacertfile'] != 'AUTO':
+            cacert = self.conf['cacertfile']
+        ssl_ctx = ssl.create_default_context(cafile=cacert)
+        ssl_ctx.load_cert_chain(self.conf['certfile'],
+                                keyfile=self.conf['keyfile'],
+                                password=key_pw)
+        return ssl_ctx
 
     def make_connection(self, host):
         """Override default HTTPS Transport to include key/cert support.
@@ -110,33 +130,26 @@ class SafeCertTransport(xmlrpc.client.SafeTransport):
         """
         if self._connection and host == self._connection[0]:
             return self._connection[1]
+
         try:
             HTTPS = http.client.HTTPSConnection
         except AttributeError:
             raise NotImplementedError(
                 "your version of httplib doesn't support HTTPS")
 
-        key_pw = self.conf.get('password', None)
-        cacert = None
-        if self.conf['cacertfile'] and self.conf['cacertfile'] != 'AUTO':
-            cacert = self.conf['cacertfile']
-        ssl_ctx = ssl.create_default_context(cafile=cacert)
-        ssl_ctx.load_cert_chain(self.conf['certfile'],
-                                keyfile=self.conf['keyfile'], password=key_pw)
         self._connection = host, HTTPS(self.conf['host'],
-                                       port=self.conf['port'], context=ssl_ctx)
+                                       port=self.conf['port'],
+                                       context=self.ssl_ctx)
         return self._connection[1]
 
 
 def xmlrpcgetserver(conf):
     cert_transport = SafeCertTransport(conf=conf)
-    # TODO: extract ssl_ctx from cert_transport?
-    ssl_ctx = None
     server = xmlrpc.client.ServerProxy('https://%(host)s:%(port)s%(script)s' %
                                        conf, transport=cert_transport,
                                        # encoding='utf-8',
                                        # verbose=True
-                                       context=ssl_ctx
+                                       context=cert_transport.ssl_ctx
                                        )
     return server
 

--- a/mig/user/xmlrpctriggers.py
+++ b/mig/user/xmlrpctriggers.py
@@ -64,8 +64,7 @@ if '__main__' == __name__:
     host_port = url_tuple[1].split(':', 1)
     if len(host_port) < 2:
         host_port.append('443')
-    host_port[1] = int(host_port[1])
-    conf['host'], conf['port'] = host_port
+    conf['host'], conf['port'] = host_port[0], int(host_port[1])
 
     print('''Testing XMLRPC triggers against %(migserver)s with user certificate
 from %(certfile)s , key from %(keyfile)s and

--- a/mig/user/xmlrpctriggers.py
+++ b/mig/user/xmlrpctriggers.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # xmlrpcsslclient - XMLRPC client with HTTPS user certificate support
-# Copyright (C) 2003-2015  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,12 +20,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
 
-"""XMLRPC client with support for HTTPS using client certificates"""
+"""XMLRPC trigger helper with support for HTTPS using client certificates"""
+
 from __future__ import print_function
 
 from future import standard_library
@@ -65,16 +67,20 @@ if '__main__' == __name__:
     host_port[1] = int(host_port[1])
     conf['host'], conf['port'] = host_port
 
-    print('Testing XMLRPC client over HTTPS with user certificates for triggers')
-    print('You may get prompted for your MiG key/certificate passphrase before you can continue')
+    print('''Testing XMLRPC triggers against %(migserver)s with user certificate
+from %(certfile)s , key from %(keyfile)s and
+CA certificate %(cacertfile)s . You may get prompted for your MiG
+key/certificate passphrase before you can continue.
+    ''' % conf)
     server = xmlrpcgetserver(conf)
 
     methods = server.system.listMethods()
     print('supported remote methods:\n%s' % '\n'.join(methods))
     print()
-    print('submit() signature: %s'\
-        % server.system.methodSignature('submit'))
-    print('the signature is a tuple of output object type and a list of expected/default input values')
+    print('submit() signature: %s'
+          % server.system.methodSignature('submit'))
+    print('the signature is a tuple of output object type and a list of ')
+    print('expected/default input values')
     print('submit() help: %s' % server.system.methodHelp('submit'))
     print('please note that help is not yet available for all methods')
     print()

--- a/mig/user/xmlrpctriggers.py
+++ b/mig/user/xmlrpctriggers.py
@@ -36,7 +36,7 @@ import os
 import sys
 from urllib.parse import urlparse
 
-from xmlrpcsslclient import xmlrpcgetserver, read_user_conf
+from mig.user.xmlrpcsslclient import xmlrpcgetserver, read_user_conf
 
 
 if '__main__' == __name__:


### PR DESCRIPTION
Sync xmlrpc examples to use single shared setup from original example. Update to current xmlrpc API there.

Address some backend stub import issues (#594) when attempting to run the xmlrpc client examples.
