### PR TITLE
Simplify and add additional simple functionality backend unit tests

### DIFF
--- a/mig/shared/functionality/docs.py
+++ b/mig/shared/functionality/docs.py
@@ -40,8 +40,10 @@ import os
 from mig.shared import mrslkeywords
 from mig.shared import resconfkeywords
 from mig.shared import returnvalues
+from mig.shared.base import requested_backend
 from mig.shared.functional import validate_input
-from mig.shared.init import initialize_main_variables
+from mig.shared.init import initialize_main_variables, make_title_entry, \
+    make_start_entry
 from mig.shared.output import get_valid_outputformats
 
 
@@ -215,7 +217,7 @@ The MiG software license follows below:<br />
     lic_text = ''.join(lic_lines[2:-1])
     output_objects.append({'object_type': 'html_form', 'text':
                            '<code>%s</code><br />' %
-                           lic_text.replace('\n', '<br \>')})
+                           lic_text.replace('\n', '<br />')})
 
     output_objects.append(
         {'object_type': 'header', 'text': 'Acknowledgements'})
@@ -606,8 +608,35 @@ The workflows also requires that the resources provide the SSHFS_MOUNT runtime e
                                'text': 'sshfs client (GNU v2.0)'})
 
 
-def main(client_id, user_arguments_dict):
-    """Main function used by front end"""
+def main(client_id, user_arguments_dict, environ=None):
+    """Main function wrapper used by front end"""
+
+    if environ is None:
+        environ = os.environ
+
+    (configuration, logger, output_objects, op_name) = \
+        initialize_main_variables(client_id)
+
+    return _main(configuration, logger, environ, op_name=op_name,
+                 output_objects=output_objects, client_id=client_id,
+                 user_arguments_dict=user_arguments_dict)
+
+
+def _main(configuration, logger, environ, op_name='', output_objects=None,
+          client_id=None, user_arguments_dict=None):
+    """Actual main function to generate contents for the front end"""
+
+    assert environ is not None, "required arg: environ"
+
+    if logger is None:
+        logger = configuration.logger
+
+    # Create new output_objects list with start entry if None was supplied
+    if output_objects is None:
+        output_objects = [make_start_entry()]
+        if not op_name:
+            op_name = requested_backend()
+        output_objects.append(make_title_entry('%s' % op_name))
 
     (configuration, logger, output_objects, op_name) = \
         initialize_main_variables(client_id, op_header=False,

--- a/mig/shared/functionality/docs.py
+++ b/mig/shared/functionality/docs.py
@@ -439,7 +439,7 @@ Web interfaces are served with the Apache HTTP Server:"""})
                                'title': 'RSync Home Page',
                                'text':
                                'RSync incremental file transfer client (GPL license)'})
-    if configuration.site_password_cracklib:
+    if password_dep and configuration.site_password_cracklib:
         output_objects.append({'object_type': 'text', 'text': """
 The optional password strength testing for SFTP/DAVS/FTPS servers relies
 on the Cracklib module from:"""})

--- a/mig/shared/functionality/fileman.py
+++ b/mig/shared/functionality/fileman.py
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #

--- a/mig/shared/functionality/fileman.py
+++ b/mig/shared/functionality/fileman.py
@@ -31,10 +31,10 @@ their home directories.
 
 from __future__ import absolute_import
 
-import sys
+import os
 
 from mig.shared import returnvalues
-from mig.shared.base import client_id_dir, requested_backend
+from mig.shared.base import requested_backend
 from mig.shared.defaults import trash_linkname, csrf_backends, csrf_field, \
     default_max_chunks
 from mig.shared.freezefunctions import import_freeze_form
@@ -692,7 +692,6 @@ def _main(configuration, logger, environ, op_name='', output_objects=None,
             op_name = requested_backend()
         output_objects.append(make_title_entry('%s' % op_name))
 
-    client_dir = client_id_dir(client_id)
     defaults = signature()[1]
     (validate_status, accepted) = validate_input_and_cert(
         user_arguments_dict,

--- a/mig/shared/functionality/fileman.py
+++ b/mig/shared/functionality/fileman.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # fileman - File manager UI for browsing and manipulating files and folders
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -34,7 +34,7 @@ from __future__ import absolute_import
 import sys
 
 from mig.shared import returnvalues
-from mig.shared.base import client_id_dir
+from mig.shared.base import client_id_dir, requested_backend
 from mig.shared.defaults import trash_linkname, csrf_backends, csrf_field, \
     default_max_chunks
 from mig.shared.freezefunctions import import_freeze_form
@@ -44,7 +44,8 @@ from mig.shared.functionality.editor import advanced_editor_css_deps, \
 from mig.shared.gdp.all import get_project_from_client_id
 from mig.shared.handlers import get_csrf_limit, make_csrf_token
 from mig.shared.htmlgen import themed_styles, legacy_user_interface
-from mig.shared.init import initialize_main_variables, find_entry, extract_menu
+from mig.shared.init import initialize_main_variables, extract_menu, \
+    find_entry, make_title_entry, make_start_entry
 from mig.shared.pwcrypto import sorted_hash_algos, default_algo
 from mig.shared.sharelinks import create_share_link_form, import_share_link_form
 
@@ -463,7 +464,7 @@ def js_tmpl_parts(configuration,
             ('%s' % (configuration.site_enable_transfers and legacy_buttons)).lower(),
         'enable_gdp':
             ('%s' % configuration.site_enable_gdp).lower(),
-        'max_stream_size': 64*1024*1024
+        'max_stream_size': 64 * 1024 * 1024
     }
 
     js_import = '''
@@ -661,11 +662,36 @@ def signature():
     return ['', defaults]
 
 
-def main(client_id, user_arguments_dict):
-    """Main function used by front end"""
+def main(client_id, user_arguments_dict, environ=None):
+    """Main function wrapper used by front end"""
+
+    if environ is None:
+        environ = os.environ
 
     (configuration, logger, output_objects, op_name) = \
         initialize_main_variables(client_id, op_header=False)
+
+    return _main(configuration, logger, environ, op_name=op_name,
+                 output_objects=output_objects, client_id=client_id,
+                 user_arguments_dict=user_arguments_dict)
+
+
+def _main(configuration, logger, environ, op_name='', output_objects=None,
+          client_id=None, user_arguments_dict=None):
+    """Actual main function to generate contents for the front end"""
+
+    assert environ is not None, "required arg: environ"
+
+    if logger is None:
+        logger = configuration.logger
+
+    # Create new output_objects list with start entry if None was supplied
+    if output_objects is None:
+        output_objects = [make_start_entry()]
+        if not op_name:
+            op_name = requested_backend()
+        output_objects.append(make_title_entry('%s' % op_name))
+
     client_dir = client_id_dir(client_id)
     defaults = signature()[1]
     (validate_status, accepted) = validate_input_and_cert(
@@ -675,6 +701,7 @@ def main(client_id, user_arguments_dict):
         client_id,
         configuration,
         allow_rejects=False,
+        environ=environ,
         # NOTE: path cannot use wildcards here
         typecheck_overrides={},
     )

--- a/mig/shared/functionality/resedit.py
+++ b/mig/shared/functionality/resedit.py
@@ -32,6 +32,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from builtins import range
+import os
 import socket
 
 from mig.shared import resconfkeywords

--- a/mig/shared/functionality/resedit.py
+++ b/mig/shared/functionality/resedit.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # resedit - Resource editor back end
-# Copyright (C) 2003-2019  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,14 +20,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
 
-# Martin Rehr martin@rehr.dk August 2005
-
 """Display resource editor"""
+
 from __future__ import print_function
 from __future__ import absolute_import
 
@@ -36,10 +36,12 @@ import socket
 
 from mig.shared import resconfkeywords
 from mig.shared import returnvalues
+from mig.shared.base import requested_backend
 from mig.shared.defaults import csrf_field
 from mig.shared.functional import validate_input_and_cert
 from mig.shared.handlers import get_csrf_limit, make_csrf_token
-from mig.shared.init import initialize_main_variables, find_entry
+from mig.shared.init import initialize_main_variables, find_entry, \
+    make_title_entry, make_start_entry
 from mig.shared.refunctions import list_runtime_environments
 from mig.shared.resource import init_conf, empty_resource_config
 from mig.shared.vgridaccess import res_vgrid_access
@@ -87,11 +89,36 @@ def available_choices(configuration, client_id, resource_id, field, spec):
     return choices
 
 
-def main(client_id, user_arguments_dict):
-    """Main function used by front end"""
+def main(client_id, user_arguments_dict, environ=None):
+    """Main function wrapper used by front end"""
+
+    if environ is None:
+        environ = os.environ
 
     (configuration, logger, output_objects, op_name) = \
         initialize_main_variables(client_id, op_header=False)
+
+    return _main(configuration, logger, environ, op_name=op_name,
+                 output_objects=output_objects, client_id=client_id,
+                 user_arguments_dict=user_arguments_dict)
+
+
+def _main(configuration, logger, environ, op_name='', output_objects=None,
+          client_id=None, user_arguments_dict=None):
+    """Actual main function to generate contents for the front end"""
+
+    assert environ is not None, "required arg: environ"
+
+    if logger is None:
+        logger = configuration.logger
+
+    # Create new output_objects list with start entry if None was supplied
+    if output_objects is None:
+        output_objects = [make_start_entry()]
+        if not op_name:
+            op_name = requested_backend()
+        output_objects.append(make_title_entry('%s' % op_name))
+
     defaults = signature()[1]
     (validate_status, accepted) = validate_input_and_cert(
         user_arguments_dict,
@@ -100,6 +127,7 @@ def main(client_id, user_arguments_dict):
         client_id,
         configuration,
         allow_rejects=False,
+        environ=environ
     )
     if not validate_status:
         return (accepted, returnvalues.CLIENT_ERROR)

--- a/mig/shared/functionality/vgridworkflows.py
+++ b/mig/shared/functionality/vgridworkflows.py
@@ -44,7 +44,7 @@ import time
 
 from mig.lib.events import get_path_expand_map
 from mig.shared import returnvalues
-from mig.shared.base import client_id_dir
+from mig.shared.base import client_id_dir, requested_backend
 from mig.shared.cmdapi import get_usage_map
 from mig.shared.defaults import keyword_all, keyword_auto, \
     valid_trigger_changes, valid_trigger_actions, workflows_log_name, \
@@ -52,7 +52,8 @@ from mig.shared.defaults import keyword_all, keyword_auto, \
 from mig.shared.fileio import unpickle, makedirs_rec, move_file
 from mig.shared.functional import validate_input_and_cert, REJECT_UNSET
 from mig.shared.htmlgen import man_base_js, man_base_html
-from mig.shared.init import initialize_main_variables, find_entry
+from mig.shared.init import initialize_main_variables, find_entry, \
+    make_title_entry, make_start_entry
 from mig.shared.parseflags import verbose
 from mig.shared.vgrid import vgrid_add_remove_table, vgrid_is_owner_or_member, \
     vgrid_triggers, vgrid_set_triggers
@@ -107,11 +108,36 @@ def read_trigger_log(configuration, vgrid_name, flags):
     return log_content
 
 
-def main(client_id, user_arguments_dict):
-    """Main function used by front end"""
+def main(client_id, user_arguments_dict, environ=None):
+    """Main function wrapper used by front end"""
+
+    if environ is None:
+        environ = os.environ
 
     (configuration, logger, output_objects, op_name) = \
         initialize_main_variables(client_id, op_header=False)
+
+    return _main(configuration, logger, environ, op_name=op_name,
+                 output_objects=output_objects, client_id=client_id,
+                 user_arguments_dict=user_arguments_dict)
+
+
+def _main(configuration, logger, environ, op_name='', output_objects=None,
+          client_id=None, user_arguments_dict=None):
+    """Actual main function to generate contents for the front end"""
+
+    assert environ is not None, "required arg: environ"
+
+    if logger is None:
+        logger = configuration.logger
+
+    # Create new output_objects list with start entry if None was supplied
+    if output_objects is None:
+        output_objects = [make_start_entry()]
+        if not op_name:
+            op_name = requested_backend()
+        output_objects.append(make_title_entry('%s' % op_name))
+
     defaults = signature()[1]
     title_entry = find_entry(output_objects, 'title')
     label = "%s" % configuration.site_vgrid_label
@@ -123,6 +149,7 @@ def main(client_id, user_arguments_dict):
         output_objects,
         client_id,
         configuration,
+        environ=environ,
         allow_rejects=False,
     )
     if not validate_status:
@@ -131,6 +158,11 @@ def main(client_id, user_arguments_dict):
     vgrid_name = accepted['vgrid_name'][-1]
     operation = accepted['operation'][-1]
     flags = ''.join(accepted['flags'][-1])
+
+    if not configuration.site_enable_workflows:
+        output_objects.append({'object_type': 'error_text', 'text':
+                               '''Workflows are not enabled on this system'''})
+        return (output_objects, returnvalues.SYSTEM_ERROR)
 
     if not vgrid_is_owner_or_member(vgrid_name, client_id,
                                     configuration):
@@ -174,6 +206,8 @@ access the workflows.'''
               $(".workflow-tabs").tabs();
               $("#logarea").scrollTop($("#logarea")[0].scrollHeight);
         '''
+        for name in ('advanced', 'init', 'ready'):
+            title_entry['script'][name] = title_entry['script'].get(name, '')
         title_entry['script']['advanced'] += add_import
         title_entry['script']['init'] += add_init
         title_entry['script']['ready'] += add_ready

--- a/tests/support/wsgisupp.py
+++ b/tests/support/wsgisupp.py
@@ -51,7 +51,7 @@ class FakeWsgiStartResponse:
         self.calls.append((status, headers, exc))
 
 
-def create_http_environ(configuration):
+def create_http_environ(configuration, path_info=''):
     """Small helper that can create a minimum viable environ dict suitable
     for passing to http-facing code for the supplied configuration.
     """
@@ -59,10 +59,10 @@ def create_http_environ(configuration):
     environ = {}
     environ["MIG_CONF"] = configuration.config_file
     environ["HTTP_HOST"] = "localhost"
-    environ["PATH_INFO"] = "/"
+    environ["PATH_INFO"] = path_info
     environ["REMOTE_ADDR"] = "127.0.0.1"
     environ["SCRIPT_URI"] = "".join(
-        ("https://", environ["HTTP_HOST"], environ["PATH_INFO"])
+        ("https://", environ["HTTP_HOST"], path_info)
     )
     return environ
 

--- a/tests/support/wsgisupp.py
+++ b/tests/support/wsgisupp.py
@@ -51,6 +51,27 @@ class FakeWsgiStartResponse:
         self.calls.append((status, headers, exc))
 
 
+def create_http_environ(configuration):
+    """Small helper that can create a minimum viable environ dict suitable
+    for passing to http-facing code for the supplied configuration.
+    """
+
+    environ = {}
+    environ["MIG_CONF"] = configuration.config_file
+    environ["HTTP_HOST"] = "localhost"
+    environ["PATH_INFO"] = "/"
+    environ["REMOTE_ADDR"] = "127.0.0.1"
+    environ["SCRIPT_URI"] = "".join(
+        ("https://", environ["HTTP_HOST"], environ["PATH_INFO"])
+    )
+    return environ
+
+
+def _only_output_objects(output_objects, with_object_type=None):
+    """Filter output objects to pick only those of a specific object_type"""
+    return [o for o in output_objects if o["object_type"] == with_object_type]
+
+
 def create_wsgi_environ(configuration, wsgi_url, method='GET', query=None, headers=None, form=None):
     """Populate the necessary variables that will constitute a valid WSGI
     environment given a URL to which we will make a requests under test and

--- a/tests/support/wsgisupp.py
+++ b/tests/support/wsgisupp.py
@@ -67,7 +67,7 @@ def create_http_environ(configuration):
     return environ
 
 
-def _only_output_objects(output_objects, with_object_type=None):
+def filter_output_objects(output_objects, with_object_type=None):
     """Filter output objects to pick only those of a specific object_type"""
     return [o for o in output_objects if o["object_type"] == with_object_type]
 

--- a/tests/test_mig_shared_functionality_cat.py
+++ b/tests/test_mig_shared_functionality_cat.py
@@ -3,7 +3,7 @@
 # --- BEGIN_HEADER ---
 #
 # test_mig_shared_functionality_cat - unit test of the corresponding mig module
-# Copyright (C) 2003-2024  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -28,176 +28,198 @@
 """Unit tests of the MiG functionality file implementing the cat backend"""
 
 from __future__ import print_function
-import importlib
+
 import os
 import shutil
-import sys
-import unittest
 
-from tests.support import MIG_BASE, PY2, TEST_DATA_DIR, MigTestCase, testmain, \
-    temppath, ensure_dirs_exist
+# Imports of the code under test
+from mig.shared.functionality.cat import _main as submain
+from mig.shared.functionality.cat import main as realmain
 
-from mig.shared.base import client_id_dir
-from mig.shared.functionality.cat import _main as submain, main as realmain
+# Imports required for the unit tests themselves
+from tests.support import (
+    TEST_DATA_DIR,
+    MigTestCase,
+    testmain,
+)
+from tests.support.usersupp import TEST_USER_DN
+from tests.support.wsgisupp import create_http_environ, filter_output_objects
 
-
-def create_http_environ(configuration):
-    """Small helper that can create a minimum viable environ dict suitable
-    for passing to http-facing code for the supplied configuration.
-    """
-
-    environ = {}
-    environ['MIG_CONF'] = configuration.config_file
-    environ['HTTP_HOST'] = 'localhost'
-    environ['PATH_INFO'] = '/'
-    environ['REMOTE_ADDR'] = '127.0.0.1'
-    environ['SCRIPT_URI'] = ''.join(('https://', environ['HTTP_HOST'],
-                                     environ['PATH_INFO']))
-    return environ
+# Imports required for the unit test wrapping
 
 
-def _only_output_objects(output_objects, with_object_type=None):
-    return [o for o in output_objects if o['object_type'] == with_object_type]
 
 
 class MigSharedFunctionalityCat(MigTestCase):
     """Wrap unit tests for the corresponding module"""
 
-    TEST_CLIENT_ID = '/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com'
+    TEST_CLIENT_ID = "/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com"
 
     def _provide_configuration(self):
-        return 'testconfig'
+        return "testconfig"
 
     def before_each(self):
-        self.test_user_dir = self._provision_test_user(self, self.TEST_CLIENT_ID)
-        self.test_environ = create_http_environ(self.configuration)
+        self.test_user_dir = self._provision_test_user(self, TEST_USER_DN)
+        self.test_environ = create_http_environ(
+            self.configuration, "wsgi-bin/cat.py"
+        )
 
     def assertSingleOutputObject(self, output_objects, with_object_type=None):
         assert with_object_type is not None
-        found_objects = _only_output_objects(output_objects,
-                                             with_object_type=with_object_type)
+        found_objects = filter_output_objects(
+            output_objects, with_object_type=with_object_type
+        )
         self.assertEqual(len(found_objects), 1)
         return found_objects[0]
 
     def test_file_serving_a_single_file_match(self):
-        with open(os.path.join(self.test_user_dir, 'foobar.txt'), 'w'):
+        with open(os.path.join(self.test_user_dir, "foobar.txt"), "w"):
             pass
         payload = {
-            'path': ['foobar.txt'],
+            "path": ["foobar.txt"],
         }
 
-        (output_objects, status) = submain(self.configuration, self.logger,
-                                           client_id=self.TEST_CLIENT_ID,
-                                           user_arguments_dict=payload,
-                                           environ=self.test_environ)
+        output_objects, status = submain(
+            self.configuration,
+            self.logger,
+            client_id=TEST_USER_DN,
+            user_arguments_dict=payload,
+            environ=self.test_environ,
+        )
 
         # NOTE: start entry with headers and actual content
         self.assertEqual(len(output_objects), 2)
-        self.assertSingleOutputObject(output_objects,
-                                      with_object_type='file_output')
+        self.assertSingleOutputObject(
+            output_objects, with_object_type="file_output"
+        )
 
     def test_file_serving_at_limit(self):
         test_binary_file = os.path.realpath(
-            os.path.join(TEST_DATA_DIR, 'loading.gif'))
+            os.path.join(TEST_DATA_DIR, "loading.gif")
+        )
         test_binary_file_size = os.stat(test_binary_file).st_size
-        with open(test_binary_file, 'rb') as fh_test_file:
+        with open(test_binary_file, "rb") as fh_test_file:
             test_binary_file_data = fh_test_file.read()
-        shutil.copyfile(test_binary_file, os.path.join(
-            self.test_user_dir, 'loading.gif'))
+        shutil.copyfile(
+            test_binary_file, os.path.join(self.test_user_dir, "loading.gif")
+        )
         payload = {
-            'output_format': ['file'],
-            'path': ['loading.gif'],
+            "output_format": ["file"],
+            "path": ["loading.gif"],
         }
 
         self.configuration.wwwserve_max_bytes = test_binary_file_size
 
-        (output_objects, status) = submain(self.configuration, self.logger,
-                                           client_id=self.TEST_CLIENT_ID,
-                                           user_arguments_dict=payload,
-                                           environ=self.test_environ)
+        output_objects, status = submain(
+            self.configuration,
+            self.logger,
+            client_id=TEST_USER_DN,
+            user_arguments_dict=payload,
+            environ=self.test_environ,
+        )
 
         self.assertEqual(len(output_objects), 2)
-        relevant_obj = self.assertSingleOutputObject(output_objects,
-                                                     with_object_type='file_output')
-        self.assertEqual(len(relevant_obj['lines']), 1)
-        self.assertEqual(relevant_obj['lines'][0], test_binary_file_data)
+        relevant_obj = self.assertSingleOutputObject(
+            output_objects, with_object_type="file_output"
+        )
+        self.assertEqual(len(relevant_obj["lines"]), 1)
+        self.assertEqual(relevant_obj["lines"][0], test_binary_file_data)
 
     def test_file_serving_over_limit_without_storage_protocols(self):
-        test_binary_file = os.path.realpath(os.path.join(TEST_DATA_DIR,
-                                                         'loading.gif'))
+        test_binary_file = os.path.realpath(
+            os.path.join(TEST_DATA_DIR, "loading.gif")
+        )
         test_binary_file_size = os.stat(test_binary_file).st_size
-        with open(test_binary_file, 'rb') as fh_test_file:
-            test_binary_file_data = fh_test_file.read()
-        shutil.copyfile(test_binary_file, os.path.join(self.test_user_dir,
-                                                       'loading.gif'))
+        with open(test_binary_file, "rb") as fh_test_file:
+            _ = fh_test_file.read()
+        shutil.copyfile(
+            test_binary_file, os.path.join(self.test_user_dir, "loading.gif")
+        )
         payload = {
-            'output_format': ['file'],
-            'path': ['loading.gif'],
+            "output_format": ["file"],
+            "path": ["loading.gif"],
         }
 
         # NOTE: override default storage_protocols to empty in this test
         self.configuration.storage_protocols = []
         self.configuration.wwwserve_max_bytes = test_binary_file_size - 1
 
-        (output_objects, status) = submain(self.configuration, self.logger,
-                                           client_id=self.TEST_CLIENT_ID,
-                                           user_arguments_dict=payload,
-                                           environ=self.test_environ)
+        output_objects, status = submain(
+            self.configuration,
+            self.logger,
+            client_id=TEST_USER_DN,
+            user_arguments_dict=payload,
+            environ=self.test_environ,
+        )
 
         # NOTE: start entry with headers and actual error message
         self.assertEqual(len(output_objects), 2)
-        relevant_obj = self.assertSingleOutputObject(output_objects,
-                                                     with_object_type='error_text')
-        self.assertEqual(relevant_obj['text'],
-                         "Site configuration prevents web serving contents "
-                         "bigger than 3896 bytes")
+        relevant_obj = self.assertSingleOutputObject(
+            output_objects, with_object_type="error_text"
+        )
+        self.assertEqual(
+            relevant_obj["text"],
+            "Site configuration prevents web serving contents "
+            "bigger than 3896 bytes",
+        )
 
     def test_file_serving_over_limit_with_storage_protocols_sftp(self):
-        test_binary_file = os.path.realpath(os.path.join(TEST_DATA_DIR,
-                                                         'loading.gif'))
+        test_binary_file = os.path.realpath(
+            os.path.join(TEST_DATA_DIR, "loading.gif")
+        )
         test_binary_file_size = os.stat(test_binary_file).st_size
-        with open(test_binary_file, 'rb') as fh_test_file:
-            test_binary_file_data = fh_test_file.read()
-        shutil.copyfile(test_binary_file, os.path.join(self.test_user_dir,
-                                                       'loading.gif'))
+        with open(test_binary_file, "rb") as fh_test_file:
+            _ = fh_test_file.read()
+        shutil.copyfile(
+            test_binary_file, os.path.join(self.test_user_dir, "loading.gif")
+        )
         payload = {
-            'output_format': ['file'],
-            'path': ['loading.gif'],
+            "output_format": ["file"],
+            "path": ["loading.gif"],
         }
 
-        self.configuration.storage_protocols = ['sftp']
+        self.configuration.storage_protocols = ["sftp"]
         self.configuration.wwwserve_max_bytes = test_binary_file_size - 1
 
-        (output_objects, status) = submain(self.configuration, self.logger,
-                                           client_id=self.TEST_CLIENT_ID,
-                                           user_arguments_dict=payload,
-                                           environ=self.test_environ)
+        output_objects, status = submain(
+            self.configuration,
+            self.logger,
+            client_id=TEST_USER_DN,
+            user_arguments_dict=payload,
+            environ=self.test_environ,
+        )
 
         # NOTE: start entry with headers and actual error message
-        relevant_obj = self.assertSingleOutputObject(output_objects,
-                                                     with_object_type='error_text')
-        self.assertEqual(relevant_obj['text'],
-                         "Site configuration prevents web serving contents "
-                         "bigger than 3896 bytes - please use better "
-                         "alternatives (SFTP) to retrieve large data")
+        relevant_obj = self.assertSingleOutputObject(
+            output_objects, with_object_type="error_text"
+        )
+        self.assertEqual(
+            relevant_obj["text"],
+            "Site configuration prevents web serving contents "
+            "bigger than 3896 bytes - please use better "
+            "alternatives (SFTP) to retrieve large data",
+        )
 
-    @unittest.skipIf(PY2, "Python 3 only")
     def test_main_passes_environ(self):
         try:
-            result = realmain(self.TEST_CLIENT_ID, {}, self.test_environ)
+            result = realmain(TEST_USER_DN, {}, self.test_environ)
         except Exception as unexpectedexc:
             raise AssertionError(
-                "saw unexpected exception: %s" % (unexpectedexc,))
+                "saw unexpected exception: %s" % (unexpectedexc,)
+            )
 
-        (output_objects, status) = result
-        self.assertEqual(status[1], 'Client error')
+        output_objects, status = result
+        self.assertEqual(status[1], "Client error")
 
-        error_text_objects = _only_output_objects(output_objects,
-                                                  with_object_type='error_text')
+        error_text_objects = filter_output_objects(
+            output_objects, with_object_type="error_text"
+        )
         relevant_obj = error_text_objects[2]
         self.assertEqual(
-            relevant_obj['text'], 'Input arguments were rejected - not allowed for this script!')
+            relevant_obj["text"],
+            "Input arguments were rejected - not allowed for this script!",
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     testmain()

--- a/tests/test_mig_shared_functionality_cat.py
+++ b/tests/test_mig_shared_functionality_cat.py
@@ -48,12 +48,8 @@ from tests.support.wsgisupp import create_http_environ, filter_output_objects
 # Imports required for the unit test wrapping
 
 
-
-
 class MigSharedFunctionalityCat(MigTestCase):
     """Wrap unit tests for the corresponding module"""
-
-    TEST_CLIENT_ID = "/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com"
 
     def _provide_configuration(self):
         return "testconfig"

--- a/tests/test_mig_shared_functionality_datatransfer.py
+++ b/tests/test_mig_shared_functionality_datatransfer.py
@@ -28,24 +28,25 @@
 """Unit tests of the MiG functionality file implementing the datatransfer backend"""
 
 from __future__ import print_function
-import os
 
+# Imports required for the unit test wrapping
 import mig.shared.returnvalues as returnvalues
 from mig.shared.defaults import CSRF_MINIMAL
-from mig.shared.base import client_id_dir
-from mig.shared.functionality.datatransfer import _main as submain, main as realmain
 
+# Imports of the code under test
+from mig.shared.functionality.datatransfer import _main as submain
+from mig.shared.functionality.datatransfer import main as realmain
+
+# Imports required for the unit tests themselves
 from tests.support import (
     MigTestCase,
     testmain,
-    temppath,
-    ensure_dirs_exist,
 )
 from tests.support.usersupp import TEST_USER_DN, UserAssertMixin
 from tests.support.wsgisupp import create_http_environ, filter_output_objects
 
 
-class MigSharedFunctionalityDataTransfer(MigTestCase):
+class MigSharedFunctionalityDataTransfer(MigTestCase, UserAssertMixin):
     """Wrap unit tests for the corresponding module"""
 
     def _provide_configuration(self):
@@ -53,17 +54,27 @@ class MigSharedFunctionalityDataTransfer(MigTestCase):
 
     def before_each(self):
         self.test_user_dir = self._provision_test_user(self, TEST_USER_DN)
-        self.test_environ = create_http_environ(self.configuration)
+        self.test_environ = create_http_environ(
+            self.configuration, "wsgi-bin/datatransfer.py"
+        )
 
     def test_default_disabled_site_transfer(self):
         self.assertFalse(self.configuration.site_enable_transfers)
+        payload = {}
 
-        result = realmain(TEST_USER_DN, {}, self.test_environ)
-        (output_objects, status) = result
+        result = realmain(TEST_USER_DN, payload, self.test_environ)
+        output_objects, status = result
         self.assertEqual(status, returnvalues.OK)
 
+        # We don't expect any error message here
+        error_objects = filter_output_objects(
+            output_objects, with_object_type="error_text"
+        )
+        self.assertEqual(len(error_objects), 0)
+
         text_objects = filter_output_objects(
-            output_objects, with_object_type="text")
+            output_objects, with_object_type="text"
+        )
         self.assertEqual(len(text_objects), 1)
         self.assertIn("text", text_objects[0])
         text_object = text_objects[0]["text"]
@@ -74,7 +85,7 @@ class MigSharedFunctionalityDataTransfer(MigTestCase):
         payload = {"action": ["show"]}
         self.configuration.site_enable_transfers = True
 
-        (output_objects, status) = submain(
+        output_objects, status = submain(
             self.configuration,
             self.logger,
             client_id=TEST_USER_DN,
@@ -83,20 +94,29 @@ class MigSharedFunctionalityDataTransfer(MigTestCase):
         )
         self.assertEqual(status, returnvalues.OK)
 
+        # We don't expect any error messages here
+        error_objects = filter_output_objects(
+            output_objects, with_object_type="error_text"
+        )
+        self.assertEqual(len(error_objects), 0)
+
         # We don't expect any text messages here
         text_objects = filter_output_objects(
-            output_objects, with_object_type="text")
+            output_objects, with_object_type="text"
+        )
         self.assertEqual(len(text_objects), 0)
 
     def test_deltransfer_without_transfer_id(self):
         non_existing_transfer_id = "non-existing-transfer-id"
-        payload = {"action": ["deltransfer"],
-                   "transfer_id": [non_existing_transfer_id]}
+        payload = {
+            "action": ["deltransfer"],
+            "transfer_id": [non_existing_transfer_id],
+        }
         self.configuration.site_enable_transfers = True
         self.configuration.site_csrf_protection = CSRF_MINIMAL
         self.test_environ["REQUEST_METHOD"] = "post"
 
-        (output_objects, status) = submain(
+        output_objects, status = submain(
             self.configuration,
             self.logger,
             client_id=TEST_USER_DN,
@@ -110,7 +130,8 @@ class MigSharedFunctionalityDataTransfer(MigTestCase):
         )
         self.assertEqual(len(error_text_objects), 1)
         self.assertEqual(
-            error_text_objects[0]["text"], "existing transfer_id is required for delete"
+            error_text_objects[0]["text"],
+            "existing transfer_id is required for delete",
         )
 
     def test_redotransfer_without_transfer_id(self):
@@ -123,7 +144,7 @@ class MigSharedFunctionalityDataTransfer(MigTestCase):
         self.configuration.site_csrf_protection = CSRF_MINIMAL
         self.test_environ["REQUEST_METHOD"] = "post"
 
-        (output_objects, status) = submain(
+        output_objects, status = submain(
             self.configuration,
             self.logger,
             client_id=TEST_USER_DN,

--- a/tests/test_mig_shared_functionality_datatransfer.py
+++ b/tests/test_mig_shared_functionality_datatransfer.py
@@ -106,6 +106,11 @@ class MigSharedFunctionalityDataTransfer(MigTestCase, UserAssertMixin):
         )
         self.assertEqual(len(text_objects), 0)
 
+        # We expect 10 html snippets here
+        html_objects = filter_output_objects(output_objects,
+                                             with_object_type="html_form")
+        self.assertEqual(len(html_objects), 10)
+
     def test_deltransfer_without_transfer_id(self):
         non_existing_transfer_id = "non-existing-transfer-id"
         payload = {

--- a/tests/test_mig_shared_functionality_datatransfer.py
+++ b/tests/test_mig_shared_functionality_datatransfer.py
@@ -3,7 +3,7 @@
 # --- BEGIN_HEADER ---
 #
 # test_mig_shared_functionality_datatransfer - unit test of the corresponding mig module
-# Copyright (C) 2003-2025  The MiG Project by the Science HPC Center at UCPH
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -41,50 +41,29 @@ from tests.support import (
     temppath,
     ensure_dirs_exist,
 )
-
-
-def create_http_environ(configuration):
-    """Small helper that can create a minimum viable environ dict suitable
-    for passing to http-facing code for the supplied configuration.
-    """
-
-    environ = {}
-    environ["MIG_CONF"] = configuration.config_file
-    environ["HTTP_HOST"] = "localhost"
-    environ["PATH_INFO"] = "/"
-    environ["REMOTE_ADDR"] = "127.0.0.1"
-    environ["SCRIPT_URI"] = "".join(
-        ("https://", environ["HTTP_HOST"], environ["PATH_INFO"])
-    )
-    return environ
-
-
-def _only_output_objects(output_objects, with_object_type=None):
-    return [o for o in output_objects if o["object_type"] == with_object_type]
+from tests.support.usersupp import TEST_USER_DN, UserAssertMixin
+from tests.support.wsgisupp import create_http_environ, filter_output_objects
 
 
 class MigSharedFunctionalityDataTransfer(MigTestCase):
     """Wrap unit tests for the corresponding module"""
 
-    TEST_CLIENT_ID = (
-        "/C=DK/ST=NA/L=NA/O=Test Org/OU=NA/CN=Test User/emailAddress=test@example.com"
-    )
-
     def _provide_configuration(self):
         return "testconfig"
 
     def before_each(self):
-        self.test_user_dir = self._provision_test_user(self, self.TEST_CLIENT_ID)
+        self.test_user_dir = self._provision_test_user(self, TEST_USER_DN)
         self.test_environ = create_http_environ(self.configuration)
 
     def test_default_disabled_site_transfer(self):
         self.assertFalse(self.configuration.site_enable_transfers)
 
-        result = realmain(self.TEST_CLIENT_ID, {}, self.test_environ)
+        result = realmain(TEST_USER_DN, {}, self.test_environ)
         (output_objects, status) = result
         self.assertEqual(status, returnvalues.OK)
 
-        text_objects = _only_output_objects(output_objects, with_object_type="text")
+        text_objects = filter_output_objects(
+            output_objects, with_object_type="text")
         self.assertEqual(len(text_objects), 1)
         self.assertIn("text", text_objects[0])
         text_object = text_objects[0]["text"]
@@ -98,19 +77,21 @@ class MigSharedFunctionalityDataTransfer(MigTestCase):
         (output_objects, status) = submain(
             self.configuration,
             self.logger,
-            client_id=self.TEST_CLIENT_ID,
+            client_id=TEST_USER_DN,
             user_arguments_dict=payload,
             environ=self.test_environ,
         )
         self.assertEqual(status, returnvalues.OK)
 
         # We don't expect any text messages here
-        text_objects = _only_output_objects(output_objects, with_object_type="text")
+        text_objects = filter_output_objects(
+            output_objects, with_object_type="text")
         self.assertEqual(len(text_objects), 0)
 
     def test_deltransfer_without_transfer_id(self):
         non_existing_transfer_id = "non-existing-transfer-id"
-        payload = {"action": ["deltransfer"], "transfer_id": [non_existing_transfer_id]}
+        payload = {"action": ["deltransfer"],
+                   "transfer_id": [non_existing_transfer_id]}
         self.configuration.site_enable_transfers = True
         self.configuration.site_csrf_protection = CSRF_MINIMAL
         self.test_environ["REQUEST_METHOD"] = "post"
@@ -118,13 +99,13 @@ class MigSharedFunctionalityDataTransfer(MigTestCase):
         (output_objects, status) = submain(
             self.configuration,
             self.logger,
-            client_id=self.TEST_CLIENT_ID,
+            client_id=TEST_USER_DN,
             user_arguments_dict=payload,
             environ=self.test_environ,
         )
         self.assertEqual(status, returnvalues.CLIENT_ERROR)
 
-        error_text_objects = _only_output_objects(
+        error_text_objects = filter_output_objects(
             output_objects, with_object_type="error_text"
         )
         self.assertEqual(len(error_text_objects), 1)
@@ -145,13 +126,13 @@ class MigSharedFunctionalityDataTransfer(MigTestCase):
         (output_objects, status) = submain(
             self.configuration,
             self.logger,
-            client_id=self.TEST_CLIENT_ID,
+            client_id=TEST_USER_DN,
             user_arguments_dict=payload,
             environ=self.test_environ,
         )
         self.assertEqual(status, returnvalues.CLIENT_ERROR)
 
-        error_text_objects = _only_output_objects(
+        error_text_objects = filter_output_objects(
             output_objects, with_object_type="error_text"
         )
         self.assertEqual(len(error_text_objects), 1)
@@ -161,7 +142,7 @@ class MigSharedFunctionalityDataTransfer(MigTestCase):
         )
 
 
-# TODO, add additional tests that succesfully makes data transfers across a range of protocols
+# TODO: extend tests to cover data transfers across a range of protocols
 
 if __name__ == "__main__":
     testmain()

--- a/tests/test_mig_shared_functionality_docs.py
+++ b/tests/test_mig_shared_functionality_docs.py
@@ -28,6 +28,7 @@
 """Unit tests of the MiG functionality file implementing the docs backend"""
 
 from __future__ import print_function
+
 import os
 
 # Imports required for the unit test wrapping
@@ -35,17 +36,18 @@ import mig.shared.returnvalues as returnvalues
 from mig.shared.base import client_id_dir
 
 # Imports of the code under test
-from mig.shared.functionality.docs import _main as submain, main as realmain
+from mig.shared.functionality.docs import _main as submain
+from mig.shared.functionality.docs import main as realmain
 
 # Imports required for the unit tests themselves
 from tests.support import (
     MigTestCase,
-    testmain,
-    temppath,
     ensure_dirs_exist,
+    temppath,
+    testmain,
 )
 from tests.support.usersupp import TEST_USER_DN, UserAssertMixin
-from tests.support.wsgisupp import create_http_environ, _only_output_objects
+from tests.support.wsgisupp import create_http_environ, filter_output_objects
 
 
 class MigSharedFunctionalityDocs(MigTestCase, UserAssertMixin):
@@ -61,7 +63,7 @@ class MigSharedFunctionalityDocs(MigTestCase, UserAssertMixin):
     def test_show_default_site_docs(self):
         payload = {"show": [""]}
 
-        (output_objects, status) = submain(
+        output_objects, status = submain(
             self.configuration,
             self.logger,
             client_id=TEST_USER_DN,
@@ -71,13 +73,15 @@ class MigSharedFunctionalityDocs(MigTestCase, UserAssertMixin):
         self.assertEqual(status, returnvalues.OK)
 
         # We expect two text messages here
-        text_objects = _only_output_objects(
-            output_objects, with_object_type="text")
+        text_objects = filter_output_objects(
+            output_objects, with_object_type="text"
+        )
         self.assertEqual(len(text_objects), 2)
 
         # We expect 6 html snippets here
-        html_objects = _only_output_objects(output_objects,
-                                            with_object_type="html_form")
+        html_objects = filter_output_objects(
+            output_objects, with_object_type="html_form"
+        )
         self.assertEqual(len(html_objects), 6)
 
 

--- a/tests/test_mig_shared_functionality_docs.py
+++ b/tests/test_mig_shared_functionality_docs.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# --- BEGIN_HEADER ---
+#
+# test_mig_shared_functionality_docs - unit test of the corresponding mig module
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
+#
+# This file is part of MiG.
+#
+# MiG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# MiG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+#
+# --- END_HEADER ---
+#
+
+"""Unit tests of the MiG functionality file implementing the docs backend"""
+
+from __future__ import print_function
+import os
+
+# Imports required for the unit test wrapping
+import mig.shared.returnvalues as returnvalues
+from mig.shared.base import client_id_dir
+
+# Imports of the code under test
+from mig.shared.functionality.docs import _main as submain, main as realmain
+
+# Imports required for the unit tests themselves
+from tests.support import (
+    MigTestCase,
+    testmain,
+    temppath,
+    ensure_dirs_exist,
+)
+from tests.support.usersupp import TEST_USER_DN, UserAssertMixin
+from tests.support.wsgisupp import create_http_environ, _only_output_objects
+
+
+class MigSharedFunctionalityDocs(MigTestCase, UserAssertMixin):
+    """Wrap unit tests for the corresponding module"""
+
+    def _provide_configuration(self):
+        return "testconfig"
+
+    def before_each(self):
+        self.test_user_dir = self._provision_test_user(self, TEST_USER_DN)
+        self.test_environ = create_http_environ(self.configuration)
+
+    def test_show_default_site_docs(self):
+        payload = {"show": [""]}
+
+        (output_objects, status) = submain(
+            self.configuration,
+            self.logger,
+            client_id=TEST_USER_DN,
+            user_arguments_dict=payload,
+            environ=self.test_environ,
+        )
+        self.assertEqual(status, returnvalues.OK)
+
+        # We expect two text messages here
+        text_objects = _only_output_objects(
+            output_objects, with_object_type="text")
+        self.assertEqual(len(text_objects), 2)
+
+        # We expect 6 html snippets here
+        html_objects = _only_output_objects(output_objects,
+                                            with_object_type="html_form")
+        self.assertEqual(len(html_objects), 6)
+
+
+# TODO: add additional tests to cover other uses
+
+if __name__ == "__main__":
+    testmain()

--- a/tests/test_mig_shared_functionality_fileman.py
+++ b/tests/test_mig_shared_functionality_fileman.py
@@ -2,7 +2,7 @@
 #
 # --- BEGIN_HEADER ---
 #
-# test_mig_shared_functionality_docs - unit test of the corresponding mig module
+# test_mig_shared_functionality_fileman - unit test of the corresponding mig module
 # Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
@@ -25,7 +25,7 @@
 # --- END_HEADER ---
 #
 
-"""Unit tests of the MiG functionality file implementing the docs backend"""
+"""Unit tests of the MiG functionality file implementing the fileman backend"""
 
 from __future__ import print_function
 
@@ -33,7 +33,7 @@ from __future__ import print_function
 import mig.shared.returnvalues as returnvalues
 
 # Imports of the code under test
-from mig.shared.functionality.docs import _main as submain
+from mig.shared.functionality.fileman import main as realmain
 
 # Imports required for the unit tests themselves
 from tests.support import (
@@ -44,7 +44,7 @@ from tests.support.usersupp import TEST_USER_DN, UserAssertMixin
 from tests.support.wsgisupp import create_http_environ, filter_output_objects
 
 
-class MigSharedFunctionalityDocs(MigTestCase, UserAssertMixin):
+class MigSharedFunctionalityFileman(MigTestCase, UserAssertMixin):
     """Wrap unit tests for the corresponding module"""
 
     def _provide_configuration(self):
@@ -53,19 +53,13 @@ class MigSharedFunctionalityDocs(MigTestCase, UserAssertMixin):
     def before_each(self):
         self.test_user_dir = self._provision_test_user(self, TEST_USER_DN)
         self.test_environ = create_http_environ(
-            self.configuration, "wsgi-bin/docs.py"
+            self.configuration, "wsgi-bin/fileman.py"
         )
 
-    def test_show_default_site_docs(self):
-        payload = {"show": [""]}
-
-        output_objects, status = submain(
-            self.configuration,
-            self.logger,
-            client_id=TEST_USER_DN,
-            user_arguments_dict=payload,
-            environ=self.test_environ,
-        )
+    def test_show_default_user_fileman(self):
+        payload = {}
+        result = realmain(TEST_USER_DN, payload, self.test_environ)
+        output_objects, status = result
         self.assertEqual(status, returnvalues.OK)
 
         # We don't expect any error messages here
@@ -74,17 +68,17 @@ class MigSharedFunctionalityDocs(MigTestCase, UserAssertMixin):
         )
         self.assertEqual(len(error_objects), 0)
 
-        # We expect two text messages here
+        # We don't expect any text messages here
         text_objects = filter_output_objects(
             output_objects, with_object_type="text"
         )
-        self.assertEqual(len(text_objects), 2)
+        self.assertEqual(len(text_objects), 0)
 
-        # We expect 6 html snippets here
+        # We expect one html snippet here
         html_objects = filter_output_objects(
             output_objects, with_object_type="html_form"
         )
-        self.assertEqual(len(html_objects), 6)
+        self.assertEqual(len(html_objects), 1)
 
 
 # TODO: add additional tests to cover other uses

--- a/tests/test_mig_shared_functionality_resedit.py
+++ b/tests/test_mig_shared_functionality_resedit.py
@@ -2,7 +2,7 @@
 #
 # --- BEGIN_HEADER ---
 #
-# test_mig_shared_functionality_docs - unit test of the corresponding mig module
+# test_mig_shared_functionality_resedit - unit test of the corresponding mig module
 # Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
@@ -25,7 +25,7 @@
 # --- END_HEADER ---
 #
 
-"""Unit tests of the MiG functionality file implementing the docs backend"""
+"""Unit tests of the MiG functionality file implementing the resedit backend"""
 
 from __future__ import print_function
 
@@ -33,31 +33,67 @@ from __future__ import print_function
 import mig.shared.returnvalues as returnvalues
 
 # Imports of the code under test
-from mig.shared.functionality.docs import _main as submain
+from mig.shared.functionality.resedit import _main as submain
+from mig.shared.functionality.resedit import main as realmain
 
 # Imports required for the unit tests themselves
 from tests.support import (
     MigTestCase,
+    ensure_dirs_exist,
     testmain,
 )
 from tests.support.usersupp import TEST_USER_DN, UserAssertMixin
 from tests.support.wsgisupp import create_http_environ, filter_output_objects
 
 
-class MigSharedFunctionalityDocs(MigTestCase, UserAssertMixin):
+class MigSharedFunctionalityResedit(MigTestCase, UserAssertMixin):
     """Wrap unit tests for the corresponding module"""
 
     def _provide_configuration(self):
         return "testconfig"
 
     def before_each(self):
+        ensure_dirs_exist(self.configuration.resource_home)
+        ensure_dirs_exist(self.configuration.vgrid_home)
+        ensure_dirs_exist(self.configuration.mig_system_files)
         self.test_user_dir = self._provision_test_user(self, TEST_USER_DN)
         self.test_environ = create_http_environ(
-            self.configuration, "wsgi-bin/docs.py"
+            self.configuration, "wsgi-bin/resedit.py"
         )
 
-    def test_show_default_site_docs(self):
-        payload = {"show": [""]}
+    def test_resedit_disabled_site_resources(self):
+        self.assertFalse(self.configuration.site_enable_resources)
+        payload = {}
+
+        result = realmain(TEST_USER_DN, payload, self.test_environ)
+        output_objects, status = result
+        self.assertEqual(status, returnvalues.SYSTEM_ERROR)
+
+        # We expect one error message here
+        error_objects = filter_output_objects(
+            output_objects, with_object_type="error_text"
+        )
+        self.assertEqual(len(error_objects), 1)
+        self.assertIn("text", error_objects[0])
+        text_object = error_objects[0]["text"]
+        expected_response_msg = "Resources are not enabled on this system"
+        self.assertIn(expected_response_msg, text_object)
+
+        # We don't expect any text message here
+        text_objects = filter_output_objects(
+            output_objects, with_object_type="text"
+        )
+        self.assertEqual(len(text_objects), 0)
+
+        # We don't expect any html snippets here
+        html_objects = filter_output_objects(
+            output_objects, with_object_type="html_form"
+        )
+        self.assertEqual(len(html_objects), 0)
+
+    def test_show_default_user_resedit(self):
+        self.configuration.site_enable_resources = True
+        payload = {}
 
         output_objects, status = submain(
             self.configuration,
@@ -74,17 +110,17 @@ class MigSharedFunctionalityDocs(MigTestCase, UserAssertMixin):
         )
         self.assertEqual(len(error_objects), 0)
 
-        # We expect two text messages here
+        # We expect four text messages here
         text_objects = filter_output_objects(
             output_objects, with_object_type="text"
         )
-        self.assertEqual(len(text_objects), 2)
+        self.assertEqual(len(text_objects), 4)
 
-        # We expect 6 html snippets here
+        # We expect 54 html snippets here
         html_objects = filter_output_objects(
             output_objects, with_object_type="html_form"
         )
-        self.assertEqual(len(html_objects), 6)
+        self.assertEqual(len(html_objects), 54)
 
 
 # TODO: add additional tests to cover other uses

--- a/tests/test_mig_shared_functionality_vgridworkflows.py
+++ b/tests/test_mig_shared_functionality_vgridworkflows.py
@@ -2,7 +2,7 @@
 #
 # --- BEGIN_HEADER ---
 #
-# test_mig_shared_functionality_docs - unit test of the corresponding mig module
+# test_mig_shared_functionality_vgridworkflows - unit test of the corresponding mig module
 # Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
@@ -25,7 +25,7 @@
 # --- END_HEADER ---
 #
 
-"""Unit tests of the MiG functionality file implementing the docs backend"""
+"""Unit tests of the MiG functionality file implementing the vgridworkflows backend"""
 
 from __future__ import print_function
 
@@ -33,31 +33,67 @@ from __future__ import print_function
 import mig.shared.returnvalues as returnvalues
 
 # Imports of the code under test
-from mig.shared.functionality.docs import _main as submain
+from mig.shared.functionality.vgridworkflows import _main as submain
+from mig.shared.functionality.vgridworkflows import main as realmain
 
 # Imports required for the unit tests themselves
 from tests.support import (
     MigTestCase,
+    ensure_dirs_exist,
     testmain,
 )
 from tests.support.usersupp import TEST_USER_DN, UserAssertMixin
 from tests.support.wsgisupp import create_http_environ, filter_output_objects
 
 
-class MigSharedFunctionalityDocs(MigTestCase, UserAssertMixin):
+class MigSharedFunctionalityVgridworkflows(MigTestCase, UserAssertMixin):
     """Wrap unit tests for the corresponding module"""
 
     def _provide_configuration(self):
         return "testconfig"
 
     def before_each(self):
+        ensure_dirs_exist(self.configuration.resource_home)
+        ensure_dirs_exist(self.configuration.vgrid_home)
+        ensure_dirs_exist(self.configuration.mig_system_files)
         self.test_user_dir = self._provision_test_user(self, TEST_USER_DN)
         self.test_environ = create_http_environ(
-            self.configuration, "wsgi-bin/docs.py"
+            self.configuration, "wsgi-bin/vgridworkflows.py"
         )
 
-    def test_show_default_site_docs(self):
-        payload = {"show": [""]}
+    def test_vgridworkflows_disabled_site_workflows(self):
+        self.assertFalse(self.configuration.site_enable_workflows)
+        payload = {"vgrid_name": ["Generic"]}
+
+        result = realmain(TEST_USER_DN, payload, self.test_environ)
+        output_objects, status = result
+        self.assertEqual(status, returnvalues.SYSTEM_ERROR)
+
+        # We expect one error message here
+        error_objects = filter_output_objects(
+            output_objects, with_object_type="error_text"
+        )
+        self.assertEqual(len(error_objects), 1)
+        self.assertIn("text", error_objects[0])
+        text_object = error_objects[0]["text"]
+        expected_response_msg = "Workflows are not enabled on this system"
+        self.assertIn(expected_response_msg, text_object)
+
+        # We don't expect any text message here
+        text_objects = filter_output_objects(
+            output_objects, with_object_type="text"
+        )
+        self.assertEqual(len(text_objects), 0)
+
+        # We don't expect any html snippets here
+        html_objects = filter_output_objects(
+            output_objects, with_object_type="html_form"
+        )
+        self.assertEqual(len(html_objects), 0)
+
+    def test_show_default_user_vgridworkflows(self):
+        self.configuration.site_enable_workflows = True
+        payload = {"vgrid_name": ["Generic"]}
 
         output_objects, status = submain(
             self.configuration,
@@ -74,17 +110,17 @@ class MigSharedFunctionalityDocs(MigTestCase, UserAssertMixin):
         )
         self.assertEqual(len(error_objects), 0)
 
-        # We expect two text messages here
+        # We don't expect any text messages here
         text_objects = filter_output_objects(
             output_objects, with_object_type="text"
         )
-        self.assertEqual(len(text_objects), 2)
+        self.assertEqual(len(text_objects), 0)
 
-        # We expect 6 html snippets here
+        # We expect 11 html snippets here
         html_objects = filter_output_objects(
             output_objects, with_object_type="html_form"
         )
-        self.assertEqual(len(html_objects), 6)
+        self.assertEqual(len(html_objects), 11)
 
 
 # TODO: add additional tests to cover other uses


### PR DESCRIPTION
Simplify and add additional simple functionality backend unit tests mainly in relation to #395 verification.

Some tweaks were needed in functionality backends to allow reuse of the existing datatransfer unit tests.
