### PR TITLE
Migrate jsonrpclib to maintained fork and sync interfaces to current API

### DIFF
--- a/README
+++ b/README
@@ -82,7 +82,7 @@ The software needed for the above optional components is mainly provided by:
 -Python OpenSSL module (https://pypi.python.org/pypi/pyOpenSSL/)
 -Python WSGI WebDAV module (http://wsgidav.readthedocs.org/)
 -Python watchdog module (https://pypi.python.org/pypi/watchdog/)
--Python jsonrpclib module (https://pypi.python.org/pypi/jsonrpclib/)
+-Python forked jsonrpclib module (https://pypi.org/project/jsonrpclib-pelix)
 -Python irclib module (https://pypi.python.org/pypi/python-irclib/)
 -Python requests module (https://pypi.python.org/pypi/requests/)
 -Python cracklib module (https://pypi.org/project/cracklib/)

--- a/mig/cgi-bin/jsonrpcinterface.py
+++ b/mig/cgi-bin/jsonrpcinterface.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # jsonrpcinterface - Provides the entire JSONRPC interface over CGI
-# Copyright (C) 2003-2017  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -28,26 +28,21 @@
 """JSONRPC interface to expose all XGI methods through platform-independent
 JSON Remote Procedure Calls.
 
-Requires the jsonrpclib module from https://pypi.python.org/pypi/jsonrpclib
+Requires the jsonrpclib module from https://pypi.org/project/jsonrpclib-pelix
 to be installed. That is easily done with e.g.
-pip install jsonrpclib
-or
-apt install python-jsonrpclib
-or
-yum install python-jsonrpclib
-depending on the platform.
+pip install jsonrpclib-pelix
 """
+
 from __future__ import absolute_import
 
 from future import standard_library
 standard_library.install_aliases()
 from jsonrpclib.SimpleJSONRPCServer import CGIJSONRPCRequestHandler
-# NOTE: See below for explanation of this XMLRPC dependency 
+# NOTE: See below for explanation of this XMLRPC dependency
 from xmlrpc.server import CGIXMLRPCRequestHandler
 
 from mig.shared.rpcfunctions import expose_functions, system_method_signature, \
-       system_method_help
-
+    system_method_help
 
 
 class MiGCGIJSONRPCRequestHandler(CGIJSONRPCRequestHandler,
@@ -72,7 +67,7 @@ class MiGCGIJSONRPCRequestHandler(CGIJSONRPCRequestHandler,
 def serverMethodSignatures(server):
     """List all methods as well as signatures"""
     methods = CGIJSONRPCRequestHandler.system_listMethods(server)
-    methods_and_signatures = [(method, server.system_methodSignature(method)) \
+    methods_and_signatures = [(method, server.system_methodSignature(method))
                               for method in methods]
     return methods_and_signatures
 

--- a/mig/shared/functionality/docs.py
+++ b/mig/shared/functionality/docs.py
@@ -540,12 +540,12 @@ openstack client module from:"""})
                                'text': 'Python OpenStack Client (Apache 2.0 license)'})
 
     output_objects.append({'object_type': 'text', 'text': """The optional
-JSONRPC interface is delivered with the jsonrpclib module:"""})
+JSONRPC interface is delivered with the Pelix-forked jsonrpclib module:"""})
     output_objects.append({'object_type': 'link',
-                           'destination': 'https://pypi.python.org/pypi/jsonrpclib',
+                           'destination': 'https://pypi.org/project/jsonrpclib-pelix',
                            'class': 'urllink iconspace',
-                           'title': 'Python JSONRPC Module at Python Package Index',
-                           'text': 'Python JSONRPClib Module (Apache 2.0 license)'})
+                           'title': 'Python JSONRPC Pelix Module fork at Python Package Index',
+                           'text': 'Python JSONRPClib Pelix Module (Apache 2.0 license)'})
 
     output_objects.append({'object_type': 'text', 'text': """
 The optional country code validation support in certificate and OpenID account

--- a/mig/shared/handlers.py
+++ b/mig/shared/handlers.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # handlers - back end handler helpers
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -84,7 +84,7 @@ def check_enable_csrf(configuration, accepted_dict, environ=None):
     # We look for curl and xmlrpc/jsonrpc first in user agent to match e.g.
     # * curl/7.38.0
     # * xmlrpclib.py/1.0.1 (by www.pythonware.com)
-    # * jsonrpclib/0.1 (Python X.Y.Z)
+    # * jsonrpclib/1.0 (Python X.Y.Z)
     agent = environ.get('HTTP_USER_AGENT', 'UNKNOWN')
     if agent.lower().startswith('curl') or agent.lower().startswith('xmlrpc') \
             or agent.lower().startswith('python-xmlrpc') or \

--- a/mig/shared/rpcfunctions.py
+++ b/mig/shared/rpcfunctions.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # rpcfunctions - Backend for XMLRPC and JSONRPC interfaces over CGI
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -31,6 +31,7 @@ methods through platform-independent Remote Procedure Calls.
 
 from __future__ import absolute_import
 
+import importlib
 import os
 import time
 
@@ -39,7 +40,7 @@ from mig.shared.base import force_utf8_rec
 from mig.shared.conf import get_configuration_object
 from mig.shared.httpsclient import extract_client_id
 from mig.shared.objecttypes import get_object_type_info
-from mig.shared.output import validate
+from mig.shared.output import validate, kwargs_for_functionality, dummy_main
 
 
 def system_method_signature(method_name):
@@ -80,27 +81,32 @@ def object_type_info(object_type):
     return get_object_type_info(object_type)
 
 
-def stub(function, user_arguments_dict):
+def stub(function, user_arguments_dict, environ=None,
+         _import_module=importlib.import_module):
     """Run backend function with supplied arguments"""
 
     before_time = time.time()
 
-    environ = os.environ
+    if environ is None:
+        environ = os.environ
     configuration = get_configuration_object()
     _logger = configuration.logger
 
     # get ID of user currently logged in
 
-    main = id
     client_id = extract_client_id(configuration, environ)
     output_objects = []
+    main = dummy_main
     _logger.debug("import main for function: %s" % function)
     try:
-        exec('from %s import main' % function)
+        # NOTE: dynamic module loading to find corresponding main function
+        module_handle = _import_module(function)
+        main = module_handle.main
     except Exception as err:
+        _logger.warning("import main for %s failed: %s" % (function, err))
         output_objects.extend([
             {'object_type': 'error_text', 'text':
-             'Could not import module! %s: %s' % (function, err)}])
+             'Could not load %r backend!' % function}])
         return (output_objects, returnvalues.SYSTEM_ERROR)
 
     # Save actual functionality backend for initialize_main_variables to expose
@@ -111,17 +117,18 @@ def stub(function, user_arguments_dict):
              'user_arguments_dict is not a dictionary/struct type!'}])
         return (output_objects, returnvalues.INVALID_ARGUMENT)
 
-    # NOTE: Force to UTF-8 - JSONRPC dict is unicode while XMLRPC is UTF-8
-    if user_arguments_dict:
-        user_arguments_dict = force_utf8_rec(user_arguments_dict)
+    # TODO: Force to unicode now with py3?
+    # NOTE: on py2 JSONRPC dict was unicode and XMLRPC UTF-8 so we forced utf8
 
     _logger.debug("run %s.main(%s)" % (function, user_arguments_dict))
     try:
-
-        # TODO: add environ arg support to all main backends and use here
+        main_kwargs = kwargs_for_functionality(main,
+                                               configuration=configuration,
+                                               environ=environ)
 
         (output_objects, (ret_code, ret_msg)) = main(client_id,
-                                                     user_arguments_dict)
+                                                     user_arguments_dict,
+                                                     **main_kwargs)
     except Exception as err:
         _logger.error("%s main failed: %s" % (function, err))
         import traceback
@@ -149,716 +156,716 @@ def stub(function, user_arguments_dict):
 def ls(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.ls', user_arguments_dict)
+    return stub('mig.shared.functionality.ls', user_arguments_dict)
 
 
 def tail(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.tail', user_arguments_dict)
+    return stub('mig.shared.functionality.tail', user_arguments_dict)
 
 
 def head(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.head', user_arguments_dict)
+    return stub('mig.shared.functionality.head', user_arguments_dict)
 
 
 def find(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.find', user_arguments_dict)
+    return stub('mig.shared.functionality.find', user_arguments_dict)
 
 
 def grep(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.grep', user_arguments_dict)
+    return stub('mig.shared.functionality.grep', user_arguments_dict)
 
 
 def wc(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.wc', user_arguments_dict)
+    return stub('mig.shared.functionality.wc', user_arguments_dict)
 
 
 def docs(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.docs', user_arguments_dict)
+    return stub('mig.shared.functionality.docs', user_arguments_dict)
 
 
 def spell(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.spell', user_arguments_dict)
+    return stub('mig.shared.functionality.spell', user_arguments_dict)
 
 
 def editfile(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.editfile', user_arguments_dict)
+    return stub('mig.shared.functionality.editfile', user_arguments_dict)
 
 
 def editor(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.editor', user_arguments_dict)
+    return stub('mig.shared.functionality.editor', user_arguments_dict)
 
 
 def rmdir(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmdir', user_arguments_dict)
+    return stub('mig.shared.functionality.rmdir', user_arguments_dict)
 
 
 def zip(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.zip', user_arguments_dict)
+    return stub('mig.shared.functionality.zip', user_arguments_dict)
 
 
 def unzip(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.unzip', user_arguments_dict)
+    return stub('mig.shared.functionality.unzip', user_arguments_dict)
 
 
 def tar(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.tar', user_arguments_dict)
+    return stub('mig.shared.functionality.tar', user_arguments_dict)
 
 
 def untar(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.untar', user_arguments_dict)
+    return stub('mig.shared.functionality.untar', user_arguments_dict)
 
 
 def pack(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.pack', user_arguments_dict)
+    return stub('mig.shared.functionality.pack', user_arguments_dict)
 
 
 def unpack(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.unpack', user_arguments_dict)
+    return stub('mig.shared.functionality.unpack', user_arguments_dict)
 
 
 def chksum(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.chksum', user_arguments_dict)
+    return stub('mig.shared.functionality.chksum', user_arguments_dict)
 
 
 def mv(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.mv', user_arguments_dict)
+    return stub('mig.shared.functionality.mv', user_arguments_dict)
 
 
 def mkdir(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.mkdir', user_arguments_dict)
+    return stub('mig.shared.functionality.mkdir', user_arguments_dict)
 
 
 def touch(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.touch', user_arguments_dict)
+    return stub('mig.shared.functionality.touch', user_arguments_dict)
 
 
 def cat(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cat', user_arguments_dict)
+    return stub('mig.shared.functionality.cat', user_arguments_dict)
 
 
 def cp(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cp', user_arguments_dict)
+    return stub('mig.shared.functionality.cp', user_arguments_dict)
 
 
 def stat(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.statpath', user_arguments_dict)
+    return stub('mig.shared.functionality.statpath', user_arguments_dict)
 
 
 def truncate(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.truncate', user_arguments_dict)
+    return stub('mig.shared.functionality.truncate', user_arguments_dict)
 
 
 def rm(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rm', user_arguments_dict)
+    return stub('mig.shared.functionality.rm', user_arguments_dict)
 
 
 def mrslview(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.mrslview', user_arguments_dict)
+    return stub('mig.shared.functionality.mrslview', user_arguments_dict)
 
 
 def jobstatus(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.jobstatus', user_arguments_dict)
+    return stub('mig.shared.functionality.jobstatus', user_arguments_dict)
 
 
 def jobaction(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.jobaction', user_arguments_dict)
+    return stub('mig.shared.functionality.jobaction', user_arguments_dict)
 
 
 def jobfeasible(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.jobfeasible', user_arguments_dict)
+    return stub('mig.shared.functionality.jobfeasible', user_arguments_dict)
 
 
 def jobschedule(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.jobschedule', user_arguments_dict)
+    return stub('mig.shared.functionality.jobschedule', user_arguments_dict)
 
 
 def canceljob(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.canceljob', user_arguments_dict)
+    return stub('mig.shared.functionality.canceljob', user_arguments_dict)
 
 
 def submit(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.submit', user_arguments_dict)
+    return stub('mig.shared.functionality.submit', user_arguments_dict)
 
 
 def resubmit(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.resubmit', user_arguments_dict)
+    return stub('mig.shared.functionality.resubmit', user_arguments_dict)
 
 
 def jobobjsubmit(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.jobobjsubmit',
+    return stub('mig.shared.functionality.jobobjsubmit',
                 user_arguments_dict)
 
 
 def getjobobj(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.getjobobj', user_arguments_dict)
+    return stub('mig.shared.functionality.getjobobj', user_arguments_dict)
 
 
 def scripts(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.scripts', user_arguments_dict)
+    return stub('mig.shared.functionality.scripts', user_arguments_dict)
 
 
 def liveio(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.liveio', user_arguments_dict)
+    return stub('mig.shared.functionality.liveio', user_arguments_dict)
 
 
 def mqueue(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.mqueue', user_arguments_dict)
+    return stub('mig.shared.functionality.mqueue', user_arguments_dict)
 
 
 def datatransfer(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.datatransfer', user_arguments_dict)
+    return stub('mig.shared.functionality.datatransfer', user_arguments_dict)
 
 
 def sharelink(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.sharelink', user_arguments_dict)
+    return stub('mig.shared.functionality.sharelink', user_arguments_dict)
 
 
 def crontab(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.crontab', user_arguments_dict)
+    return stub('mig.shared.functionality.crontab', user_arguments_dict)
 
 
 def lscrontab(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.lscrontab', user_arguments_dict)
+    return stub('mig.shared.functionality.lscrontab', user_arguments_dict)
 
 
 def addcrontab(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.addcrontab', user_arguments_dict)
+    return stub('mig.shared.functionality.addcrontab', user_arguments_dict)
 
 
 def rmcrontab(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmcrontab', user_arguments_dict)
+    return stub('mig.shared.functionality.rmcrontab', user_arguments_dict)
 
 
 def textarea(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.textarea', user_arguments_dict)
+    return stub('mig.shared.functionality.textarea', user_arguments_dict)
 
 
 def updateresconfig(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.updateresconfig',
+    return stub('mig.shared.functionality.updateresconfig',
                 user_arguments_dict)
 
 
 def addresowner(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.addresowner', user_arguments_dict)
+    return stub('mig.shared.functionality.addresowner', user_arguments_dict)
 
 
 def rmresowner(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmresowner', user_arguments_dict)
+    return stub('mig.shared.functionality.rmresowner', user_arguments_dict)
 
 
 def lsresowners(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.lsresowners', user_arguments_dict)
+    return stub('mig.shared.functionality.lsresowners', user_arguments_dict)
 
 
 def delres(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.delres', user_arguments_dict)
+    return stub('mig.shared.functionality.delres', user_arguments_dict)
 
 
 def restartfe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.restartfe', user_arguments_dict)
+    return stub('mig.shared.functionality.restartfe', user_arguments_dict)
 
 
 def startfe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.startfe', user_arguments_dict)
+    return stub('mig.shared.functionality.startfe', user_arguments_dict)
 
 
 def statusfe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.statusfe', user_arguments_dict)
+    return stub('mig.shared.functionality.statusfe', user_arguments_dict)
 
 
 def stopfe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.stopfe', user_arguments_dict)
+    return stub('mig.shared.functionality.stopfe', user_arguments_dict)
 
 
 def cleanfe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cleanfe', user_arguments_dict)
+    return stub('mig.shared.functionality.cleanfe', user_arguments_dict)
 
 
 def restartallexes(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.restartallexes', user_arguments_dict)
+    return stub('mig.shared.functionality.restartallexes', user_arguments_dict)
 
 
 def restartexe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.restartexe', user_arguments_dict)
+    return stub('mig.shared.functionality.restartexe', user_arguments_dict)
 
 
 def startallexes(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.startallexes', user_arguments_dict)
+    return stub('mig.shared.functionality.startallexes', user_arguments_dict)
 
 
 def startexe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.startexe', user_arguments_dict)
+    return stub('mig.shared.functionality.startexe', user_arguments_dict)
 
 
 def statusallexes(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.statusallexes', user_arguments_dict)
+    return stub('mig.shared.functionality.statusallexes', user_arguments_dict)
 
 
 def statusexe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.statusexe', user_arguments_dict)
+    return stub('mig.shared.functionality.statusexe', user_arguments_dict)
 
 
 def stopallexes(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.stopallexes', user_arguments_dict)
+    return stub('mig.shared.functionality.stopallexes', user_arguments_dict)
 
 
 def stopexe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.stopexe', user_arguments_dict)
+    return stub('mig.shared.functionality.stopexe', user_arguments_dict)
 
 
 def cleanallexes(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cleanallexes', user_arguments_dict)
+    return stub('mig.shared.functionality.cleanallexes', user_arguments_dict)
 
 
 def cleanexe(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cleanexe', user_arguments_dict)
+    return stub('mig.shared.functionality.cleanexe', user_arguments_dict)
 
 
 def restartallstores(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.restartallstores', user_arguments_dict)
+    return stub('mig.shared.functionality.restartallstores', user_arguments_dict)
 
 
 def restartstore(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.restartstore', user_arguments_dict)
+    return stub('mig.shared.functionality.restartstore', user_arguments_dict)
 
 
 def startallstores(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.startallstores', user_arguments_dict)
+    return stub('mig.shared.functionality.startallstores', user_arguments_dict)
 
 
 def startstore(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.startstore', user_arguments_dict)
+    return stub('mig.shared.functionality.startstore', user_arguments_dict)
 
 
 def statusallstores(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.statusallstores', user_arguments_dict)
+    return stub('mig.shared.functionality.statusallstores', user_arguments_dict)
 
 
 def statusstore(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.statusstore', user_arguments_dict)
+    return stub('mig.shared.functionality.statusstore', user_arguments_dict)
 
 
 def stopallstores(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.stopallstores', user_arguments_dict)
+    return stub('mig.shared.functionality.stopallstores', user_arguments_dict)
 
 
 def stopstore(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.stopstore', user_arguments_dict)
+    return stub('mig.shared.functionality.stopstore', user_arguments_dict)
 
 
 def cleanallstores(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cleanallstores', user_arguments_dict)
+    return stub('mig.shared.functionality.cleanallstores', user_arguments_dict)
 
 
 def cleanstore(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.cleanstore', user_arguments_dict)
+    return stub('mig.shared.functionality.cleanstore', user_arguments_dict)
 
 
 def vgridmemberrequest(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.vgridmemberrequest',
+    return stub('mig.shared.functionality.vgridmemberrequest',
                 user_arguments_dict)
 
 
 def vgridmemberrequestaction(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.vgridmemberrequestaction',
+    return stub('mig.shared.functionality.vgridmemberrequestaction',
                 user_arguments_dict)
 
 
 def createvgrid(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.createvgrid', user_arguments_dict)
+    return stub('mig.shared.functionality.createvgrid', user_arguments_dict)
 
 
 def rmvgridowner(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmvgridowner',
+    return stub('mig.shared.functionality.rmvgridowner',
                 user_arguments_dict)
 
 
 def rmvgridmember(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmvgridmember',
+    return stub('mig.shared.functionality.rmvgridmember',
                 user_arguments_dict)
 
 
 def addvgridmember(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.addvgridmember',
+    return stub('mig.shared.functionality.addvgridmember',
                 user_arguments_dict)
 
 
 def addvgridowner(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.addvgridowner',
+    return stub('mig.shared.functionality.addvgridowner',
                 user_arguments_dict)
 
 
 def lsvgridowners(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.lsvgridowners',
+    return stub('mig.shared.functionality.lsvgridowners',
                 user_arguments_dict)
 
 
 def lsvgridmembers(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.lsvgridmembers',
+    return stub('mig.shared.functionality.lsvgridmembers',
                 user_arguments_dict)
 
 
 def lsvgridres(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.lsvgridres', user_arguments_dict)
+    return stub('mig.shared.functionality.lsvgridres', user_arguments_dict)
 
 
 def addvgridres(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.addvgridres', user_arguments_dict)
+    return stub('mig.shared.functionality.addvgridres', user_arguments_dict)
 
 
 def rmvgridres(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmvgridres', user_arguments_dict)
+    return stub('mig.shared.functionality.rmvgridres', user_arguments_dict)
 
 
 def lsvgridtriggers(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.lsvgridtriggers', user_arguments_dict)
+    return stub('mig.shared.functionality.lsvgridtriggers', user_arguments_dict)
 
 
 def addvgridtrigger(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.addvgridtrigger', user_arguments_dict)
+    return stub('mig.shared.functionality.addvgridtrigger', user_arguments_dict)
 
 
 def rmvgridtrigger(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.rmvgridtrigger', user_arguments_dict)
+    return stub('mig.shared.functionality.rmvgridtrigger', user_arguments_dict)
 
 
 def vgridworkflows(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.vgridworkflows', user_arguments_dict)
+    return stub('mig.shared.functionality.vgridworkflows', user_arguments_dict)
 
 
 def vgridsettings(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.vgridsettings', user_arguments_dict)
+    return stub('mig.shared.functionality.vgridsettings', user_arguments_dict)
 
 
 def viewvgrid(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.viewvgrid', user_arguments_dict)
+    return stub('mig.shared.functionality.viewvgrid', user_arguments_dict)
 
 
 def showvgridmonitor(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.showvgridmonitor',
+    return stub('mig.shared.functionality.showvgridmonitor',
                 user_arguments_dict)
 
 
 def showvgridprivatefile(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.showvgridprivatefile',
+    return stub('mig.shared.functionality.showvgridprivatefile',
                 user_arguments_dict)
 
 
 def adminvgrid(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.adminvgrid', user_arguments_dict)
+    return stub('mig.shared.functionality.adminvgrid', user_arguments_dict)
 
 
 def createre(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.createre', user_arguments_dict)
+    return stub('mig.shared.functionality.createre', user_arguments_dict)
 
 
 def deletere(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.deletere', user_arguments_dict)
+    return stub('mig.shared.functionality.deletere', user_arguments_dict)
 
 
 def showre(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.showre', user_arguments_dict)
+    return stub('mig.shared.functionality.showre', user_arguments_dict)
 
 
 def redb(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.redb', user_arguments_dict)
+    return stub('mig.shared.functionality.redb', user_arguments_dict)
 
 
 def adminre(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.adminre', user_arguments_dict)
+    return stub('mig.shared.functionality.adminre', user_arguments_dict)
 
 
 def createbackup(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.createbackup', user_arguments_dict)
+    return stub('mig.shared.functionality.createbackup', user_arguments_dict)
 
 
 def deletebackup(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.deletebackup', user_arguments_dict)
+    return stub('mig.shared.functionality.deletebackup', user_arguments_dict)
 
 
 def showbackup(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.showbackup', user_arguments_dict)
+    return stub('mig.shared.functionality.showbackup', user_arguments_dict)
 
 
 def createfreeze(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.createfreeze', user_arguments_dict)
+    return stub('mig.shared.functionality.createfreeze', user_arguments_dict)
 
 
 def deletefreeze(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.deletefreeze', user_arguments_dict)
+    return stub('mig.shared.functionality.deletefreeze', user_arguments_dict)
 
 
 def adminfreeze(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.adminfreeze', user_arguments_dict)
+    return stub('mig.shared.functionality.adminfreeze', user_arguments_dict)
 
 
 def showfreeze(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.showfreeze', user_arguments_dict)
+    return stub('mig.shared.functionality.showfreeze', user_arguments_dict)
 
 
 def freezedb(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.freezedb', user_arguments_dict)
+    return stub('mig.shared.functionality.freezedb', user_arguments_dict)
 
 
 def settings(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.settings', user_arguments_dict)
+    return stub('mig.shared.functionality.settings', user_arguments_dict)
 
 
 def settingsaction(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.settingsaction', user_arguments_dict)
+    return stub('mig.shared.functionality.settingsaction', user_arguments_dict)
 
 
 def sendrequest(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.sendrequest', user_arguments_dict)
+    return stub('mig.shared.functionality.sendrequest', user_arguments_dict)
 
 
 def sendrequestaction(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.sendrequestaction', user_arguments_dict)
+    return stub('mig.shared.functionality.sendrequestaction', user_arguments_dict)
 
 
 def pubvgridprojects(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.pubvgridprojects',
+    return stub('mig.shared.functionality.pubvgridprojects',
                 user_arguments_dict)
 
 
 def people(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.people', user_arguments_dict)
+    return stub('mig.shared.functionality.people', user_arguments_dict)
 
 
 def signature(user_arguments_dict):
     """Wrap backend of same name"""
 
-    return stub('shared.functionality.signature', user_arguments_dict)
+    return stub('mig.shared.functionality.signature', user_arguments_dict)
 
 
 # IMPORTANT: List of all functions to expose both in XMLRPC and JSONRPC

--- a/mig/user/jsonrpcsslclient.py
+++ b/mig/user/jsonrpcsslclient.py
@@ -75,7 +75,7 @@ def read_user_conf():
             parts = thisline.split(None)
             (key, val) = parts[:2]
             (key, val) = key.strip(), val.strip()
-            if not key in needed_settings + optional_settings:
+            if key not in needed_settings + optional_settings:
                 continue
             if key in expand_paths:
                 val = os.path.expandvars(os.path.expanduser(val))
@@ -102,64 +102,13 @@ class SafeCertTransport(jsonrpc.SafeTransport):
     _extra_headers = []
 
     def __init__(self, config, context=None, conf=None):
-        """For backward compatibility with python < 2.7 . Call parent
-        constructor and check if the new _connection attribute is set.
-        If not we must switch to compatibility mode where the request
-        method needs to be overridden.
-        """
+        """Simply wrap parent constructor with our own conf added"""
         jsonrpc.SafeTransport.__init__(self, config=config, context=context)
         if conf:
             self.conf.update(conf)
 
-        if not hasattr(self, '_connection'):
-            # print "DEBUG: switch to compat mode"
-            self._connection = (None, None)
-            self.request = self._compat_request
-
-    def _compat_request(self, host, handler, request_body, verbose=0):
-        """For backward compatibility with < 2.7 : must override connection
-        calls to fit older httplib API.
-
-        Reuse existing connections to avoid repeating passphrase every single
-        time.
-        """
-
-        # issue JSON-RPC request
-
-        if not self.host:
-            self.host = self.make_connection(host)
-        if verbose:
-            self.host.set_debuglevel(1)
-
-        self.send_request(self.host, handler, request_body)
-
-        self.send_user_agent(self.host)
-        self.send_content(self.host, request_body)
-
-        resp = self.host.getresponse()
-        errcode = resp.status
-        errmsg = resp.reason
-        headers = resp.getheaders()
-
-        if errcode != 200:
-            raise jsonrpc.ProtocolError(host + handler, errcode,
-                                        errmsg, headers)
-
-        self.verbose = verbose
-
-        try:
-            sock = self.host._conn.sock
-        except AttributeError:
-            sock = None
-
-        # return self._parse_response(resp, sock)
-        return self.parse_response(resp)
-
     def make_connection(self, host):
-        """Override default HTTPS Transport to include key/cert support. This
-        is the python 2.7 version which changed internals and broke
-        backward compatibility. We use the exact same structure and do the
-        plumbing for backward compatibility in the constructor instead.
+        """Override default HTTPS Transport to include key/cert support.
 
         Reuses connections if possible to support HTTP/1.1 keep-alive.
 

--- a/mig/user/jsonrpcsslclient.py
+++ b/mig/user/jsonrpcsslclient.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # jsonrpcsslclient - JSONRPC client with HTTPS user certificate support
-# Copyright (C) 2003-2021  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,21 +20,17 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
 
 """JSONRPC client with support for HTTPS using client certificates. Requires
-the jsonrpclib module from
-https://pypi.python.org/pypi/jsonrpclib
+the forked jsonrpclib module from
+https://pypi.org/project/jsonrpclib-pelix
 to be installed on client and server. That is easily done with e.g.
-pip install jsonrpclib
-or
-apt install python-jsonrpclib
-or
-yum install python-jsonrpclib
-depending on the platform.
+pip install jsonrpclib-pelix
 """
 
 from __future__ import print_function
@@ -47,7 +43,7 @@ import ssl
 import sys
 import time
 
-from jsonrpclib import jsonrpc
+from jsonrpclib import jsonrpc, config
 from urllib.parse import urlparse
 
 
@@ -105,14 +101,15 @@ class SafeCertTransport(jsonrpc.SafeTransport):
     # Needed for jsonrpc
     _extra_headers = []
 
-    def __init__(self, conf={}):
+    def __init__(self, config, context=None, conf=None):
         """For backward compatibility with python < 2.7 . Call parent
         constructor and check if the new _connection attribute is set.
         If not we must switch to compatibility mode where the request
         method needs to be overridden.
         """
-        jsonrpc.SafeTransport.__init__(self)
-        self.conf.update(conf)
+        jsonrpc.SafeTransport.__init__(self, config=config, context=context)
+        if conf:
+            self.conf.update(conf)
 
         if not hasattr(self, '_connection'):
             # print "DEBUG: switch to compat mode"
@@ -189,11 +186,16 @@ class SafeCertTransport(jsonrpc.SafeTransport):
 
 
 def jsonrpcgetserver(conf):
-    cert_transport = SafeCertTransport(conf=conf)
+    jsonrpc_config = config.Config(version='1.0')
+    cert_transport = SafeCertTransport(jsonrpc_config, conf=conf)
+    # TODO: extract ssl_ctx from cert_transport?
+    ssl_ctx = None
     server = jsonrpc.ServerProxy('https://%(host)s:%(port)s%(script)s' %
                                  conf, transport=cert_transport,
                                  # encoding='utf-8',
                                  # verbose=True
+                                 config=jsonrpc_config,
+                                 context=ssl_ctx
                                  )
     return server
 
@@ -381,7 +383,7 @@ vgrid=Generic
 
 """
 
-    # (inlist, retval) = server.ls({"path": job_id_list]})
+    # (inlist, retval) = server.ls({"path": path_list})
     # print server.lsresowners({"unique_resource_name":["%s" % sys.argv[2]]})
     # print server.addresowner({"new_owner":["%s" % sys.argv[1]], "unique_resource_name":["%s" % sys.argv[2]]})
     # print server.lsresowners({"unique_resource_name":["%s" % sys.argv[2]]})
@@ -430,9 +432,9 @@ vgrid=Generic
 
     # (inlist, retval) = server.jobstatus({"job_id":["%s" % sys.argv[1]]})
     # (inlist, retval) = server.textarea({
-    #     "jobname_0_0_0":"abc", "fileupload_0_0_0filename":"nyfil.mrsl",
-    #     "submitmrsl_0":["ON"], "fileupload_0_0_0":["%s" % mrsl]
-    #     })
+    #    "jobname_0_0_0":"abc", "fileupload_0_0_0filename":"nyfil.mrsl",
+    #    "submitmrsl_0":["ON"], "fileupload_0_0_0":["%s" % mrsl]
+    #    })
     # print  "%s : %s" % (retval, inlist)
     # (inlist, retval) = server.editfile({"path":["/m2"], "submitjob":["True"], "editarea":["%s" % mrsl]})
     # (inlist, retval) = server.canceljob({"job_id":["%s" % sys.argv[1]]})

--- a/mig/user/jsonrpcsslclient.py
+++ b/mig/user/jsonrpcsslclient.py
@@ -186,7 +186,7 @@ class SafeCertTransport(jsonrpc.SafeTransport):
 
 
 def jsonrpcgetserver(conf):
-    jsonrpc_config = config.Config(version='1.0')
+    jsonrpc_config = config.Config()
     cert_transport = SafeCertTransport(jsonrpc_config, conf=conf)
     # TODO: extract ssl_ctx from cert_transport?
     ssl_ctx = None

--- a/mig/user/jsonrpcsslclient.py
+++ b/mig/user/jsonrpcsslclient.py
@@ -175,7 +175,7 @@ class SafeCertTransport(jsonrpc.SafeTransport):
 
         key_pw = self.conf.get('password', None)
         cacert = None
-        if conf['cacertfile'] and conf['cacertfile'] != 'AUTO':
+        if self.conf['cacertfile'] and self.conf['cacertfile'] != 'AUTO':
             cacert = self.conf['cacertfile']
         ssl_ctx = ssl.create_default_context(cafile=cacert)
         ssl_ctx.load_cert_chain(self.conf['certfile'],
@@ -227,8 +227,7 @@ if '__main__' == __name__:
     host_port = url_tuple[1].split(':', 1)
     if len(host_port) < 2:
         host_port.append('443')
-    host_port[1] = int(host_port[1])
-    conf['host'], conf['port'] = host_port
+    conf['host'], conf['port'] = host_port[0], int(host_port[1])
 
     print('''Testing JSONRPC client against %(migserver)s with user certificate
 from %(certfile)s , key from %(keyfile)s and
@@ -276,7 +275,10 @@ key/certificate passphrase before you can continue.
         {'job_id': job_id_list, 'flags': 'vs', 'max_jobs': '5'})
     (returnval, returnmsg) = retval
     if returnval != 0:
-        print('Error %s:%s ' % (returnval, returnmsg))
+        print('Error %s:%s' % (returnval, returnmsg))
+        for ele in inlist:
+            if ele['object_type'] == 'error_text':
+                print(ele['text'])
 
     for ele in inlist:
         if ele['object_type'] == 'job_list':
@@ -439,12 +441,28 @@ vgrid=Generic
     # (inlist, retval) = server.editfile({"path":["/m2"], "submitjob":["True"], "editarea":["%s" % mrsl]})
     # (inlist, retval) = server.canceljob({"job_id":["%s" % sys.argv[1]]})
 
+    print("cat as text file")
+    (inlist, retval) = server.cat({"path": path_list, "flags": "v"})
+    print('cat status: %s' % retval)
+    if returnval != 0:
+        print('Error %s:%s' % (returnval, returnmsg))
+    for ele in inlist:
+        if ele['object_type'] == 'error_text':
+            print(ele['text'])
+        elif 'file_output' == ele['object_type']:
+            print(''.join(ele['lines']))
+
+    print("cat as binary file")
     try:
-        print("cat as binary file")
         (inlist, retval) = server.cat({"path": path_list, "flags": "vb"})
-        for entry in inlist:
-            if 'file_output' == entry['object_type']:
-                print(''.join([i for i in entry['lines']]))
+        print('cat status: %s' % retval)
+        if returnval != 0:
+            print('Error %s:%s' % (returnval, returnmsg))
+        for ele in inlist:
+            if ele['object_type'] == 'error_text':
+                print(ele['text'])
+            elif 'file_output' == ele['object_type']:
+                print(ele['lines'])
     except Exception as exc:
         print("Error: could not cat as binary file: %s" % exc)
 
@@ -468,9 +486,14 @@ ANY
         "jobname_0_0_0": "abc", "fileupload_0_0_0filename": "newfile.txt",
         "submitmrsl_0": ["OFF"], "fileupload_0_0_0": ["%s" % mrsl]
     })
-    print(inlist)
-
-    # print "DEBUG: %s\n%s" % (inlist, retval)
+    print('upload status: %s' % retval)
+    # print(inlist)
+    for entry in inlist:
+        if 'text' == entry['object_type']:
+            print('upload status: %s' % entry['text'])
+        elif 'fileuploadobjs' == entry['object_type']:
+            for obj in entry["fileuploadobjs"]:
+                print('uploaded %(name)s of %(size)db' % obj)
 
     print('submit job description in %s' % mrsl_path)
     (inlist, retval) = server.submit({'path': [mrsl_path]})

--- a/mig/user/jsonrpcsslclient.py
+++ b/mig/user/jsonrpcsslclient.py
@@ -116,10 +116,12 @@ class SafeCertTransport(jsonrpc.SafeTransport):
     def __init_ssl_ctx(self):
         """Helper to set up an ssl_ctx with client key and cert plus optional
         reading of the key passphrase from conf to enable non-interactive use.
+        Uses any configured CA certificate, too, but defaults to system ones.
         """
         key_pw = self.conf.get('password', None)
         cacert = None
-        if self.conf['cacertfile'] and self.conf['cacertfile'] != 'AUTO':
+        if self.conf.get('cacertfile', None) and \
+                self.conf['cacertfile'] != 'AUTO':
             cacert = self.conf['cacertfile']
         ssl_ctx = ssl.create_default_context(cafile=cacert)
         ssl_ctx.load_cert_chain(self.conf['certfile'],
@@ -406,6 +408,7 @@ vgrid=Generic
     print("cat as text file")
     (inlist, retval) = server.cat({"path": path_list, "flags": "v"})
     print('cat status: %s' % retval)
+    (returnval, returnmsg) = retval
     if returnval != 0:
         print('Error %s:%s' % (returnval, returnmsg))
     for ele in inlist:
@@ -418,6 +421,7 @@ vgrid=Generic
     try:
         (inlist, retval) = server.cat({"path": path_list, "flags": "vb"})
         print('cat status: %s' % retval)
+        (returnval, returnmsg) = retval
         if returnval != 0:
             print('Error %s:%s' % (returnval, returnmsg))
         for ele in inlist:

--- a/mig/user/jsonrpcsslclient.py
+++ b/mig/user/jsonrpcsslclient.py
@@ -93,19 +93,39 @@ def read_user_conf():
 
 
 class SafeCertTransport(jsonrpc.SafeTransport):
-
     """HTTPS with user certificate"""
 
     host = None
+    ssl_ctx = None
+    _connection = None
     conf = {}
     # Needed for jsonrpc
     _extra_headers = []
 
     def __init__(self, config, context=None, conf=None):
-        """Simply wrap parent constructor with our own conf added"""
+        """Wrap parent constructor with our conf and optional ssl_ctx init"""
         jsonrpc.SafeTransport.__init__(self, config=config, context=context)
         if conf:
             self.conf.update(conf)
+
+        if context is None:
+            self.ssl_ctx = self.__init_ssl_ctx()
+        else:
+            self.ssl_ctx = context
+
+    def __init_ssl_ctx(self):
+        """Helper to set up an ssl_ctx with client key and cert plus optional
+        reading of the key passphrase from conf to enable non-interactive use.
+        """
+        key_pw = self.conf.get('password', None)
+        cacert = None
+        if self.conf['cacertfile'] and self.conf['cacertfile'] != 'AUTO':
+            cacert = self.conf['cacertfile']
+        ssl_ctx = ssl.create_default_context(cafile=cacert)
+        ssl_ctx.load_cert_chain(self.conf['certfile'],
+                                keyfile=self.conf['keyfile'],
+                                password=key_pw)
+        return ssl_ctx
 
     def make_connection(self, host):
         """Override default HTTPS Transport to include key/cert support.
@@ -116,35 +136,28 @@ class SafeCertTransport(jsonrpc.SafeTransport):
         """
         if self._connection and host == self._connection[0]:
             return self._connection[1]
+
         try:
             HTTPS = http.client.HTTPSConnection
         except AttributeError:
             raise NotImplementedError(
                 "your version of httplib doesn't support HTTPS")
 
-        key_pw = self.conf.get('password', None)
-        cacert = None
-        if self.conf['cacertfile'] and self.conf['cacertfile'] != 'AUTO':
-            cacert = self.conf['cacertfile']
-        ssl_ctx = ssl.create_default_context(cafile=cacert)
-        ssl_ctx.load_cert_chain(self.conf['certfile'],
-                                keyfile=self.conf['keyfile'], password=key_pw)
         self._connection = host, HTTPS(self.conf['host'],
-                                       port=self.conf['port'], context=ssl_ctx)
+                                       port=self.conf['port'],
+                                       context=self.ssl_ctx)
         return self._connection[1]
 
 
 def jsonrpcgetserver(conf):
     jsonrpc_config = config.Config()
     cert_transport = SafeCertTransport(jsonrpc_config, conf=conf)
-    # TODO: extract ssl_ctx from cert_transport?
-    ssl_ctx = None
     server = jsonrpc.ServerProxy('https://%(host)s:%(port)s%(script)s' %
                                  conf, transport=cert_transport,
                                  # encoding='utf-8',
                                  # verbose=True
                                  config=jsonrpc_config,
-                                 context=ssl_ctx
+                                 context=cert_transport.ssl_ctx
                                  )
     return server
 

--- a/recommended.txt
+++ b/recommended.txt
@@ -22,7 +22,8 @@ scandir
 python-openid
 # NOTE: this used to be called irclib and is untested for any recent versions 
 irc
-jsonrpclib
+# Use the maintained fork of the now stale original jsonrpclib
+jsonrpclib-pelix
 requests
 # cracklib requires libcrack2-dev or similar system package to build
 #cracklib


### PR DESCRIPTION
Migrate our `jsonrpclib` dependency for the `mig/cgi-bin/jsonrpcinterface.py` backend and `mig/user/jsonrpcsslclient.py` example to the actively maintained `jsonrpclib-pelix` fork and sync interfaces to current API.
Polish and reuse more from xmlrpcX example scripts in lockstep with #595. Also includes the `mig/shared/rpcfunctions.py` server-side fixes from there so there's a bit of overlap.

NB: a similar jsonrpclib switch to jsonrpclib-pelix is needed in the docker-migrid Dockerfile.