### PR TITLE
Update the seahub css templates to current stable Seafile 13.x

### DIFF
--- a/mig/images/skin/erda-basic/seafile/seahub.css
+++ b/mig/images/skin/erda-basic/seafile/seahub.css
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # seahub - site style overrides for all seafile pages
-# Copyright (C) 2003-2019  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -32,7 +32,7 @@
 
 /* Replace the different orange colors in the original css specs. 
    Keep rules in sync with styles from:
-   seafile/seafile-server-latest/seahub/media/css/*.css 
+   seafile/seafile-server-latest/seahub/media/css/*.css
    and use something like the following simplified mappings:
    #eb8205 / #ee8204 / #f7941d / #de3f1c / #DD4B39 / #c77405 / #f59f00 / #e83 -> #147
    #f93 / #feac74 / #fbcb09 / #a68558 -> #369
@@ -99,6 +99,10 @@ a:focus, a:hover {
 .nav .nav-item.active .nav-link {
     color: #369;
     border-color: #147;
+}
+/* NOTE: color before active nav item added in 13.x */
+.nav-item.active::before {
+    background-color: #147 !important;
 }
 .nav .nav-item .nav-link:hover {
     /* NOTE: diverge from std color mapping here to avoid that active nav elem

--- a/mig/images/skin/erda-ucph-science/seafile/seahub.css
+++ b/mig/images/skin/erda-ucph-science/seafile/seahub.css
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # seahub - site style overrides for all seafile pages
-# Copyright (C) 2003-2019  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -32,12 +32,12 @@
 
 /* Replace the different orange colors in the original css specs. 
    Keep rules in sync with styles from:
-   seafile/seafile-server-latest/seahub/media/css/*.css 
+   seafile/seafile-server-latest/seahub/media/css/*.css
    and use something like the following simplified mappings:
    #eb8205 / #ee8204 / #f7941d / #de3f1c / #DD4B39 / #c77405 / #f59f00 / #e83 -> #46743c
    #f93 / #ff9933 / #feac74 / #fbcb09 / #a68558 -> #679c5b
    #fff1a8 / #f89a68 / #feefb8 / #fdf5ce / #fddaa4 / #f9edbe -> #8fd182
-   rgba(241, 150, 69, 0.25) -> rgba(103, 156, 91, 0.25) 
+   rgba(241, 150, 69, 0.25) -> rgba(103, 156, 91, 0.25)
 */
 
 a { 
@@ -99,6 +99,10 @@ a:focus, a:hover {
 .nav .nav-item.active .nav-link {
     color: #679c5b;
     border-color: #46743c;
+}
+/* NOTE: color before active nav item added in 13.x */
+.nav-item.active::before {
+    background-color: #46743c !important;
 }
 .nav .nav-item .nav-link:hover {
     /* NOTE: diverge from std color mapping here to avoid that active nav elem

--- a/mig/images/skin/erda-user-friendly/seafile/seahub.css
+++ b/mig/images/skin/erda-user-friendly/seafile/seahub.css
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # seahub - site style overrides for all seafile pages
-# Copyright (C) 2003-2018  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -32,11 +32,12 @@
 
 /* Replace the different orange colors in the original css specs. 
    Keep rules in sync with styles from:
-   seafile-server-latest/seahub/media/css/seahub.css 
+   seafile/seafile-server-latest/seahub/media/css/*.css
    and use something like the following simplified mappings:
    #eb8205 / #ee8204 / #f7941d / #de3f1c / #DD4B39 / #c77405 / #f59f00 / #e83 -> #46743c
    #f93 / #ff9933 / #feac74 / #fbcb09 / #a68558 -> #679c5b
    #fff1a8 / #f89a68 / #feefb8 / #fdf5ce / #fddaa4 / #f9edbe -> #8fd182
+   rgba(241, 150, 69, 0.25) -> rgba(103, 156, 91, 0.25)
 */
 
 a { 
@@ -44,6 +45,9 @@ a {
 }
 a:focus, a:hover {
     color: #679c5b;
+}
+.a-simulate {
+    color: #8fd182 !important;
 }
 .strip-tip {
     background:#8fd182;
@@ -67,19 +71,54 @@ a:focus, a:hover {
     background:#679c5b;
 }
 
+/* NOTE: With upgrade from 6.x to 7.x and switch to React nav class names changed */
+.sf-heading,
 .side-tabnav h3.hd,
 .side-tabnav .hd h3 {
     color:#46743c;
 }
 
+.nav-pills .nav-item .nav-link:hover,
 .side-tabnav-tabs .tab a:hover {
     background-color:#8fd182;
 }
 
+.nav-pills .show > .nav-link,
+.nav-pills .nav-item .nav-link.active,
+.nav-pills .nav-item .nav-link.active:hover,
 .side-tabnav-tabs .tab-cur a,
 .side-tabnav-tabs .tab-cur a:hover {
     background-color: #679c5b;
 }
+
+.nav .nav-item .nav-link {
+    color: #679c5b;
+    /* NOTE: Force rounded corners like main nav */
+    border-radius: 5px;
+}
+.nav .nav-item.active .nav-link {
+    color: #679c5b;
+    border-color: #46743c;
+}
+/* NOTE: color before active nav item added in 13.x */
+.nav-item.active::before {
+    background-color: #46743c !important;
+}
+.nav .nav-item .nav-link:hover {
+    /* NOTE: diverge from std color mapping here to avoid that active nav elem
+     * has same color as hovered ones */
+    background-color: #8fd182;
+}
+.nav .nav-item .nav-link.active,
+.nav .nav-item .nav-link.active:hover {
+    color: #fff;
+    border-color: #679c5b;
+    /* NOTE: override e.g. active sharelink tab to avoid white on white */
+    background-color: #679c5b;
+    padding-left: 2px;
+    padding-right: 2px;
+}
+
 
 .side-textnav-tabs .tab-cur a,
 .side-textnav-tabs .tab a:hover {
@@ -87,7 +126,7 @@ a:focus, a:hover {
 }
 
 .messages .info {
-    background:#8FD182;
+    background:#8fd182;
 }
 
 .new-narrow-panel .hd {
@@ -100,6 +139,11 @@ a:focus, a:hover {
 }
 .tab-tabs-nav .tab .a:hover {
     color:#46743c;
+}
+.cur-view-path .tab-tabs-nav .ui-state-active .a,
+.cur-view-path .tab-tabs-nav .a:hover {
+    color:#679c5b;
+    border-bottom:2px solid #679c5b;
 }
 
 .tab-popup-tabs-nav .ui-state-active .a,
@@ -165,6 +209,11 @@ a:focus, a:hover {
     color: #46743c;
 }
 
+/* NOTE: .progress-bar class is new in 7.x */
+.progress-bar {
+    background-color: #46743c;
+}
+
 .ui-progressbar-value,
 .progress .bar {
     background: #46743c;
@@ -195,9 +244,14 @@ a:focus, a:hover {
 }
 
 /* mouse-over icons */
+.op-icon,
+.op-icon:focus,
+.op-icon:hover,
 .op-icon.sf2-x,
+.op-icon.sf2-x:focus,
 .op-icon.sf2-x:hover {
     color:#8fd182;
+    border-bottom-color:#8fd182;
 }
 
 /**** btn with link styles ****/
@@ -232,6 +286,10 @@ a:focus, a:hover {
     background:#679c5b;
 }    
 
+.mobile-menu-content ul li:hover{
+    background-color:#679c5b;
+}
+
 .load-more-discussion {
     color:#46743c;
 }
@@ -245,6 +303,10 @@ a:focus, a:hover {
 /* Login button on entry page */
 .login-panel .submit {
     background:#46743c;
+    color: #fff;
+}
+.login-panel .submit:focus {
+    border-color:#8fd182;
 }
 
 .fixed-upload-file-dialog .fileupload-buttonbar .cancel,
@@ -255,6 +317,272 @@ a:focus, a:hover {
 .grid-item .text-link.hl {
     color:#679c5b;
 }
+
+.path-link {
+    color: #679c5b !important;
+}
+
+.list-show-more {
+    color: #679c5b;
+}
+
+#groups .group-name .a {
+    color:#46743c;
+}
+
+.traffic-tab-nav .tab .a:hover {
+    color:#679c5b;
+    border-bottom-color:#679c5b;
+}
+
+.dir-toolbar-2 .op-link:hover {
+    color:#679c5b;
+}
+
+.path-toolbar .toolbar-item .op-link:hover {
+    color:#679c5b;
+}
+
+
+/*** New rules for bootstrap elements added in 7.x ***/
+
+/* outlined buttons */
+.btn-primary {
+    background-color: #679c5b;
+    border-color: #679c5b;
+}
+.btn-primary:hover {
+    background-color: #46743c;
+    border-color: #46743c;
+}
+.btn-primary:focus, .btn-primary.focus {
+    box-shadow: 0 0 0 2px rgba(103, 156, 91, 0.25);
+}
+.btn-primary.disabled,
+.btn-primary:disabled {
+    background-color: #679c5b;
+    border-color: #679c5b;
+}
+.btn-primary:not(:disabled):not(.disabled):active,
+.btn-primary:not(:disabled):not(.disabled).active,
+.show > .btn-primary.dropdown-toggle {
+    background-color: #46743c;
+    border-color: #46743c;
+}
+.btn-primary:not(:disabled):not(.disabled):active:focus,
+.btn-primary:not(:disabled):not(.disabled).active:focus,
+.show > .btn-primary.dropdown-toggle:focus {
+    box-shadow: 0 0 0 2px rgba(103, 156, 91, 0.25);
+}
+
+.btn-outline-primary {
+    color: #679c5b;
+    border-color: #679c5b;
+}
+.btn-outline-primary:hover {
+    background-color: #679c5b;
+    border-color: #679c5b;
+}
+.btn-outline-primary:focus,
+.btn-outline-primary.focus {
+    box-shadow: 0 0 0 2px rgba(103, 156, 91, 0.25);
+}
+.btn-outline-primary.disabled,
+.btn-outline-primary:disabled {
+    color: #679c5b;
+}
+.btn-outline-primary:not(:disabled):not(.disabled):active,
+.btn-outline-primary:not(:disabled):not(.disabled).active,
+.show > .btn-outline-primary.dropdown-toggle {
+    background-color: #679c5b;
+    border-color: #679c5b;
+}
+.btn-outline-primary:not(:disabled):not(.disabled):active:focus,
+.btn-outline-primary:not(:disabled):not(.disabled).active:focus,
+.show > .btn-outline-primary.dropdown-toggle:focus {
+    box-shadow: 0 0 0 2px rgba(103, 156, 91, 0.25);
+}
+
+.btn-link {
+    color: #679c5b;
+}
+.btn-link:hover {
+    color: #46743c;
+}
+.btn-link:disabled, .btn-link.disabled {
+    color: #679c5b;
+}
+
+.dropdown-item.active,                                                                                   
+.dropdown-item:active {
+    background-color: #679c5b;
+}
+
+.custom-control-input:checked ~ .custom-control-label::before {
+    background-color: #679c5b;
+}
+
+.custom-checkbox .custom-control-input:checked ~ .custom-control-label::before {
+    background-color: #679c5b;
+}
+
+.custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::before {
+    background-color: #679c5b;
+}
+
+.custom-radio .custom-control-input:checked ~ .custom-control-label::before {
+    background-color: #679c5b;
+}
+
+.custom-range::-webkit-slider-thumb {
+    background-color: #679c5b;
+}
+.custom-range::-moz-range-thumb {
+    background-color: #679c5b;
+}
+.custom-range::-ms-thumb {
+    background-color: #679c5b;
+}
+
+.page-item.active .page-link {
+    background-color: #679c5b;
+    border-color: #679c5b;
+}
+
+.badge-primary {
+    background-color: #679c5b;
+}
+
+.list-group-item.active {
+    color: #679c5b;
+}
+
+.bg-primary {
+background-color: #679c5b !important;
+}
+
+a.bg-primary:hover, a.bg-primary:focus,
+button.bg-primary:hover,
+button.bg-primary:focus {
+    background-color: #46743c !important; 
+}
+
+.border-primary {
+    border-color: #679c5b !important;
+}
+
+.text-primary {
+    color: #679c5b !important;
+}
+
+a.text-primary:hover, a.text-primary:focus {
+    color: #46743c !important;
+}
+
+.nav-tabs .nav-submenu .nav-item.active {
+    color: #679c5b;
+}
+
+.table-calendar-link:before {
+    background: #679c5b;
+}
+.table-calendar-link:hover {
+    background: #679c5b;
+}
+
+.form-help:hover,
+.form-help[aria-describedby] {
+    background: #679c5b;
+}
+
+.chat-message {
+    background-color: #679c5b;
+}
+.chat-message:after {
+    border-left-color: #679c5b;
+}
+
+.tag-primary {
+    background-color: #679c5b;
+}
+
+.custom-range:focus::-webkit-slider-thumb {
+    border-color: #679c5b;
+    background-color: #679c5b;
+}
+.custom-range:focus::-moz-range-thumb {
+    border-color: #679c5b;
+    background-color: #679c5b;
+}
+.custom-range:focus::-ms-thumb {
+    border-color: #679c5b;
+    background-color: #679c5b;
+}
+.custom-range::-webkit-slider-runnable-track {
+    background: #679c5b;
+}
+.custom-range::-moz-range-progress {
+    background: #679c5b;
+}
+.custom-range::-ms-fill-lower {
+    background: #679c5b;
+}
+
+.selectgroup-input:checked + .selectgroup-button {
+    border-color: #679c5b;
+    color: #679c5b;
+    background: #8fd182;
+}
+
+.selectgroup-input:focus + .selectgroup-button {
+    border-color: #679c5b;
+    color: #679c5b;
+    box-shadow: 0 0 0 2px rgba(103, 156, 91, 0.25);
+}
+
+.custom-switch-input:checked ~ .custom-switch-indicator {
+    background: #679c5b;
+}
+.custom-switch-input:focus ~ .custom-switch-indicator {
+    box-shadow: 0 0 0 2px rgba(103, 156, 91, 0.25);
+    border-color: #679c5b;
+}
+
+.imagecheck-input:focus ~ .imagecheck-figure {
+    border-color: #679c5b;
+    box-shadow: 0 0 0 2px rgba(103, 156, 91, 0.25); }
+.imagecheck-figure:before {
+    background-color: #679c5b;
+}
+
+.colorinput-input:focus ~ .colorinput-color {
+    border-color: #679c5b;
+    box-shadow: 0 0 0 2px rgba(103, 156, 91, 0.25);
+}
+
+.table-primary,
+.table-primary > th,
+.table-primary > td {
+    background-color: #8fd182;
+}
+
+.table-hover .table-primary:hover {
+    background-color: #679c5b;
+}
+.table-hover .table-primary:hover > td,
+.table-hover .table-primary:hover > th {
+    background-color: #679c5b;
+}
+
+.go-back:focus,
+.go-back:hover,
+.old-history-main .go-back:focus,
+.old-history-main .go-back:hover,
+.old-history-main .file-name,
+.old-history-main .commit-list .username {
+    color: #679c5b;
+}
+
 
 /* Hide signup link on login page to reduce unwanted direct signup attempts */
 /* There used to be no signup link id or class to target, so we relied on the
@@ -270,7 +598,8 @@ a:focus, a:hover {
    telling that user exists and with the option to try again. This enables
    users to edit email and try to register additional accounts. We don't really
    want that, so we obfuscate the possibility of changing the email field. */
-div.con form #id_email {
+/* NOTE: form got unique ID in 7.x */
+div.con form #id_email, #signup-form #id_email {
     border: 0px;
     /* These are additional disabling suggestions in case users get creative.
        They do not completely disable text edit, but make it harder. */

--- a/mig/images/skin/migrid-basic/seafile/seahub.css
+++ b/mig/images/skin/migrid-basic/seafile/seahub.css
@@ -4,7 +4,7 @@
 # --- BEGIN_HEADER ---
 #
 # seahub - site style overrides for all seafile pages
-# Copyright (C) 2003-2019  The MiG Project lead by Brian Vinter
+# Copyright (C) 2003-2026  The MiG Project by the Science HPC Center at UCPH
 #
 # This file is part of MiG.
 #
@@ -32,7 +32,7 @@
 
 /* Replace the different orange colors in the original css specs. 
    Keep rules in sync with styles from:
-   seafile/seafile-server-latest/seahub/media/css/*.css 
+   seafile/seafile-server-latest/seahub/media/css/*.css
    and use something like the following simplified mappings:
    #eb8205 / #ee8204 / #f7941d / #de3f1c / #DD4B39 / #c77405 / #f59f00 / #e83 -> #147
    #f93 / #feac74 / #fbcb09 / #a68558 -> #369
@@ -99,6 +99,10 @@ a:focus, a:hover {
 .nav .nav-item.active .nav-link {
     color: #369;
     border-color: #147;
+}
+/* NOTE: color before active nav item added in 13.x */
+.nav-item.active::before {
+    background-color: #147 !important;
 }
 .nav .nav-item .nav-link:hover {
     /* NOTE: diverge from std color mapping here to avoid that active nav elem


### PR DESCRIPTION
Update the seahub css templates to current stable Seafile 13.x. Namely, override the orange active marker in the workspace nav on the left. Various older updates resynced into other skins than the ERDA UCPH one.