### PR TITLE
Retire obsolete `prefer_python3` option which is now the only supported platform

### DIFF
--- a/mig/install/MiGserver-template.conf
+++ b/mig/install/MiGserver-template.conf
@@ -521,8 +521,6 @@ update_interval = __ACCOUNTING_UPDATE_INTERVAL__
 
 [SITE]
 # Web site appearance
-# Whether to use Python 3 for all Python invocations
-prefer_python3 = __PREFER_PYTHON3__
 # Dynamic entry page to pick user default with fallback to site landing page
 autolaunch_page = __AUTOLAUNCH_PAGE__
 # Entry page if not explictly provided or overriden by user

--- a/mig/install/apache-mimic-deb-template.conf
+++ b/mig/install/apache-mimic-deb-template.conf
@@ -46,7 +46,6 @@ __APACHE_RECENT__ LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
 LoadModule version_module modules/mod_version.so
 
 # Optional WSGI if requested
-__WSGI_PY2_COMMENTED__ LoadModule wsgi_module modules/mod_wsgi.so
 __WSGI_PY3_COMMENTED__ LoadModule wsgi_module modules/mod_wsgi_python3.so
 
 # Optional OpenID support if requested

--- a/mig/install/generateconfs.py
+++ b/mig/install/generateconfs.py
@@ -306,7 +306,6 @@ def main(argv, _generate_confs=generate_confs, _print=print):
         'seafile_ro_access',
         'public_use_https',
         'jupyter_services_enable_proxy_https',
-        'prefer_python3',
         'io_account_expire',
         'gdp_email_notify',
     ]

--- a/mig/shared/configuration.py
+++ b/mig/shared/configuration.py
@@ -576,7 +576,6 @@ _CONFIGURATION_PROPERTIES = {
     'workflows_vgrid_recipes_home': '',
     'workflows_vgrid_history_home': '',
     'site_user_id_format': DEFAULT_USER_ID_FORMAT,
-    'site_prefer_python3': False,
     'site_autolaunch_page': '',
     'site_landing_page': '',
     'site_skin': '',
@@ -2006,11 +2005,6 @@ location.""" % self.config_file)
             self.site_assets = config.get('SITE', 'assets')
         else:
             self.site_assets = "/assets"
-        if config.has_option('SITE', 'prefer_python3'):
-            self.site_prefer_python3 = config.getboolean('SITE',
-                                                         'prefer_python3')
-        else:
-            self.site_prefer_python3 = False
         if config.has_option('SITE', 'user_id_format'):
             self.site_user_id_format = config.get('SITE', 'user_id_format')
             if not self.site_user_id_format in valid_user_id_formats:
@@ -2808,8 +2802,9 @@ location.""" % self.config_file)
     def apply_loaded_config_to_division(self, division, config):
         defaults = _FIX_MISSING_DEFINITIONS[division]
         relevant = {k: config.get(division, k, fallback=defaults[k])
-                        for k in defaults}
-        normalise_division = getattr(self, "division_normalise_%s" % (division,))
+                    for k in defaults}
+        normalise_division = getattr(
+            self, "division_normalise_%s" % (division,))
         normalise_division(relevant)
 
     def division_normalise_TEMPLATES(self, candidates):

--- a/mig/shared/install.py
+++ b/mig/shared/install.py
@@ -405,7 +405,6 @@ def generate_confs(
     enable_sitestatus=True,
     enable_quota=False,
     enable_accounting=False,
-    prefer_python3=False,
     io_account_expire=False,
     gdp_email_notify=False,
     user_interface="V3 V2",
@@ -738,7 +737,6 @@ def _generate_confs_prepare(
     enable_sitestatus,
     enable_quota,
     enable_accounting,
-    prefer_python3,
     io_account_expire,
     gdp_email_notify,
     user_interface,
@@ -998,7 +996,6 @@ def _generate_confs_prepare(
     user_dict['__ENABLE_SITESTATUS__'] = "%s" % enable_sitestatus
     user_dict['__ENABLE_QUOTA__'] = "%s" % enable_quota
     user_dict['__ENABLE_ACCOUNTING__'] = "%s" % enable_accounting
-    user_dict['__PREFER_PYTHON3__'] = "%s" % prefer_python3
     user_dict['__IO_ACCOUNT_EXPIRE__'] = "%s" % io_account_expire
     user_dict['__GDP_EMAIL_NOTIFY__'] = "%s" % gdp_email_notify
     user_dict['__USER_INTERFACE__'] = user_interface
@@ -1352,18 +1349,11 @@ cert, oid and sid based https!
         # WSGI shares auth and bin and only discriminates in backend
         xgi_bin = xgi_auth = 'wsgi-bin'
         user_dict['__WSGI_COMMENTED__'] = ''
-        # Switch between python 2 and 3 wsgi module on request
-        if prefer_python3:
-            user_dict['__WSGI_PY3_COMMENTED__'] = ''
-            user_dict['__WSGI_PY2_COMMENTED__'] = '#'
-        else:
-            user_dict['__WSGI_PY2_COMMENTED__'] = ''
-            user_dict['__WSGI_PY3_COMMENTED__'] = '#'
+        user_dict['__WSGI_PY3_COMMENTED__'] = ''
     else:
         xgi_bin = 'cgi-bin'
         xgi_auth = 'cgi-auth'
         user_dict['__WSGI_COMMENTED__'] = '#'
-        user_dict['__WSGI_PY2_COMMENTED__'] = '#'
         user_dict['__WSGI_PY3_COMMENTED__'] = '#'
 
     # Enable HSTS security improvement only if explicitly requested

--- a/tests/data/MiGserver--customised-include_sections.conf
+++ b/tests/data/MiGserver--customised-include_sections.conf
@@ -517,8 +517,6 @@ update_interval = 3600
 
 [SITE]
 # Web site appearance
-# Whether to use Python 3 for all Python invocations
-prefer_python3 = False
 # Dynamic entry page to pick user default with fallback to site landing page
 autolaunch_page = /wsgi-bin/autolaunch.py
 # Entry page if not explictly provided or overriden by user

--- a/tests/data/MiGserver--customised.conf
+++ b/tests/data/MiGserver--customised.conf
@@ -517,8 +517,6 @@ update_interval = 3600
 
 [SITE]
 # Web site appearance
-# Whether to use Python 3 for all Python invocations
-prefer_python3 = False
 # Dynamic entry page to pick user default with fallback to site landing page
 autolaunch_page = /wsgi-bin/autolaunch.py
 # Entry page if not explictly provided or overriden by user

--- a/tests/data/MiGserver--default_templates.conf
+++ b/tests/data/MiGserver--default_templates.conf
@@ -521,8 +521,6 @@ update_interval = 3600
 
 [SITE]
 # Web site appearance
-# Whether to use Python 3 for all Python invocations
-prefer_python3 = False
 # Dynamic entry page to pick user default with fallback to site landing page
 autolaunch_page = /wsgi-bin/autolaunch.py
 # Entry page if not explictly provided or overriden by user

--- a/tests/data/MiGserver--empty_templates.conf
+++ b/tests/data/MiGserver--empty_templates.conf
@@ -521,8 +521,6 @@ update_interval = 3600
 
 [SITE]
 # Web site appearance
-# Whether to use Python 3 for all Python invocations
-prefer_python3 = False
 # Dynamic entry page to pick user default with fallback to site landing page
 autolaunch_page = /wsgi-bin/autolaunch.py
 # Entry page if not explictly provided or overriden by user

--- a/tests/data/MiGserver--templates.conf
+++ b/tests/data/MiGserver--templates.conf
@@ -521,8 +521,6 @@ update_interval = 3600
 
 [SITE]
 # Web site appearance
-# Whether to use Python 3 for all Python invocations
-prefer_python3 = False
 # Dynamic entry page to pick user default with fallback to site landing page
 autolaunch_page = /wsgi-bin/autolaunch.py
 # Entry page if not explictly provided or overriden by user

--- a/tests/fixture/confs-stdlocal/MiGserver.conf
+++ b/tests/fixture/confs-stdlocal/MiGserver.conf
@@ -521,8 +521,6 @@ update_interval = 3600
 
 [SITE]
 # Web site appearance
-# Whether to use Python 3 for all Python invocations
-prefer_python3 = False
 # Dynamic entry page to pick user default with fallback to site landing page
 autolaunch_page = /wsgi-bin/autolaunch.py
 # Entry page if not explictly provided or overriden by user

--- a/tests/fixture/confs-stdlocal/mimic-deb.conf
+++ b/tests/fixture/confs-stdlocal/mimic-deb.conf
@@ -46,8 +46,7 @@ LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
 LoadModule version_module modules/mod_version.so
 
 # Optional WSGI if requested
-LoadModule wsgi_module modules/mod_wsgi.so
-#LoadModule wsgi_module modules/mod_wsgi_python3.so
+LoadModule wsgi_module modules/mod_wsgi_python3.so
 
 # Optional OpenID support if requested
 # Please note that fully functional OpenID cert_redirect requires reverse

--- a/tests/fixture/mig_shared_configuration--new.json
+++ b/tests/fixture/mig_shared_configuration--new.json
@@ -164,7 +164,6 @@
       ".*"
     ]
   ],
-  "site_prefer_python3": false,
   "site_signup_hint": "",
   "site_signup_methods": [
     "extcert"


### PR DESCRIPTION
Retire obsolete `prefer_python3` option which is now the only supported platform and already prepared retired in
https://github.com/ucphhpc/docker-migrid/issues/166
Also remove the related obsolete `__WSGI_PY2_COMMENTED__` internal marker to effectively move the optional wsgi support in Apache to the explicit python3 version. Please note that if you use docker-migrid or similar RHEL/Rocky-based deployments with the distro python3 wsgi module package it should automatically match the generated configuration.