### PR TITLE
Fix issues in strip_password calls in openid service surfacing after PR592

### DIFF
--- a/mig/server/grid_openid.py
+++ b/mig/server/grid_openid.py
@@ -211,11 +211,12 @@ def filter_why_pw(configuration, why):
         return strip_password(configuration, text)
     elif isinstance(why, server.ProtocolError):
         # NOTE: UntrustedReturnURL does not have message but it may have been
-        #       renamed to openid_message - fallback to str
+        #       renamed to openid_message - fallback to raw why and always
+        #       force to str for strip_password to apply.
         if hasattr(why, 'openid_message'):
-            text = why.openid_message
+            text = str(why.openid_message)
         elif hasattr(why, 'message'):
-            text = why.message
+            text = str(why.message)
         else:
             text = str(why)
         return strip_password(configuration, text)


### PR DESCRIPTION
Follow-up to #592 which results in `strip_password` helper sometimes hitting openid message objects that it doesn't know what to do about:
`2026-08-18 16:30:16,711 ERROR not filtering unexpected obj in strip_password: <openid.message.Message ...`

Force those message objects to string to make it succeed.
