### PR TITLE
Rework openid handling of UntrustedReturnURL from PR592

### DIFF
--- a/mig/install/migerrors-template.sh.cronjob
+++ b/mig/install/migerrors-template.sh.cronjob
@@ -52,7 +52,7 @@ ENABLE_QUOTA="__ENABLE_QUOTA__"
 
 [ "$ENABLE_DAVS" == "True" ] && grep -a -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES
 
-[ "$ENABLE_OPENID" == "True" ] && grep -a -H " ERROR " $LOGDIR/openid.log | grep -E -v "crashed: Unexpected query variable|retry_url: shorter than minimum length|invalid retry_url: found invalid character|crashed: int\(\) argument must be a string|input: shorter than minimum length|input: found invalid character:" | tail -n $MAXLINES
+[ "$ENABLE_OPENID" == "True" ] && grep -a -H " ERROR " $LOGDIR/openid.log | grep -E -v "crashed: Unexpected query variable|retry_url: shorter than minimum length|invalid retry_url: found invalid character|crashed: int\(\) argument must be a string|input: shorter than minimum length|input: found invalid character:| not under trust_root " | tail -n $MAXLINES
 
 [ "$ENABLE_CRONTAB" == "True" ] && grep -a -H " ERROR " $LOGDIR/cron.log | tail -n $MAXLINES
 

--- a/mig/server/grid_openid.py
+++ b/mig/server/grid_openid.py
@@ -210,12 +210,9 @@ def filter_why_pw(configuration, why):
         text = why.response.encodeToKVForm()
         return strip_password(configuration, text)
     elif isinstance(why, server.ProtocolError):
-        # NOTE: UntrustedReturnURL does not have message but it may have been
-        #       renamed to openid_message - fallback to raw why and always
-        #       force to str for strip_password to apply.
-        if hasattr(why, 'openid_message'):
-            text = str(why.openid_message)
-        elif hasattr(why, 'message'):
+        # NOTE: UntrustedReturnURL does not have message but raw str suffices.
+        #       Always force to str for strip_password to apply.
+        if hasattr(why, 'message'):
             text = str(why.message)
         else:
             text = str(why)

--- a/tests/fixture/confs-stdlocal/migerrors
+++ b/tests/fixture/confs-stdlocal/migerrors
@@ -52,7 +52,7 @@ ENABLE_QUOTA="False"
 
 [ "$ENABLE_DAVS" == "True" ] && grep -a -H " ERROR " $LOGDIR/davs.log | grep -E -v "The handshake operation timed out|decryption failed or bad record mac|length too short|no ciphers specified|(unknown error|parse tlsext|https proxy request) \(_ssl.c:\)|SSL/TLS wrap of .* failed unexpectedly:|Failed password login for .* from ${SECSCANIP}|ERROR (Invalid user(name)?|auth failed) .* from ${SECSCANIP}|${SECSCANIP}, .* Invalid user(name)?|GDP: Project logout failed for user: .* from ip: ${SECSCANIP} with|Invalid username [a-zA-Z0-9._-]* from|ERROR Account disabled or expired|invalid share mode (write|read)-only for |: Invalid path characters" | tail -n $MAXLINES
 
-[ "$ENABLE_OPENID" == "True" ] && grep -a -H " ERROR " $LOGDIR/openid.log | grep -E -v "crashed: Unexpected query variable|retry_url: shorter than minimum length|invalid retry_url: found invalid character|crashed: int\(\) argument must be a string|input: shorter than minimum length|input: found invalid character:" | tail -n $MAXLINES
+[ "$ENABLE_OPENID" == "True" ] && grep -a -H " ERROR " $LOGDIR/openid.log | grep -E -v "crashed: Unexpected query variable|retry_url: shorter than minimum length|invalid retry_url: found invalid character|crashed: int\(\) argument must be a string|input: shorter than minimum length|input: found invalid character:| not under trust_root " | tail -n $MAXLINES
 
 [ "$ENABLE_CRONTAB" == "True" ] && grep -a -H " ERROR " $LOGDIR/cron.log | tail -n $MAXLINES
 


### PR DESCRIPTION
It turns out that our attempted fix to openid `UntrustedReturnURL` exceptions missing a `message` field by using `openid_message` instead as discussed in https://github.com/ucphhpc/migrid-sync/pull/592#discussion_r3665401227 only muddies the log messages, because the latter field contains no information that it was in fact caused by an untrusted return URL. Just forcing the exception to string in that case will actually be far more informative. Revert that bit of #592 to also simplify a bit.

Add a `migerrors` filter for the resulting specific untrusted return url noise in `openid.log`.