### PR TITLE
Support for passing a new ID or an updated user dict file to edituser

### DIFF
--- a/mig/server/createuser.py
+++ b/mig/server/createuser.py
@@ -70,10 +70,14 @@ def usage(name='createuser.py'):
 Usage:
 %(name)s [OPTIONS] -u USER_FILE
 or
-%(name)s [OPTIONS] -r -i USER_ID
+%(name)s [OPTIONS] [FULL_NAME ORGANIZATION STATE COUNTRY EMAIL COMMENT PASSWORD]
+to create a new user account non-interactively
 or
-%(name)s [OPTIONS] [FULL_NAME ORGANIZATION STATE COUNTRY \
-    EMAIL COMMENT PASSWORD]
+%(name)s [OPTIONS]
+to create a new user account interactively
+or
+%(name)s [OPTIONS] -r -i USER_ID
+to renew an existing user, optionally with non-ID data changes.
 Where OPTIONS may be one or more of:
    -a AUTH_TYPE        Prepare account for AUTH_TYPE login (expire, password)
    -c CONF_FILE        Use CONF_FILE as server configuration
@@ -185,11 +189,9 @@ if '__main__' == __name__:
 
     if verbose:
         if conf_path:
-            if verbose:
-                print('using configuration in %s' % conf_path)
+            print('using configuration in %s' % conf_path)
         else:
-            if verbose:
-                print('using configuration from MIG_CONF (or default)')
+            print('using configuration from MIG_CONF (or default)')
 
     configuration = get_configuration_object(config_file=conf_path)
     logger = configuration.logger

--- a/mig/server/createuser.py
+++ b/mig/server/createuser.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # createuser - Create or renew a MiG user with all the necessary directories
-# Copyright (C) 2003-2023  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,12 +20,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
 
-"""Add or renew MiG user in user DB and in file system"""
+"""Add or renew MiG user in user database and file system"""
 
 from __future__ import print_function
 from __future__ import absolute_import
@@ -50,7 +51,7 @@ from mig.shared.useradm import init_user_adm, create_user, load_user_dict
 from mig.shared.userdb import default_db_path
 
 cert_warn = """
-Please note that you *must* use either the -i CERT_DN option to createuser
+Please note that you *must* use either the -i USER_ID option to createuser
 or use importuser instead if you want to use other certificate DN formats
 than the one expected by MiG (/C=.*/ST=.*/L=NA/O=.*/CN=.*/emailAddress=.*)
 Otherwise those users will NOT be able to access their MiG interfaces!
@@ -67,12 +68,12 @@ def usage(name='createuser.py'):
     print("""Create user in the MiG user database and file system.
 %(cert_warn)s
 Usage:
-%(name)s [OPTIONS] [FULL_NAME ORGANIZATION STATE COUNTRY \
-    EMAIL COMMENT PASSWORD]
-or
 %(name)s [OPTIONS] -u USER_FILE
 or
-%(name)s [OPTIONS] -i CERT_DN
+%(name)s [OPTIONS] -r -i USER_ID
+or
+%(name)s [OPTIONS] [FULL_NAME ORGANIZATION STATE COUNTRY \
+    EMAIL COMMENT PASSWORD]
 Where OPTIONS may be one or more of:
    -a AUTH_TYPE        Prepare account for AUTH_TYPE login (expire, password)
    -c CONF_FILE        Use CONF_FILE as server configuration
@@ -80,7 +81,7 @@ Where OPTIONS may be one or more of:
    -e EXPIRE           Set user account expiration to EXPIRE (epoch)
    -f                  Force operations to continue past errors
    -h                  Show this help
-   -i CERT_DN          Use CERT_DN as user ID despite what other fields suggest
+   -i USER_ID          Use USER_ID as user ID despite what other fields suggest
    -o SHORT_ID         Add SHORT_ID as OpenID alias for user
    -p PEER_PATTERN     Verify in Peers of existing account matching PEER_PATTERN
    -r                  Renew user account with existing values
@@ -167,7 +168,7 @@ if '__main__' == __name__:
             override_fields['role'] = role
         elif opt == '-s':
             # Translate slack days into seconds as
-            slack_secs = int(float(val)*24*3600)
+            slack_secs = int(float(val) * 24 * 3600)
         elif opt == '-u':
             user_file = val
             # NOTE: hashing should already be handled explicitly
@@ -216,9 +217,7 @@ if '__main__' == __name__:
 
     raw_user = {}
     if args:
-        #logger.debug('createuser called with args: %s' % args)
-        # logger.debug('createuser using default %s and fs %s encoding' %
-        #             (sys.getdefaultencoding(), sys.getfilesystemencoding()))
+        # logger.debug('createuser called with args: %s' % args)
         try:
             raw_user['full_name'] = args[0]
             raw_user['organization'] = args[1]
@@ -245,7 +244,7 @@ if '__main__' == __name__:
             usage()
             sys.exit(1)
     elif default_renew and user_id:
-        #logger.debug('createuser called with user_id: %s' % [user_id])
+        # logger.debug('createuser called with user_id: %s' % [user_id])
         saved = load_user_dict(logger, user_id, db_path, verbose)
         if not saved:
             print('Error: no such user in user db: %s' % user_id)
@@ -254,6 +253,7 @@ if '__main__' == __name__:
         user_dict.update(saved)
         del user_dict['expire']
     elif not configuration.site_enable_gdp:
+        # NOTE: We do not allow interactive user management on GDP systems
         if verbose:
             print('''Entering interactive mode
 %s''' % cert_warn)
@@ -293,7 +293,7 @@ if '__main__' == __name__:
     elif 'distinguished_name' not in user_dict:
         fill_distinguished_name(user_dict)
 
-    #logger.debug('createuser with ID: %s' % [user_dict['distinguished_name']])
+    # logger.debug('createuser with ID: %(distinguished_name)s' % user_dict)
     fill_user(user_dict)
 
     force_native_str_rec(user_dict)
@@ -312,25 +312,25 @@ if '__main__' == __name__:
     # Now all user fields are set and we can begin adding the user
 
     if verbose:
-        print('using user dict: %s' % user_dict)
+        print('Creating DB entry and dirs using dict: %s' % user_dict)
     try:
-        create_user(user_dict, configuration, db_path, force, verbose,
-                    ask_renew, default_renew, verify_peer=peer_pattern,
-                    peer_expire_slack=slack_secs, ask_change_pw=ask_change_pw)
+        user = create_user(user_dict, configuration, db_path, force, verbose,
+                           ask_renew, default_renew, verify_peer=peer_pattern,
+                           peer_expire_slack=slack_secs,
+                           ask_change_pw=ask_change_pw)
         if configuration.site_enable_gdp:
             (success_here, msg) = ensure_gdp_user(configuration,
                                                   "127.0.0.1",
                                                   user_dict['distinguished_name'])
             if not success_here:
                 raise Exception("Failed to ensure GDP user: %s" % msg)
-
     except Exception as exc:
         print("Error creating user: %s" % exc)
         import traceback
         logger.warning("Error creating user: %s" % traceback.format_exc())
         sys.exit(1)
-    print('Created or updated %s in user database and in file system' %
-          user_dict['distinguished_name'])
+    print('Created or updated %s in user database and file system' %
+          user['distinguished_name'])
     if user_file:
         if verbose:
             print('Cleaning up tmp file: %s' % user_file)

--- a/mig/server/edituser.py
+++ b/mig/server/edituser.py
@@ -171,7 +171,7 @@ if '__main__' == __name__:
         raw_user = distinguished_name_to_user(new_id)
     elif user_file:
         try:
-            user_dict = load(user_file)
+            raw_user = load(user_file)
         except Exception as err:
             print('Error in %r user extraction: %s' % (user_file, err))
             usage()

--- a/mig/server/edituser.py
+++ b/mig/server/edituser.py
@@ -229,7 +229,7 @@ if '__main__' == __name__:
     except Exception as exc:
         print("Error editing user: %s" % exc)
         import traceback
-        logger.warning("Error creating user: %s" % traceback.format_exc())
+        logger.warning("Error editing user: %s" % traceback.format_exc())
         sys.exit(1)
     print('%s\nchanged to\n%s\nin user database and file system' %
           (user_id, user['distinguished_name']))

--- a/mig/server/edituser.py
+++ b/mig/server/edituser.py
@@ -69,7 +69,7 @@ Where OPTIONS may be one or more of:
    -o SHORT_ID         Change OpenID alias of user to SHORT_ID
    -r FIELDS           Remove FIELDS for user in user DB
    -R ROLES            Change user affiliation to ROLES
-   -u USER_FILE      Update to new user information from pickle file
+   -u USER_FILE        Update to new user information from pickle file
    -v                  Verbose output
 """ % {'name': name})
 
@@ -167,19 +167,13 @@ if '__main__' == __name__:
                   % len(args))
             usage()
             sys.exit(1)
-        # Force user ID fields to canonical form for consistency
-        # Title name, lowercase email, uppercase country and state, etc.
-        user_dict = canonical_user(configuration, raw_user, raw_user.keys())
     elif new_id:
         raw_user = distinguished_name_to_user(new_id)
-        # Force user ID fields to canonical form for consistency
-        # Title name, lowercase email, uppercase country and state, etc.
-        user_dict = canonical_user(configuration, raw_user, raw_user.keys())
     elif user_file:
         try:
             user_dict = load(user_file)
         except Exception as err:
-            print('Error in user name extraction: %s' % err)
+            print('Error in %r user extraction: %s' % (user_file, err))
             usage()
             sys.exit(1)
     elif not configuration.site_enable_gdp:
@@ -192,15 +186,15 @@ if '__main__' == __name__:
         raw_user['state'] = input('State: ')
         raw_user['country'] = input('2-letter Country Code: ')
         raw_user['email'] = input('Email: ')
-        # Force user ID fields to canonical form for consistency
-        # Title name, lowercase email, uppercase country and state, etc.
-        user_dict = canonical_user(configuration, raw_user, raw_user.keys())
     else:
         print("Error: Missing one or more of the arguments: "
               + "[FULL_NAME] [ORGANIZATION] [STATE] [COUNTRY] "
               + "[EMAIL]")
         sys.exit(1)
 
+    # Force user ID fields to canonical form for consistency
+    # Title name, lowercase email, uppercase country and state, etc.
+    user_dict = canonical_user(configuration, raw_user, raw_user.keys())
     fill_distinguished_name(user_dict)
 
     # logger.debug('edituser to new ID: %(distinguished_name)s' % user_dict)

--- a/mig/server/edituser.py
+++ b/mig/server/edituser.py
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # edituser - Edit a MiG user
-# Copyright (C) 2003-2024  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -20,7 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
 #
 # -- END_HEADER ---
 #
@@ -35,9 +36,13 @@ import getopt
 import os
 import sys
 
-from mig.shared.base import is_gdp_user
+from mig.shared.base import fill_distinguished_name, fill_user, canonical_user, \
+    force_native_str_rec, is_gdp_user
 from mig.shared.conf import get_configuration_object
+from mig.shared.defaults import keyword_auto
+from mig.shared.serial import load
 from mig.shared.useradm import init_user_adm, edit_user
+from mig.shared.userdb import default_db_path
 
 
 def usage(name='edituser.py'):
@@ -47,35 +52,39 @@ def usage(name='edituser.py'):
 user ID changes.
 NOTE: It's usually easier to use editmeta.py for non-ID field changes.
 Usage:
+%(name)s [OPTIONS] -i USER_ID -u USER_FILE
+or
+%(name)s [OPTIONS] -i USER_ID -n NEW_ID
+or
 %(name)s [OPTIONS] -i USER_ID [FULL_NAME] [ORGANIZATION] [STATE] [COUNTRY] \
-    [EMAIL] [COMMENT] [PASSWORD]
+    [EMAIL]
 Where OPTIONS may be one or more of:
    -c CONF_FILE        Use CONF_FILE as server configuration
    -d DB_FILE          Use DB_FILE as user data base file
    -f                  Force operations to continue past errors
    -h                  Show this help
-   -i CERT_DN          CERT_DN of user to edit
+   -i USER_ID          USER_ID of the user to edit
+   -n NEW_ID           Edit existing user ID fields to fit NEW_ID
    -o SHORT_ID         Change OpenID alias of user to SHORT_ID
    -r FIELDS           Remove FIELDS for user in user DB
    -R ROLES            Change user affiliation to ROLES
+   -u USER_FILE      Update to new user information from pickle file
    -v                  Verbose output
-"""
-          % {'name': name})
+""" % {'name': name})
 
-
-# ## Main ###
 
 if '__main__' == __name__:
     (args, app_dir, db_path) = init_user_adm()
     conf_path = None
     force = False
     verbose = False
+    user_file = None
     user_id = None
     short_id = None
     role = None
     remove_fields = []
     user_dict = {}
-    opt_args = 'c:d:fhi:o:r:R:v'
+    opt_args = 'c:d:fhi:o:r:R:u:v'
     try:
         (opts, args) = getopt.getopt(args, opt_args)
     except getopt.GetoptError as err:
@@ -101,10 +110,13 @@ if '__main__' == __name__:
             remove_fields += val.split()
         elif opt == '-R':
             role = val
+        elif opt == '-u':
+            user_file = val
         elif opt == '-v':
             verbose = True
         else:
             print('Error: %s not supported!' % opt)
+            sys.exit(1)
 
     if conf_path and not os.path.isfile(conf_path):
         print('Failed to read configuration file: %s' % conf_path)
@@ -112,12 +124,21 @@ if '__main__' == __name__:
 
     if verbose:
         if conf_path:
-            print('using configuration in %s' % conf_path)
+            if verbose:
+                print('using configuration in %s' % conf_path)
         else:
-            print('using configuration from MIG_CONF (or default)')
+            if verbose:
+                print('using configuration from MIG_CONF (or default)')
 
+    # TODO: do we really want skip_log here?
     configuration = get_configuration_object(
         config_file=conf_path, skip_log=True)
+    logger = configuration.logger
+
+    if user_file and args:
+        print('Error: Only one kind of user specification allowed at a time')
+        usage()
+        sys.exit(1)
 
     if not user_id:
         print('Error: Existing user ID is required')
@@ -126,38 +147,61 @@ if '__main__' == __name__:
 
     if is_gdp_user(configuration, user_id) and not force:
         print("Error: GDP user ID detected")
-        print("You probalby want to use 'editgdpuser.py'")
+        print("You probably want to use 'editgdpuser.py'")
         print("If you really mean it then use: 'edituser.py -f'")
         sys.exit(1)
 
+    raw_user = {}
     if args:
+        # logger.debug('edituser called with args: %s' % args)
         try:
-            user_dict['full_name'] = args[0]
-            user_dict['organization'] = args[1]
-            user_dict['state'] = args[2]
-            user_dict['country'] = args[3]
-            user_dict['email'] = args[4]
-            user_dict['comment'] = args[5]
-            user_dict['password'] = args[6]
+            raw_user['full_name'] = args[0]
+            raw_user['organization'] = args[1]
+            raw_user['state'] = args[2]
+            raw_user['country'] = args[3]
+            raw_user['email'] = args[4]
         except IndexError:
-
-            # Ignore missing optional arguments
-
-            pass
+            print('Error: too few arguments given (expected 5 got %d)'
+                  % len(args))
+            usage()
+            sys.exit(1)
+        # Force user ID fields to canonical form for consistency
+        # Title name, lowercase email, uppercase country and state, etc.
+        user_dict = canonical_user(configuration, raw_user, raw_user.keys())
+    elif user_file:
+        try:
+            user_dict = load(user_file)
+        except Exception as err:
+            print('Error in user name extraction: %s' % err)
+            usage()
+            sys.exit(1)
     elif not configuration.site_enable_gdp:
         # NOTE: We do not allow interactive user management on GDP systems
-        print('Please enter the new details for %s:' % user_id)
-        print('[enter to skip field]')
-        user_dict['full_name'] = input('Full Name: ').title()
-        user_dict['organization'] = input('Organization: ')
-        user_dict['state'] = input('State: ')
-        user_dict['country'] = input('2-letter Country Code: ')
-        user_dict['email'] = input('Email: ')
+        if verbose:
+            print('Entering interactive mode')
+        print('Please enter the new user details for %s:' % user_id)
+        raw_user['full_name'] = input('Full Name: ').title()
+        raw_user['organization'] = input('Organization: ')
+        raw_user['state'] = input('State: ')
+        raw_user['country'] = input('2-letter Country Code: ')
+        raw_user['email'] = input('Email: ')
+        # Force user ID fields to canonical form for consistency
+        # Title name, lowercase email, uppercase country and state, etc.
+        user_dict = canonical_user(configuration, raw_user, raw_user.keys())
     else:
         print("Error: Missing one or more of the arguments: "
               + "[FULL_NAME] [ORGANIZATION] [STATE] [COUNTRY] "
-              + "[EMAIL] [COMMENT] [PASSWORD]")
+              + "[EMAIL]")
         sys.exit(1)
+
+    fill_distinguished_name(user_dict)
+
+    # logger.debug('edituser to new ID: %(distinguished_name)s' % user_dict)
+    fill_user(user_dict)
+
+    force_native_str_rec(user_dict)
+    # logger.debug('createuser forced to ID: %s' %
+    #             [user_dict['distinguished_name']])
 
     # Pass optional short_id as well
     if short_id:
@@ -173,15 +217,24 @@ if '__main__' == __name__:
         if not user_dict[key]:
             del user_dict[key]
 
+    # Now all user fields are set and we can begin editing the user
+
     if verbose:
-        print('Update DB entry and dirs for %s: %s' % (user_id, user_dict))
+        print('Update DB entry and dirs for %s using dict: %s' % (user_id,
+                                                                  user_dict))
     try:
-        user = edit_user(user_id, user_dict, remove_fields, conf_path, db_path, force,
-                         verbose)
-    except Exception as err:
-        print(err)
+        user = edit_user(user_id, user_dict, remove_fields, conf_path,
+                         db_path, force, verbose)
+    except Exception as exc:
+        print("Error editing user: %s" % exc)
+        import traceback
+        logger.warning("Error creating user: %s" % traceback.format_exc())
         sys.exit(1)
     print('%s\nchanged to\n%s\nin user database and file system' %
           (user_id, user['distinguished_name']))
     print()
     print('Please revoke/reissue any related certificates!')
+    if user_file:
+        if verbose:
+            print('Cleaning up tmp file: %s' % user_file)
+        os.remove(user_file)

--- a/mig/server/edituser.py
+++ b/mig/server/edituser.py
@@ -36,13 +36,11 @@ import getopt
 import os
 import sys
 
-from mig.shared.base import fill_distinguished_name, fill_user, canonical_user, \
-    force_native_str_rec, is_gdp_user
+from mig.shared.base import canonical_user, distinguished_name_to_user, \
+    fill_distinguished_name, fill_user, force_native_str_rec, is_gdp_user
 from mig.shared.conf import get_configuration_object
-from mig.shared.defaults import keyword_auto
 from mig.shared.serial import load
 from mig.shared.useradm import init_user_adm, edit_user
-from mig.shared.userdb import default_db_path
 
 
 def usage(name='edituser.py'):
@@ -56,8 +54,11 @@ Usage:
 or
 %(name)s [OPTIONS] -i USER_ID -n NEW_ID
 or
-%(name)s [OPTIONS] -i USER_ID [FULL_NAME] [ORGANIZATION] [STATE] [COUNTRY] \
-    [EMAIL]
+%(name)s [OPTIONS] -i USER_ID [FULL_NAME] [ORGANIZATION] [STATE] [COUNTRY] [EMAIL]
+to edit an existing user account non-interactively
+or
+%(name)s [OPTIONS] -i USER_ID
+to edit an existing user account interactively.
 Where OPTIONS may be one or more of:
    -c CONF_FILE        Use CONF_FILE as server configuration
    -d DB_FILE          Use DB_FILE as user data base file
@@ -80,11 +81,12 @@ if '__main__' == __name__:
     verbose = False
     user_file = None
     user_id = None
+    new_id = None
     short_id = None
     role = None
     remove_fields = []
     user_dict = {}
-    opt_args = 'c:d:fhi:o:r:R:u:v'
+    opt_args = 'c:d:fhi:n:o:r:R:u:v'
     try:
         (opts, args) = getopt.getopt(args, opt_args)
     except getopt.GetoptError as err:
@@ -104,6 +106,8 @@ if '__main__' == __name__:
             sys.exit(0)
         elif opt == '-i':
             user_id = val
+        elif opt == '-n':
+            new_id = val
         elif opt == '-o':
             short_id = val
         elif opt == '-r':
@@ -124,18 +128,16 @@ if '__main__' == __name__:
 
     if verbose:
         if conf_path:
-            if verbose:
-                print('using configuration in %s' % conf_path)
+            print('using configuration in %s' % conf_path)
         else:
-            if verbose:
-                print('using configuration from MIG_CONF (or default)')
+            print('using configuration from MIG_CONF (or default)')
 
     # TODO: do we really want skip_log here?
     configuration = get_configuration_object(
         config_file=conf_path, skip_log=True)
     logger = configuration.logger
 
-    if user_file and args:
+    if (user_file or new_id) and args or user_file and new_id:
         print('Error: Only one kind of user specification allowed at a time')
         usage()
         sys.exit(1)
@@ -165,6 +167,11 @@ if '__main__' == __name__:
                   % len(args))
             usage()
             sys.exit(1)
+        # Force user ID fields to canonical form for consistency
+        # Title name, lowercase email, uppercase country and state, etc.
+        user_dict = canonical_user(configuration, raw_user, raw_user.keys())
+    elif new_id:
+        raw_user = distinguished_name_to_user(new_id)
         # Force user ID fields to canonical form for consistency
         # Title name, lowercase email, uppercase country and state, etc.
         user_dict = canonical_user(configuration, raw_user, raw_user.keys())

--- a/mig/shared/useradm.py
+++ b/mig/shared/useradm.py
@@ -1639,8 +1639,11 @@ def edit_user(client_id, changes, removes, conf_path, db_path, force=False,
             print('unexpectedly got no saved status after edit %r' % client_id)
         _logger.error("something failed in edit user %r - delay unlocking" %
                       client_id)
-    else:
+    elif saved_status:
         user_dict['status'] = saved_status
+    else:
+        # NOTE: save will ignore empty string values so force to 'active' here
+        user_dict['status'] = 'active'
     # NOTE: only backup user DB here if we didn't already do so in call above
     create_user(user_dict, conf_path, db_path, force, verbose,
                 ask_renew=False, default_renew=True, from_edit_user=True,


### PR DESCRIPTION
Support for passing a new ID or an updated user dict file to `edituser.py`. That should make it less error prone to edit users manually and semi-automatically in relation to ID conflicts in line with #604.

Sync `createuser.py` and `edituser.py` to ease maintenance and minor lint fixes.

Incorporates the minor fix from #643 so that would best be merged first. 

**NOTE**: similar adjustments to `editgdpuser.py` may be relevant.