### PR TITLE
Switch `recommended.txt` to use `python3-openid` over `python-openid`

### DIFF
--- a/README
+++ b/README
@@ -76,7 +76,7 @@ The software needed for the above optional components is mainly provided by:
 -Apache WSGI module (https://code.google.com/p/modwsgi/)
 -Apache OpenID auth module (http://findingscience.com/mod_auth_openid/)
 -Apache OpenID Connect auth module (https://github.com/zmartzone/mod_auth_openidc)
--Python OpenID module (https://github.com/openid/python-openid/)
+-Python OpenID module (https://pypi.org/project/python3-openid/)
 -Python Paramiko module (https://pypi.python.org/pypi/paramiko/)
 -Python FTPD library (https://pypi.python.org/pypi/pyftpdlib/)
 -Python OpenSSL module (https://pypi.python.org/pypi/pyOpenSSL/)

--- a/recommended.txt
+++ b/recommended.txt
@@ -19,7 +19,7 @@ pyOpenSSL
 pyftpdlib
 watchdog
 scandir
-python-openid
+python3-openid
 # NOTE: this used to be called irclib and is untested for any recent versions 
 irc
 # Use the maintained fork of the now stale original jsonrpclib


### PR DESCRIPTION
Switch `recommended.txt` to use `python3-openid` rather than the old stale `python-openid`. It looks like that is the source of the spurious lint warnings from our GH python sanity check action whenever `grid_openid.py` is changed. For the record it uses `make PYTHON_BIN=python3 ALLDEPS=1 dependencies` in setup, which pulls everything in from `recommended.txt` including `python-openid` at the moment.
We already explicitly use `python3-python` in docker-migrid and `pylint` doesn't complain there.
Update `README` to complete the switch.

The error is e.g. seen in #645 checks:
<img width="1899" height="763" alt="Screenshot_2026-08-27_14-04-07" src="https://github.com/user-attachments/assets/0f5951f3-c563-4cf9-9568-dae622d12935" />