### PR TITLE
Add new `make secscan` target to security scan our python code with `bandit`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,23 @@ else
 	REQS_PATH = ./requirements.txt
 endif
 
+.PHONY: info
 info:
 	@echo "Welcome to MiGrid"
 	@echo
 	@echo "The following should help you get started:"
 	@echo
-	@echo "'make test'      - run the test suite (default python 3)"
-	@echo "'make test PYVER=X.Y' - run the test suite (python version X.Y)"
-	@echo "'make unittest'  - execute tests locally for development"
+	@echo "'make test'            - run the test suite (default python 3)"
+	@echo "'make test PYVER=X.Y'  - run the test suite (python version X.Y)"
+	@echo "'make unittest'        - execute tests locally for development"
+	@echo "'make lint-python'     - lint python code (in LINT_ENFORCE_DIRS)"
+	@echo "'make secscan-python'  - security scan python code (in LINT_ENFORCE_DIRS)"
+	@echo "'make format-python'   - format python code (in LINT_ENFORCE_DIRS)"
+	@echo "'make clean'           - clean up cache and other temporary files"
+	@echo "'make distclean'       - clean up completely to pristine state"
+
+.PHONY: help
+help: info
 
 .PHONY: fmt
 fmt:
@@ -42,7 +51,7 @@ endif
 
 # NOTE: black and isort use pyproject.toml to temporarily exclude a few paths
 .PHONY: format-python
-format-python:
+format-python: dependencies
 	@$(LOCAL_PYTHON_BIN) -m black $(LINT_ENFORCE_DIRS)
 	@$(LOCAL_PYTHON_BIN) -m isort $(LINT_ENFORCE_DIRS)
 
@@ -57,15 +66,28 @@ endif
 
 # NOTE: black and isort use pyproject.toml to temporarily exclude a few paths
 .PHONY: style-check-python
-style-check-python:
+style-check-python: dependencies
 	@$(LOCAL_PYTHON_BIN) -m black $(LINT_ENFORCE_DIRS) --check
 	@$(LOCAL_PYTHON_BIN) -m isort $(LINT_ENFORCE_DIRS) --check-only
 
 # NOTE: pylint and ruff use pyproject.toml to temporarily exclude a few paths
 .PHONY: lint-python
-lint-python:
+lint-python: dependencies
 	@$(LOCAL_PYTHON_BIN) -m pylint $(LINT_ENFORCE_DIRS) --errors-only
 	@$(LOCAL_PYTHON_BIN) -m ruff check $(LINT_ENFORCE_DIRS)
+
+.PHONY: secscan
+secscan:
+ifneq ($(MIG_ENV),'local')
+	@echo "unavailable outside local development environment"
+	@exit 1
+endif
+	@make secscan-python
+
+# NOTE: bandit uses pyproject.toml to temporarily exclude a few paths
+.PHONY: secscan-python
+secscan-python: dependencies
+	@$(LOCAL_PYTHON_BIN) -m bandit -r $(LINT_ENFORCE_DIRS)
 
 .PHONY: clean
 clean:

--- a/local-requirements.txt
+++ b/local-requirements.txt
@@ -6,6 +6,7 @@ black
 isort
 pylint
 ruff
+bandit
 # We need paramiko for the ssh unit tests
 # IMPORTANT: there's a known security issue (CVE-2023-48795) in paramiko<3.4.0
 #            as explained on https://www.paramiko.org/changelog.html#3.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,6 @@ extend-exclude = [
     "sbin/grid_sftp.py",
     "sbin/grid_webdavs.py"
 ]
+
+[tool.bandit]
+exclude_dirs = [".git/", "tests/data/", "tests/fixture/"]


### PR DESCRIPTION
Add new `make secscan` target with `make python-secscan` alias to enable easy inline security scanning of our python code.
Reuses the existing lint model with scanning of files in `LINT_ENFORCE_DIRS`. Example use to scan all code in the `mig/lib/` folder:
```
make secscan-python LINT_ENFORCE_DIRS=mig/lib/
```

Might be used in conjunction with or in a future replacement for #394.

Updated the Makefile inline help and polished some details to make sure local dependencies are automatically installed on first use.