### PR TITLE
Install procps package in CI Action to assure pgrep availabilty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,9 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
-      - name: Set up Python 3 and make with DNF
+      - name: Set up Python 3, make and procps (for pgrep) with DNF
         run: |
-          dnf install -y python3 python3-pip make
+          dnf install -y python3 python3-pip make procps-ng
       - name: Setup environment
         run: |
           make dependencies
@@ -104,9 +104,9 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
-      - name: Set up Python 3 and make with DNF
+      - name: Set up Python 3, make and procps (for pgrep) with DNF
         run: |
-          dnf install -y python3 python3-pip make
+          dnf install -y python3 python3-pip make procps-ng
       - name: Setup environment
         run: |
           make dependencies


### PR DESCRIPTION
Install `procps` package in CI Action to make sure the use of `pgrep` e.g. from `migadmin.py` won't fail with:
`No such file or directory: 'pgrep'`

like it did in
https://github.com/ucphhpc/migrid-sync/actions/runs/30102168256/job/89510679494

Don't forget to enable the failing unit test again afterwards.