### PR TITLE
Refuse triggers on default VGrid ('Generic')

### DIFF
--- a/mig/shared/functionality/addvgridtrigger.py
+++ b/mig/shared/functionality/addvgridtrigger.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # addvgridtrigger - add vgrid trigger
-# Copyright (C) 2003-2020  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -26,6 +26,7 @@
 #
 
 """Add a trigger to a given vgrid"""
+
 from __future__ import absolute_import
 
 import os
@@ -40,9 +41,9 @@ from mig.shared.handlers import safe_handler, get_csrf_limit
 from mig.shared.init import initialize_main_variables, find_entry
 from mig.shared.safeinput import valid_path_pattern
 from mig.shared.validstring import valid_user_path
-from mig.shared.vgrid import init_vgrid_script_add_rem, vgrid_is_trigger, \
-    vgrid_is_trigger_owner, vgrid_list_subvgrids, vgrid_add_triggers, \
-    vgrid_triggers
+from mig.shared.vgrid import init_vgrid_script_add_rem, vgrid_is_default, \
+    vgrid_is_owner_or_member, vgrid_is_trigger, vgrid_is_trigger_owner, \
+    vgrid_list_subvgrids, vgrid_add_triggers, vgrid_triggers
 from mig.shared import returnvalues
 
 
@@ -161,6 +162,14 @@ CSRF-filtered POST requests to prevent unintended updates'''
 
         output_objects.append({'object_type': 'warning', 'text': msg})
 
+    if vgrid_is_default(vgrid_name) or \
+        not vgrid_is_owner_or_member(vgrid_name, client_id,
+                                     configuration):
+        output_objects.append({'object_type': 'error_text',
+                               'text': '''You must be an active owner or member
+of %s %s to access the workflows.''' % (vgrid_name, label)})
+        return (output_objects, returnvalues.CLIENT_ERROR)
+
     # if we get here user is either vgrid owner or allowed to add rule
 
     # don't add if already in vgrid or parent vgrid - but update if owner
@@ -196,7 +205,7 @@ sub-%(vgrid_label)s and try again''' % {'rule_id': rule_id,
                                         'vgrid_label': label}})
             return (output_objects, returnvalues.CLIENT_ERROR)
 
-    if not action in valid_trigger_actions:
+    if action not in valid_trigger_actions:
         output_objects.append(
             {'object_type': 'error_text', 'text':
              "invalid action value %s" % action})
@@ -205,7 +214,7 @@ sub-%(vgrid_label)s and try again''' % {'rule_id': rule_id,
     if keyword_all in changes:
         changes = valid_trigger_changes
     for change in changes:
-        if not change in valid_trigger_changes:
+        if change not in valid_trigger_changes:
             output_objects.append(
                 {'object_type': 'error_text', 'text':
                  "found invalid change value %s" % change})

--- a/mig/shared/functionality/rmvgridtrigger.py
+++ b/mig/shared/functionality/rmvgridtrigger.py
@@ -34,8 +34,8 @@ from mig.shared import returnvalues
 from mig.shared.functional import validate_input_and_cert, REJECT_UNSET
 from mig.shared.handlers import safe_handler, get_csrf_limit
 from mig.shared.init import initialize_main_variables, find_entry
-from mig.shared.vgrid import init_vgrid_script_add_rem, vgrid_is_owner, \
-    vgrid_is_trigger, vgrid_remove_triggers
+from mig.shared.vgrid import init_vgrid_script_add_rem, vgrid_is_default, \
+    vgrid_is_owner_or_member, vgrid_is_trigger, vgrid_remove_triggers
 
 
 def signature():
@@ -96,6 +96,14 @@ CSRF-filtered POST requests to prevent unintended updates'''
         # In case of warnings, msg is non-empty while ret_val remains True
 
         output_objects.append({'object_type': 'warning', 'text': msg})
+
+    if vgrid_is_default(vgrid_name) or \
+        not vgrid_is_owner_or_member(vgrid_name, client_id,
+                                     configuration):
+        output_objects.append({'object_type': 'error_text',
+                               'text': '''You must be an active owner or member
+of %s %s to access the workflows.''' % (vgrid_name, label)})
+        return (output_objects, returnvalues.CLIENT_ERROR)
 
     # if we get here user is either vgrid owner or has rule ownership
 

--- a/mig/shared/functionality/vgridworkflows.py
+++ b/mig/shared/functionality/vgridworkflows.py
@@ -136,9 +136,8 @@ def main(client_id, user_arguments_dict):
         not vgrid_is_owner_or_member(vgrid_name, client_id,
                                      configuration):
         output_objects.append({'object_type': 'error_text',
-                               'text': '''You must be an owner or member of %s vgrid to
-access the workflows.'''
-                               % vgrid_name})
+                               'text': '''You must be an owner or member of %s
+%s to access the workflows.''' % (vgrid_name, label)})
         return (output_objects, returnvalues.CLIENT_ERROR)
 
     if operation not in allowed_operations:

--- a/mig/shared/functionality/vgridworkflows.py
+++ b/mig/shared/functionality/vgridworkflows.py
@@ -54,8 +54,8 @@ from mig.shared.functional import validate_input_and_cert, REJECT_UNSET
 from mig.shared.htmlgen import man_base_js, man_base_html
 from mig.shared.init import initialize_main_variables, find_entry
 from mig.shared.parseflags import verbose
-from mig.shared.vgrid import vgrid_add_remove_table, vgrid_is_owner_or_member, \
-    vgrid_triggers, vgrid_set_triggers
+from mig.shared.vgrid import vgrid_add_remove_table, vgrid_is_default, \
+    vgrid_is_owner_or_member
 
 default_pager_entries = 20
 
@@ -132,15 +132,16 @@ def main(client_id, user_arguments_dict):
     operation = accepted['operation'][-1]
     flags = ''.join(accepted['flags'][-1])
 
-    if not vgrid_is_owner_or_member(vgrid_name, client_id,
-                                    configuration):
+    if vgrid_is_default(vgrid_name) or \
+        not vgrid_is_owner_or_member(vgrid_name, client_id,
+                                     configuration):
         output_objects.append({'object_type': 'error_text',
                                'text': '''You must be an owner or member of %s vgrid to
 access the workflows.'''
                                % vgrid_name})
         return (output_objects, returnvalues.CLIENT_ERROR)
 
-    if not operation in allowed_operations:
+    if operation not in allowed_operations:
         output_objects.append({'object_type': 'error_text', 'text':
                                '''Operation must be one of %s.''' %
                                ', '.join(allowed_operations)})


### PR DESCRIPTION
Refuse to operate on default VGrid ('Generic') in `vgridworkflows` and underlying `addvgridtrigger` and `rmvgridtrigger`. All users are considered members but workflows or plain triggers don't make sense there.

Fixed a few lint warnings while at it.