### PR TITLE
Update Data Management Guidelines link

### DIFF
--- a/state/wwwpublic/about-erda.dk.html
+++ b/state/wwwpublic/about-erda.dk.html
@@ -139,7 +139,7 @@
                             internal and external collaboration partners. Employees and students at other
                             faculties can also get access, mainly for data archiving and publishing with UCPH DOIs
                             to support the UCPH
-                            <a class="infolink" href="https://kunet.ku.dk/work-areas/research/data/Pages/default.aspx" target="_blank">Data Management Guidelines</a>.
+                            <a class="infolink" href="https://kunet.ku.dk/employee-guide/Pages/Research/Introduction-to-research-data-management.aspx" target="_blank">Data Management Guidelines</a>.
                         </p>
                     </div>
 

--- a/state/wwwpublic/about-erda.dk.html
+++ b/state/wwwpublic/about-erda.dk.html
@@ -207,7 +207,7 @@
                             og eksterne samarbejdspartnere. Ansatte og studerende ved andre fakulteter
                             kan også få adgang, især til data-arkivering og -publicering med KUs DOIer
                             med henblik på at understøtte KUs
-                            <a class="infolink" href="https://kunet.ku.dk/arbejdsomraader/forskning/data/Sider/default.aspx" target="_blank">data management forskrifter</a>.
+                            <a class="infolink" href="https://kunet.ku.dk/medarbejderguide/Sider/Forskning/intro-til-forskningsdatamanagement.aspx" target="_blank">data management forskrifter</a>.
                         </p>
                     </div>
 


### PR DESCRIPTION
The previous link leads to a 404 page as reported by one of our users. The new one leads to the introduction page which holds the policy itself, as well as contact links for different sections