### PR TITLE
More seahub css tweaks to replace default orange background blobs

### DIFF
--- a/mig/images/skin/erda-basic/seafile/seahub.css
+++ b/mig/images/skin/erda-basic/seafile/seahub.css
@@ -58,6 +58,9 @@ a:focus, a:hover {
 .repo-op a.op-link:hover {
     color: #147;
 }
+.repo-list-item.active:before, .tree-node-hight-light::before {
+    background-color: #147 !important;
+}
 
 .op-target {
     color:#147;
@@ -101,7 +104,7 @@ a:focus, a:hover {
     border-color: #147;
 }
 /* NOTE: color before active nav item added in 13.x */
-.nav-item.active::before {
+.nav-item.active::before, .nav-link.active::before  {
     background-color: #147 !important;
 }
 .nav .nav-item .nav-link:hover {

--- a/mig/images/skin/erda-ucph-science/seafile/seahub.css
+++ b/mig/images/skin/erda-ucph-science/seafile/seahub.css
@@ -58,6 +58,9 @@ a:focus, a:hover {
 .repo-op a.op-link:hover {
     color: #46743c;
 }
+.repo-list-item.active:before, .tree-node-hight-light::before {
+    background-color: #46743c !important;
+}
 
 .op-target {
     color:#46743c;
@@ -101,7 +104,7 @@ a:focus, a:hover {
     border-color: #46743c;
 }
 /* NOTE: color before active nav item added in 13.x */
-.nav-item.active::before {
+.nav-item.active::before, .nav-link.active::before {
     background-color: #46743c !important;
 }
 .nav .nav-item .nav-link:hover {

--- a/mig/images/skin/erda-user-friendly/seafile/seahub.css
+++ b/mig/images/skin/erda-user-friendly/seafile/seahub.css
@@ -58,6 +58,9 @@ a:focus, a:hover {
 .repo-op a.op-link:hover {
     color: #46743c;
 }
+.repo-list-item.active:before, .tree-node-hight-light::before {
+    background-color: #46743c !important;
+}
 
 .op-target {
     color:#46743c;
@@ -101,7 +104,7 @@ a:focus, a:hover {
     border-color: #46743c;
 }
 /* NOTE: color before active nav item added in 13.x */
-.nav-item.active::before {
+.nav-item.active::before, .nav-link.active::before  {
     background-color: #46743c !important;
 }
 .nav .nav-item .nav-link:hover {

--- a/mig/images/skin/migrid-basic/seafile/seahub.css
+++ b/mig/images/skin/migrid-basic/seafile/seahub.css
@@ -58,6 +58,9 @@ a:focus, a:hover {
 .repo-op a.op-link:hover {
     color: #147;
 }
+.repo-list-item.active:before, .tree-node-hight-light::before {
+    background-color: #147 !important;
+}
 
 .op-target {
     color:#147;
@@ -101,7 +104,7 @@ a:focus, a:hover {
     border-color: #147;
 }
 /* NOTE: color before active nav item added in 13.x */
-.nav-item.active::before {
+.nav-item.active::before, .nav-link.active::before  {
     background-color: #147 !important;
 }
 .nav .nav-item .nav-link:hover {


### PR DESCRIPTION
Additional seahub css tweaks to replace default orange background blobs to the individual skins. Follow-up to #642 with more Seafile features enabled.